### PR TITLE
LAWS-775_add-mlra-security-group-access

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -22,6 +22,10 @@ Parameters:
   pSev5SnsTopicArn:
     Description: ARN of Sev5 SNS topic for alerting
     Type: String
+  pMlraAppSecurityGroupId:
+    Type: String
+    Description: The Security Group Id of the AWS-hosted MLRA application
+    Default: ''
 
   # Application specific parameters
   pAppName:
@@ -126,7 +130,9 @@ Conditions:
     !Or
       - !Condition cDevTest
       - !Condition cUATStg
-
++ cAddMlraAppSecurityGroupId:
++   !Not [ !Equals [ !Ref   pMlraAppSecurityGroupId, "" ] ]
++
 Resources:
 
   ##############################################################################
@@ -153,6 +159,16 @@ Resources:
     Properties:
       GroupDescription: App ALB Security Group
       VpcId: !ImportValue "env-VpcId"
+  AppAlbSecurityGroupMlraAppInbound:
+    Condition: cAddMlraAppSecurityGroupId
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref AppAlbSecurityGroup
+      IpProtocol: tcp
+      FromPort: '443'
+      ToPort: '443'
+      SourceSecurityGroupId: !Ref pMlraAppSecurityGroupId
+
 
   ##############################################################################
   #

--- a/aws/application/parameters/development-maat-cd-api-pipeline.json
+++ b/aws/application/parameters/development-maat-cd-api-pipeline.json
@@ -6,6 +6,7 @@
     "pDockerImageTag" : "",
     "pAppCertificateArn" : "arn:aws:acm:eu-west-2:411213865113:certificate/0184743f-c424-4d2e-bd87-f2ac439c38ad",
     "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-devel-severity_5",
+    "pMlraAppSecurityGroupId": "sg-257f024e",
     "pDatasourceUrl" : "jdbc:oracle:thin:@rds.maat.aws.dev.legalservices.gov.uk:1521:MAATDB",
     "pCloudPlatformQueueRegion" : "eu-west-2",
     "pCreateLinkQueue" : "crime-apps-dev-create-link-queue-m",

--- a/aws/application/parameters/production-maat-cd-api-pipeline.json
+++ b/aws/application/parameters/production-maat-cd-api-pipeline.json
@@ -5,7 +5,8 @@
     "pECSRepositoryURL" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/maat-cd-api",
     "pDockerImageTag" : "",
     "pAppCertificateArn" : "arn:aws:acm:eu-west-2:842522700642:certificate/cf0f748f-f469-4381-9321-506665e03683",
-    "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-live-severity_5"
+    "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-live-severity_5",
+    "pMlraAppSecurityGroupId": "sg-c16a2aaa"
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/aws/application/parameters/staging-maat-cd-api-pipeline.json
+++ b/aws/application/parameters/staging-maat-cd-api-pipeline.json
@@ -5,7 +5,8 @@
     "pECSRepositoryURL" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/maat-cd-api",
     "pDockerImageTag" : "",
     "pAppCertificateArn" : "arn:aws:acm:eu-west-2:484221692666:certificate/152f7407-fdbd-4ce7-b63e-1b9f2c6a5c89",
-    "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-devel-severity_5"
+    "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-devel-severity_5",
+    "pMlraAppSecurityGroupId": "sg-9fc086f4"
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/aws/application/parameters/test-maat-cd-api-pipeline.json
+++ b/aws/application/parameters/test-maat-cd-api-pipeline.json
@@ -5,7 +5,8 @@
     "pECSRepositoryURL" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/maat-cd-api",
     "pDockerImageTag" : "",
     "pAppCertificateArn" : "arn:aws:acm:eu-west-2:013163512034:certificate/3f5ffd24-0805-475a-80ad-8bc0f1330e83",
-    "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-devel-severity_5"
+    "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-devel-severity_5",
+    "pMlraAppSecurityGroupId": "sg-2e6d2a45"
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/aws/application/parameters/uat-maat-cd-api-pipeline.json
+++ b/aws/application/parameters/uat-maat-cd-api-pipeline.json
@@ -5,7 +5,8 @@
     "pECSRepositoryURL" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/maat-cd-api",
     "pDockerImageTag" : "",
     "pAppCertificateArn" : "arn:aws:acm:eu-west-2:140455166311:certificate/be7fff7d-935d-4d35-8225-0d1fd9c07c78",
-    "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-devel-severity_5"
+    "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:sns-topic-devel-severity_5",
+    "pMlraAppSecurityGroupId": "sg-f0adeb9b"
   },
   "Tags" : {
     "business-unit" : "LAA",


### PR DESCRIPTION
allow MLRA Fargate instances access to the MAAT-cd-api load balancer

This work is required as part of the MAAT-cd-api implementation