### PR TITLE
LAWS-775_add-mlra-security-group-access-FIX

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -130,9 +130,9 @@ Conditions:
     !Or
       - !Condition cDevTest
       - !Condition cUATStg
-+ cAddMlraAppSecurityGroupId:
-+   !Not [ !Equals [ !Ref   pMlraAppSecurityGroupId, "" ] ]
-+
+  cAddMlraAppSecurityGroupId:
+    !Not [ !Equals [ !Ref   pMlraAppSecurityGroupId, "" ] ]
+
 Resources:
 
   ##############################################################################


### PR DESCRIPTION
allow MLRA Fargate instances access to the MAAT-cd-api load balancer

This work is required as part of the MAAT-cd-api implementation