### PR TITLE
LAWS-823-Increase-Load-Balancer-Timeout

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -319,10 +319,10 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: LoadBalancer
     Properties:
-      HealthCheckIntervalSeconds: 15
+      HealthCheckIntervalSeconds: 20
       HealthCheckPath: /actuator/info
       HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 5
+      HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 2
       TargetType: ip
       Name: !Sub '${pAppName}-TargetGroup'


### PR DESCRIPTION
Increase Load Balancer timout by 5 seconds

This is required as the application is not stablizing using the existing
parameters