### PR TITLE
LAWS-839-Add-timeout-startup-value-to-ECS

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -187,6 +187,7 @@ Resources:
       Cluster: !Ref AppEcsCluster
       LaunchType : !Ref pLaunchType
       DesiredCount: !If [ cDevTest, 1, 2 ]
+      HealthCheckGracePeriodSeconds: 120
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -319,10 +320,10 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: LoadBalancer
     Properties:
-      HealthCheckIntervalSeconds: 25
+      HealthCheckIntervalSeconds: 15
       HealthCheckPath: /actuator/info
       HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 15
+      HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       TargetType: ip
       Name: !Sub '${pAppName}-TargetGroup'


### PR DESCRIPTION
## What

[LAWS-839](https://dsdmoj.atlassian.net/browse/LAWS-839)

- Under ECS-Service, set 'HealthCheckGracePeriodSeconds' to 120 seconds
- Reset Load Balancer health check times to default

This change is required to allow ECS to make database changes on
startup. Without this change the Load Balancer timesout and causes the
application to fail.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
