### PR TITLE
Inserting New Result & Offence Codes to the static ref Data Sources

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/constants/CourtDataConstants.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/constants/CourtDataConstants.java
@@ -28,4 +28,7 @@ public interface CourtDataConstants {
     List<String> FAILED_LAA_STATUS = Arrays.asList("FJ", "FB");
     String CROWN_COURT = "CROWN";
     String MAGS_PROCESSING_SYSTEM_USER = "System-CP";
+    String AUTO_USER = "AUTO";
+    String RESULT_CODE_DESCRIPTION = "Automatically added result";
+    String UNKNOWN_OFFENCE = "UNKNOWN OFFENCE";
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/XLATOffence.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/XLATOffence.java
@@ -1,0 +1,38 @@
+package gov.uk.courtdata.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.LocalDate;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "XXMLA_XLAT_OFFENCE", schema = "MLA")
+public class XLATOffence {
+
+    @Id
+    @Column(name = "OFFENCE_CODE")
+    private String offenceCode;
+    @Column(name = "PARENT_CODE")
+    private String parentCode;
+    @Column(name = "CODE_MEANING")
+    private String codeMeaning;
+    @Column(name = "CODE_START")
+    private LocalDate codeStart;
+    @Column(name = "APPLICATION_FLAG")
+    private Integer applicationFlag;
+    @Column(name = "CREATED_USER")
+    private String createdUser;
+    @Column(name = "CREATED_DATE")
+    private LocalDate createdDate;
+
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hearing/magistrate/service/MagistrateCourtService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hearing/magistrate/service/MagistrateCourtService.java
@@ -1,36 +1,34 @@
 package gov.uk.courtdata.hearing.magistrate.service;
 
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
-import gov.uk.courtdata.entity.XLATResult;
-import gov.uk.courtdata.enums.WQType;
 import gov.uk.courtdata.hearing.magistrate.dto.MagistrateCourtDTO;
-import gov.uk.courtdata.hearing.magistrate.dto.ResultDTO;
 import gov.uk.courtdata.hearing.magistrate.impl.MagistrateCourtImpl;
 import gov.uk.courtdata.hearing.magistrate.mapper.MagistrateCourtDTOMapper;
 import gov.uk.courtdata.model.hearing.HearingResulted;
+import gov.uk.courtdata.processor.OffenceCodesProcessor;
+import gov.uk.courtdata.processor.ResultCodesProcessor;
 import gov.uk.courtdata.repository.IdentifierRepository;
 import gov.uk.courtdata.repository.WqLinkRegisterRepository;
-import gov.uk.courtdata.repository.XLATResultRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class MagistrateCourtService {
 
-    private static final String AUTO_USER = "AUTO";
-    private static final String RESULT_CODE_DESCRIPTION = "Automatically added result";
+
     private final MagistrateCourtDTOMapper magsCourtDTOMapper;
     private final IdentifierRepository identifierRepository;
     private final WqLinkRegisterRepository wqLinkRegisterRepository;
     private final MagistrateCourtImpl magistrateCourtImpl;
-    private final XLATResultRepository xlatResultRepository;
+    private final ResultCodesProcessor resultCodesProcessor;
+    private final OffenceCodesProcessor offenceCodesProcessor;
+
+
 
     /**
      * @param hearingResulted
@@ -45,6 +43,7 @@ public class MagistrateCourtService {
 
         hearingResulted.getDefendant().getOffences()
                 .forEach(offence -> {
+                    offenceCodesProcessor.processOffenceCode(offence.getOffenceCode());
                     offence.getResults().forEach(result -> {
 
                         MagistrateCourtDTO magsCourtDto =
@@ -52,8 +51,9 @@ public class MagistrateCourtService {
                                         wqLinkReg.getCaseId(), wqLinkReg.getProceedingId(),
                                         getNextTxId(), offence, result);
 
-                        processResultCode(magsCourtDto.getResult());
 
+                        final Integer resultCode = magsCourtDto.getResult().getResultCode();
+                        resultCodesProcessor.processResultCode(resultCode);
                         magistrateCourtImpl.execute(magsCourtDto);
 
                         log.debug(magsCourtDto.toString());
@@ -63,58 +63,6 @@ public class MagistrateCourtService {
     }
 
 
-    /**
-     * If the result code is available in xlat_result return the relevant WQ type
-     * else create a new xlat result with intervention queue type.
-     *
-     * @param resultDTO
-     * @return
-     */
-    private void processResultCode(final ResultDTO resultDTO) {
-
-        Optional<XLATResult> xlatResult =
-                xlatResultRepository.findById(resultDTO.getResultCode());
-
-        if (!xlatResult.isPresent())
-            createNewXLATResult(resultDTO);
-
-
-    }
-
-    /**
-     * Create new xlat result.
-     *
-     * @param magsCourtDTO
-     * @return
-     */
-    private XLATResult createNewXLATResult(final ResultDTO magsCourtDTO) {
-
-        XLATResult xlatResult = XLATResult.builder()
-                .cjsResultCode(magsCourtDTO.getResultCode())
-                .resultDescription(RESULT_CODE_DESCRIPTION)
-                .resultType(null)
-                .englandAndWales("Y")
-                .flag(null)
-                .notes(buildNotesContent(magsCourtDTO.getResultCode()))
-                .wqType(WQType.USER_INTERVENTIONS_QUEUE.value())
-                .createdUser(AUTO_USER)
-                .createdDate(LocalDate.now()).build();
-
-        return xlatResultRepository.save(xlatResult);
-
-
-    }
-
-    /**
-     * Build notes description for the result.
-     *
-     * @param resultCode
-     * @return
-     */
-    private String buildNotesContent(Integer resultCode) {
-        return String.format("New Result code %s  has been received " +
-                "and automatically added to the Intervention queue. Please contact support.'", resultCode);
-    }
 
     /**
      * Get next transaction id in sequence.

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hearing/processor/WQOffenceProcessor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hearing/processor/WQOffenceProcessor.java
@@ -2,6 +2,8 @@ package gov.uk.courtdata.hearing.processor;
 
 import gov.uk.courtdata.entity.WQOffence;
 import gov.uk.courtdata.hearing.magistrate.dto.MagistrateCourtDTO;
+import gov.uk.courtdata.hearing.magistrate.dto.OffenceDTO;
+import gov.uk.courtdata.processor.OffenceCodesProcessor;
 import gov.uk.courtdata.repository.WQOffenceRepository;
 import gov.uk.courtdata.util.DateUtil;
 import lombok.RequiredArgsConstructor;
@@ -16,23 +18,24 @@ public class WQOffenceProcessor {
 
     private final WQOffenceRepository wqOffenceRepository;
 
-
     public void process(final MagistrateCourtDTO magsCourtDTO) {
 
+
+        final OffenceDTO offence = magsCourtDTO.getOffence();
 
         WQOffence wqOffence = WQOffence.builder()
                 .caseId(magsCourtDTO.getCaseId())
                 .txId(magsCourtDTO.getTxId())
-                .asnSeq(magsCourtDTO.getOffence().getAsnSeq())
-                .offenceCode(magsCourtDTO.getOffence().getOffenceCode())
-                .offenceClassification(magsCourtDTO.getOffence().getOffenceClassification())
-                .legalAidStatus(mapLegalAidStatus(magsCourtDTO.getOffence().getLegalAidStatus()))
-                .legalAidStatusDate(DateUtil.toDate(magsCourtDTO.getOffence().getLegalAidStatusDate()))
-                .legalaidReason(magsCourtDTO.getOffence().getLegalAidReason())
-                .offenceDate(DateUtil.toDate(magsCourtDTO.getOffence().getOffenceDate()))
-                .offenceShortTitle(magsCourtDTO.getOffence().getOffenceShortTitle())
-                .modeOfTrial(magsCourtDTO.getOffence().getModeOfTrial())
-                .offenceWording(magsCourtDTO.getOffence().getOffenceWording())
+                .asnSeq(offence.getAsnSeq())
+                .offenceCode(offence.getOffenceCode())
+                .offenceClassification(offence.getOffenceClassification())
+                .legalAidStatus(mapLegalAidStatus(offence.getLegalAidStatus()))
+                .legalAidStatusDate(DateUtil.toDate(offence.getLegalAidStatusDate()))
+                .legalaidReason(offence.getLegalAidReason())
+                .offenceDate(DateUtil.toDate(offence.getOffenceDate()))
+                .offenceShortTitle(offence.getOffenceShortTitle())
+                .modeOfTrial(offence.getModeOfTrial())
+                .offenceWording(offence.getOffenceWording())
                 .wqOffence(null)
                 .applicationFlag(G_NO)
                 .build();

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/link/processor/ResultsInfoProcessor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/link/processor/ResultsInfoProcessor.java
@@ -3,6 +3,7 @@ package gov.uk.courtdata.link.processor;
 import gov.uk.courtdata.dto.CourtDataDTO;
 import gov.uk.courtdata.entity.ResultEntity;
 import gov.uk.courtdata.model.Result;
+import gov.uk.courtdata.processor.ResultCodesProcessor;
 import gov.uk.courtdata.repository.ResultRepository;
 import gov.uk.courtdata.util.CourtDataUtil;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +38,9 @@ public class ResultsInfoProcessor implements Process {
 
     }
 
+
     private ResultEntity buildResult(Result result, CourtDataDTO saveAndLinkModel) {
+
         return ResultEntity.builder()
                 .caseId(saveAndLinkModel.getCaseId())
                 .txId(saveAndLinkModel.getTxId())
@@ -60,4 +63,5 @@ public class ResultsInfoProcessor implements Process {
                 .wqResult(G_NO)
                 .build();
     }
+
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/processor/OffenceCodesProcessor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/processor/OffenceCodesProcessor.java
@@ -1,0 +1,61 @@
+package gov.uk.courtdata.processor;
+
+import gov.uk.courtdata.entity.XLATOffence;
+import gov.uk.courtdata.exception.MaatCourtDataException;
+import gov.uk.courtdata.repository.XLATOffenceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static gov.uk.courtdata.constants.CourtDataConstants.*;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OffenceCodesProcessor {
+
+    private final XLATOffenceRepository xlatOffenceRepository;
+
+
+    /**
+     * if the Offence Code is not available on XXMLA_XLAT_OFFENCE then
+     * Add the Offence code there.
+     */
+    public void processOffenceCode(final String offenceCode) {
+
+        if (offenceCode != null) {
+            Optional<XLATOffence> xlatOffence =
+                    xlatOffenceRepository.findById(offenceCode);
+
+            if (xlatOffence.isEmpty())
+                createNewXLATOffence(offenceCode);
+            log.info("A New Offence Code : " + offenceCode + " has been added to the Ref Data");
+        } else {
+            throw new MaatCourtDataException("A Null Offence Code is passed in");
+        }
+    }
+
+
+    private void createNewXLATOffence(final String offenceCode) {
+
+        XLATOffence xlatOffence = XLATOffence.builder()
+                .offenceCode(offenceCode)
+                .parentCode(offenceCode.length() >= 4 ? offenceCode.substring(0, 4) : offenceCode)
+                .codeMeaning(UNKNOWN_OFFENCE)
+                .applicationFlag(G_NO)
+                .codeStart(LocalDate.now())
+                .createdUser(AUTO_USER)
+                .createdDate(LocalDate.now())
+                .build();
+
+
+        xlatOffenceRepository.save(xlatOffence);
+
+
+    }
+
+
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/processor/ResultCodesProcessor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/processor/ResultCodesProcessor.java
@@ -1,0 +1,74 @@
+package gov.uk.courtdata.processor;
+
+
+import gov.uk.courtdata.entity.XLATResult;
+import gov.uk.courtdata.enums.WQType;
+import gov.uk.courtdata.exception.MaatCourtDataException;
+import gov.uk.courtdata.repository.XLATResultRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static gov.uk.courtdata.constants.CourtDataConstants.*;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ResultCodesProcessor {
+
+    private final XLATResultRepository xlatResultRepository;
+
+    /**
+     * if the Result Code is not available on XXMLA_XLAT_RESULT then
+     * Add the result code there.
+     *
+     * @param resultCode
+     * @return
+     */
+    public void processResultCode(final Integer resultCode) {
+
+        if (resultCode != null) {
+            Optional<XLATResult> xlatResult =
+                    xlatResultRepository.findById(resultCode);
+
+            if (xlatResult.isEmpty())
+                createNewXLATResult(resultCode);
+            log.info("A New CJS Result Code : " + resultCode + " has been added to the Ref Data");
+        }else {
+            throw new MaatCourtDataException("A Null Result Code is passed in");
+        }
+    }
+
+
+    private void createNewXLATResult(final Integer resultCode) {
+
+        XLATResult xlatResult = XLATResult.builder()
+                .cjsResultCode(resultCode)
+                .resultDescription(RESULT_CODE_DESCRIPTION)
+                .englandAndWales(YES)
+                .notes(buildNotesContent(resultCode))
+                .wqType(WQType.USER_INTERVENTIONS_QUEUE.value())
+                .createdUser(AUTO_USER)
+                .createdDate(LocalDate.now())
+                .build();
+
+        xlatResultRepository.save(xlatResult);
+
+
+    }
+
+    /**
+     * Build notes description for the result.
+     *
+     * @param resultCode
+     * @return
+     */
+    private String buildNotesContent(Integer resultCode) {
+        return String.format("New Result code %s  has been received " +
+                "and automatically added to the Intervention queue. Please contact support.'", resultCode);
+    }
+
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/XLATOffenceRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/XLATOffenceRepository.java
@@ -1,0 +1,9 @@
+package gov.uk.courtdata.repository;
+
+import gov.uk.courtdata.entity.XLATOffence;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface XLATOffenceRepository extends JpaRepository<XLATOffence,String> {
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/link/processor/ResultsInfoProcessorTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/link/processor/ResultsInfoProcessorTest.java
@@ -7,6 +7,7 @@ import gov.uk.courtdata.dto.CourtDataDTO;
 import gov.uk.courtdata.entity.ResultEntity;
 import gov.uk.courtdata.model.CaseDetails;
 import gov.uk.courtdata.model.Result;
+import gov.uk.courtdata.processor.ResultCodesProcessor;
 import gov.uk.courtdata.repository.ResultRepository;
 import gov.uk.courtdata.util.CourtDataUtil;
 import org.junit.Before;
@@ -37,6 +38,9 @@ public class ResultsInfoProcessorTest {
 
     @Mock
     private CourtDataUtil courtDataUtil;
+
+    @Mock
+    private ResultCodesProcessor resultCodesProcessor;
 
     @Before
     public void setUp() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/processor/OffenceCodesProcessorTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/processor/OffenceCodesProcessorTest.java
@@ -1,0 +1,91 @@
+package gov.uk.courtdata.processor;
+
+import gov.uk.courtdata.entity.XLATOffence;
+import gov.uk.courtdata.exception.MaatCourtDataException;
+import gov.uk.courtdata.repository.XLATOffenceRepository;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static gov.uk.courtdata.constants.CourtDataConstants.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OffenceCodesProcessorTest {
+
+    @InjectMocks
+    private OffenceCodesProcessor offenceCodesProcessor;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Spy
+    private XLATOffenceRepository xlatOffenceRepository;
+
+    @Captor
+    private ArgumentCaptor<XLATOffence> offenceCodeCaptor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+    }
+
+    @Test
+    public void testProcessOffenceCode_whenNewOffenceIsPassedIn_thenOffenceIsSaved() {
+
+        //given
+        String offenceCode = "ABCDEF";
+
+        //when
+        Mockito.when(xlatOffenceRepository.findById(offenceCode))
+                .thenReturn(Optional.empty());
+
+        offenceCodesProcessor.processOffenceCode(offenceCode);
+
+        //then
+        verify(xlatOffenceRepository).save(offenceCodeCaptor.capture());
+        assertThat(offenceCodeCaptor.getValue().getOffenceCode()).isEqualTo(offenceCode);
+        assertThat(offenceCodeCaptor.getValue().getParentCode()).isEqualTo("ABCD");
+        assertThat(offenceCodeCaptor.getValue().getCreatedDate()).isEqualTo(LocalDate.now());
+        assertThat(offenceCodeCaptor.getValue().getApplicationFlag()).isEqualTo(G_NO);
+        assertThat(offenceCodeCaptor.getValue().getCodeMeaning()).isEqualTo(UNKNOWN_OFFENCE);
+        assertThat(offenceCodeCaptor.getValue().getCreatedUser()).isEqualTo(AUTO_USER);
+        assertThat(offenceCodeCaptor.getValue().getCodeStart()).isEqualTo(LocalDate.now());
+
+    }
+
+    @Test
+    public void testProcessOffenceCode_whenOffenceExists_thenOffenceNotSaved() {
+
+        //given
+        String offenceCode = "ABCD";
+        final XLATOffence xlatOffence = XLATOffence.builder().offenceCode(offenceCode).build();
+
+        //when
+        Mockito.when(xlatOffenceRepository.findById(offenceCode))
+                .thenReturn(Optional.of(xlatOffence));
+
+        offenceCodesProcessor.processOffenceCode(offenceCode);
+
+        //then
+        verify(xlatOffenceRepository, times(0)).save(xlatOffence);
+    }
+
+    @Test
+    public void testProcessOffenceCode_whenNullCodeIsPassedIn_thenThrowsMaatCourtDataException() {
+
+        exceptionRule.expect(MaatCourtDataException.class);
+        exceptionRule.expectMessage("A Null Offence Code is passed in");
+        offenceCodesProcessor.processOffenceCode(null);
+    }
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/processor/ResultCodesProcessorTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/processor/ResultCodesProcessorTest.java
@@ -65,7 +65,7 @@ public class ResultCodesProcessorTest {
     }
 
     @Test
-    public void testProcessOffenceCode_whenOffenceExists_thenOffenceNotSaved() {
+    public void testProcessResultCode_whenOffenceExists_thenOffenceNotSaved() {
 
         //given
         Integer resultCode = 3333;
@@ -83,7 +83,7 @@ public class ResultCodesProcessorTest {
     }
 
     @Test
-    public void testProcessOffenceCode_whenNullCodeIsPassedIn_thenThrowsMaatCourtDataException() {
+    public void testProcessResultCode_whenNullCodeIsPassedIn_thenThrowsMaatCourtDataException() {
 
         exceptionRule.expect(MaatCourtDataException.class);
         exceptionRule.expectMessage("A Null Result Code is passed in");

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/processor/ResultCodesProcessorTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/processor/ResultCodesProcessorTest.java
@@ -1,0 +1,92 @@
+package gov.uk.courtdata.processor;
+
+import gov.uk.courtdata.entity.XLATResult;
+import gov.uk.courtdata.exception.MaatCourtDataException;
+import gov.uk.courtdata.repository.XLATResultRepository;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static gov.uk.courtdata.constants.CourtDataConstants.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResultCodesProcessorTest {
+
+    @InjectMocks
+    private ResultCodesProcessor resultCodesProcessor;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Spy
+    private XLATResultRepository xlatResultRepository;
+
+    @Captor
+    private ArgumentCaptor<XLATResult> xlatResultArgumentCaptor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+    }
+
+    @Test
+    public void testProcessResultCode_whenNewResultIsPassedIn_thenResultIsSaved() {
+
+        //given
+        Integer resultCode = 5555;
+
+        //when
+        Mockito.when(xlatResultRepository.findById(resultCode))
+                .thenReturn(Optional.empty());
+
+        resultCodesProcessor.processResultCode(resultCode);
+
+        //then
+        verify(xlatResultRepository).save(xlatResultArgumentCaptor.capture());
+        assertThat(xlatResultArgumentCaptor.getValue().getCjsResultCode()).isEqualTo(5555);
+        assertThat(xlatResultArgumentCaptor.getValue().getEnglandAndWales()).isEqualTo(YES);
+        assertThat(xlatResultArgumentCaptor.getValue().getCreatedDate()).isEqualTo(LocalDate.now());
+        assertThat(xlatResultArgumentCaptor.getValue().getResultDescription()).isEqualTo(RESULT_CODE_DESCRIPTION);
+        assertThat(xlatResultArgumentCaptor.getValue().getCreatedUser()).isEqualTo(AUTO_USER);
+        assertThat(xlatResultArgumentCaptor.getValue().getWqType()).isEqualTo(8);
+
+
+    }
+
+    @Test
+    public void testProcessOffenceCode_whenOffenceExists_thenOffenceNotSaved() {
+
+        //given
+        Integer resultCode = 3333;
+        final XLATResult xlatResult = XLATResult.builder().cjsResultCode(resultCode).build();
+
+        //when
+        Mockito.when(xlatResultRepository.findById(resultCode))
+                .thenReturn(Optional.of(xlatResult));
+
+        resultCodesProcessor.processResultCode(resultCode);
+
+        //then
+        verify(xlatResultRepository, times(0)).save(xlatResult);
+
+    }
+
+    @Test
+    public void testProcessOffenceCode_whenNullCodeIsPassedIn_thenThrowsMaatCourtDataException() {
+
+        exceptionRule.expect(MaatCourtDataException.class);
+        exceptionRule.expectMessage("A Null Result Code is passed in");
+        resultCodesProcessor.processResultCode(null);
+    }
+}


### PR DESCRIPTION
## What

Result and Offence ref Data Update.

Describe what you did and why.

Results and Offence Code should be updated to the ref Data Source during Linking & Hearing Updates. 
New Offence Codes are being updated to XXMLA_XLAT_OFFENCE
New Results Codes are being updated to XXMLA_XLAT_RESULT

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
