### PR TITLE
Change unlink with other reasons to include other reason text in request

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/constants/CourtDataConstants.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/constants/CourtDataConstants.java
@@ -29,4 +29,6 @@ public final class CourtDataConstants {
 
     public static final String CATY_CASE_TYPE = "APPEAL CC";
 
+    public static final String SYSTEM_UNLINKED = "System Unlinked";
+
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/model/Unlink.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/model/Unlink.java
@@ -13,7 +13,7 @@ public class Unlink {
     private Integer maatId;
     private String userId;
     private Integer reasonId;
-    private String reasonText;
+    private String otherReasonText;
     private UUID laaTransactionId;
 
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/unlink/impl/UnLinkImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/unlink/impl/UnLinkImpl.java
@@ -14,8 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static gov.uk.courtdata.constants.CourtDataConstants.WQ_SUCCESS_STATUS;
-import static gov.uk.courtdata.constants.CourtDataConstants.WQ_UNLINK_EVENT;
+import static gov.uk.courtdata.constants.CourtDataConstants.*;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 
 @Component
@@ -54,10 +54,14 @@ public class UnLinkImpl {
 
     private void processUnlinkReason(UnlinkModel unlinkModel) {
         Unlink unlink = unlinkModel.getUnlink();
+
+        final String otherReasonText = isBlank(unlink.getOtherReasonText()) ? SYSTEM_UNLINKED :
+        unlink.getOtherReasonText();
+
         UnlinkEntity unlinkEntity = UnlinkEntity.builder()
                 .caseId(unlinkModel.getWqLinkRegisterEntity().getCaseId())
                 .reasonId(unlink.getReasonId())
-                .otherReason(unlink.getReasonText())
+                .otherReason(otherReasonText)
                 .txId(unlinkModel.getTxId())
                 .build();
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
@@ -126,7 +126,17 @@ public class TestModelDataBuilder {
                 "  \"laaTransactionId\":\"e439dfc8-664e-4c8e-a999-d756dcf112c2\",\n" +
                 "  \"userId\": \"testUser\",\n" +
                 "  \"reasonId\": 1,\n" +
-                "  \"reasonText\" : \"Test Data\"\n" +
+                "  \"otherReasonText\" : \"\"\n" +
+                "}";
+    }
+
+    public String getUnLinkWithOtherReasonString() {
+        return "{\n" +
+                " \"maatId\": 1234,\n" +
+                "  \"laaTransactionId\":\"e439dfc8-664e-4c8e-a999-d756dcf112c2\",\n" +
+                "  \"userId\": \"testUser\",\n" +
+                "  \"reasonId\": 1,\n" +
+                "  \"otherReasonText\" : \"Other reason description\"\n" +
                 "}";
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integrationTest/unlink/controller/UnLinkControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integrationTest/unlink/controller/UnLinkControllerTest.java
@@ -62,7 +62,7 @@ public class UnLinkControllerTest {
 
         Unlink unlink = Unlink.builder()
                 .maatId(123456)
-                .reasonId(999888)
+                .reasonId(1)
                 .userId("User")
                 .laaTransactionId(UUID.randomUUID())
                 .build();


### PR DESCRIPTION
Unlink request to include reason text only when the choice to unlink is 'Other'
Describe what you did and why.

Currently on unlink all unlink reason codes requested to maat api has reasontext but we require other reason text when requested with custom reason.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
