### PR TITLE
When linking a case ,record modified user and time

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/link/processor/RepOrderCPInfoProcessor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/link/processor/RepOrderCPInfoProcessor.java
@@ -7,6 +7,7 @@ import gov.uk.courtdata.repository.RepOrderCPDataRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -24,6 +25,8 @@ public class RepOrderCPInfoProcessor implements Process {
             RepOrderCPDataEntity repOrder = repOrderEntity.get();
             repOrder.setCaseUrn(caseDetails.getCaseUrn());
             repOrder.setDefendantId(caseDetails.getDefendant().getDefendantId());
+            repOrder.setUserModified(caseDetails.getCreatedUser());
+            repOrder.setDateModified(LocalDateTime.now());
             repOrderDataRepository.save(repOrder);
         }
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/link/processor/RepOrderCPInfoProcessorTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/link/processor/RepOrderCPInfoProcessorTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.mockito.*;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -22,14 +23,13 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class RepOrderCPInfoProcessorTest {
 
+    @Captor
+    ArgumentCaptor<RepOrderCPDataEntity> repOrderCaptor;
     @InjectMocks
     private RepOrderCPInfoProcessor repOrderCPInfoProcessor;
     @Spy
     private RepOrderCPDataRepository repOrderDataRepository;
-
     private TestModelDataBuilder testModelDataBuilder;
-    @Captor
-    ArgumentCaptor<RepOrderCPDataEntity> repOrderCaptor;
 
     @Before
     public void setUp() {
@@ -54,5 +54,8 @@ public class RepOrderCPInfoProcessorTest {
         assertThat(repOrderCaptor.getValue().getCaseUrn()).isEqualTo("caseurn1");
         assertThat(repOrderCaptor.getValue().getRepOrderId()).isEqualTo(123);
         assertThat(repOrderCaptor.getValue().getDefendantId()).isEqualTo(defendant.getDefendantId());
+        assertThat(repOrderCaptor.getValue().getUserModified()).isEqualTo("testUser");
+        assertThat(repOrderCaptor.getValue().getDateModified()).isNotNull()
+                .isExactlyInstanceOf(LocalDateTime.class);
     }
 }


### PR DESCRIPTION
## What

    When linking a case ,the user and time of linking needs be recorded.

Describe what you did and why.

    On linking a case, the common platform data on maat records the linked caseurn and defendantId.
    Along with linked user and time requires be updated. Earlier linking maatId with caseurn was on MAAT and CP tried to 
    do the same linking. But with linking from CP is the source for linking a case, the user and time required be recorded. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
