### PR TITLE
LAWS-976-fix-Cloudformation-ListenerARN-reference

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -557,7 +557,7 @@ Resources:
       ApiId: !Ref ApiGateway
       Description: !Sub '${pAppName} Integration Proxy'
       IntegrationType: HTTP_PROXY
-      IntegrationUri: !Ref LoadBalancer
+      IntegrationUri: !Ref AlbHTTPListener
       IntegrationMethod: ANY
       ConnectionType: VPC_LINK
       ConnectionId: !Ref ApiGatewayVpcLink


### PR DESCRIPTION
## What

Jira [LAWS-976](https://dsdmoj.atlassian.net/browse/LAWS-976
)
- Fix Cloudformation issue where reference in API Gateway Integration
should point to the Load Balancer listener not the balancer itself

This work is required to allow secure access from external
applications

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
