### PR TITLE
Added padding to asn seq on new offence query

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hearing/processor/WQCoreProcessor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hearing/processor/WQCoreProcessor.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import static gov.uk.courtdata.constants.CourtDataConstants.LEADING_ZERO_3;
 import static gov.uk.courtdata.constants.CourtDataConstants.MAGS_PROCESSING_SYSTEM_USER;
 import static gov.uk.courtdata.enums.WQStatus.WAITING;
 
@@ -52,7 +53,9 @@ public class WQCoreProcessor {
     private int processIfNewOffence(final HearingDTO magsCourtDTO) {
 
         Integer offenceCount =
-                offenceRepository.getOffenceCountForAsnSeq(magsCourtDTO.getCaseId(), magsCourtDTO.getOffence().getAsnSeq());
+                offenceRepository.getOffenceCountForAsnSeq(
+                        magsCourtDTO.getCaseId(),
+                        String.format(LEADING_ZERO_3, Integer.parseInt(magsCourtDTO.getOffence().getAsnSeq())));
 
         return offenceCount == 0 ? 0 : 99;
     }


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/browse/CACP-485

Describe what you did and why.

  ASN Seq is padded to 3 zeros where required.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
