### PR TITLE
add sonarqube task depends on test execution,order build task before …

### DIFF
--- a/maat-court-data-api/build.gradle
+++ b/maat-court-data-api/build.gradle
@@ -147,6 +147,7 @@ pitest {
     mutationThreshold = 60
 }
 
+tasks['sonarqube'].dependsOn test
 
 sonarqube {
     properties {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,11 +4,12 @@ set -e
 
 echo Building the ear file and Docker image with gradle...
 pushd maat-court-data-api
-chmod +x ./gradlew && ./gradlew sonarqube \
+chmod +x ./gradlew
+./gradlew build
+./gradlew sonarqube \
   -Dsonar.projectKey=maat-cd-api \
   -Dsonar.host.url=http://sonarqube.aws.ssvs.legalservices.gov.uk \
   -Dsonar.login=${SONARQUBE_TOKEN}
-./gradlew build
 docker build -t maat-cda .
 docker tag maat-cda "${IMAGE_URI}"
 popd


### PR DESCRIPTION
Fix to report code coverage reports.

## What

https://dsdmoj.atlassian.net/browse/CACP-509

Sonarqube server is setup but the test reports coverage reports where in reported.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
