### PR TITLE
Sonarqube - remove scm provider and to use artifact from s3

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,6 @@ pushd maat-court-data-api
 chmod +x ./gradlew
 ./gradlew build
 ./gradlew sonarqube \
-  -Dsonar.scm.provider=git \
   -Dsonar.projectKey=maat-cd-api \
   -Dsonar.host.url=http://sonarqube.aws.ssvs.legalservices.gov.uk \
   -Dsonar.login=${SONARQUBE_TOKEN}


### PR DESCRIPTION

https://dsdmoj.atlassian.net/browse/CACP-509

sonarqube - remove scm provider property and allow to use artefact from s3.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
