### PR TITLE
Modify link created date to time stamp

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/WqLinkRegisterEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/WqLinkRegisterEntity.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Builder
@@ -19,7 +20,7 @@ public class WqLinkRegisterEntity {
     @Column(name = "CASE_ID")
     private Integer caseId;
     @Column(name = "CREATED_DATE")
-    private LocalDate createdDate;
+    private LocalDateTime createdDate;
     @Column(name = "CREATED_USER_ID")
     private String createdUserId;
     @Column(name = "REMOVED_TX_ID")

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/link/processor/WqLinkRegisterProcessor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/link/processor/WqLinkRegisterProcessor.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static gov.uk.courtdata.constants.CourtDataConstants.LEADING_ZERO_2;
 
@@ -24,7 +25,7 @@ public class WqLinkRegisterProcessor implements Process {
         Integer maatCat = geCategory(courtDataDTO);
         final WqLinkRegisterEntity wqLinkRegisterEntity = WqLinkRegisterEntity.builder()
                 .createdTxId(courtDataDTO.getTxId())
-                .createdDate(LocalDate.now())
+                .createdDate(LocalDateTime.now())
                 .createdUserId(caseDetails.getCreatedUser())
                 .caseId(courtDataDTO.getCaseId())
                 .libraId(courtDataDTO.getLibraId())


### PR DESCRIPTION
Linking CP cases created date to be recorded with time.

https://dsdmoj.atlassian.net/browse/CACP-522

When common platform cases are linked ,creation date was persisted without time to it which is causing LIBRA MI reports to fail. Fix to persist creation date as date time.   

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
