### PR TITLE
Remove caseURN checks on validation endpoint

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/link/validator/CPDataValidator.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/link/validator/CPDataValidator.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,14 +23,11 @@ public class CPDataValidator implements IValidator<Void, CaseDetails> {
     @Override
     public Optional<Void> validate(CaseDetails caseDetails) {
 
-        if (isEmpty(caseDetails.getCaseUrn()))
-            throw new ValidationException("CaseURN can't be null or empty on request.");
-
         Optional<RepOrderCPDataEntity> repOrderCPDataEntity = repOrderCPDataRepository.findByrepOrderId(caseDetails.getMaatId());
 
         if (repOrderCPDataEntity.isEmpty())
-                throw new ValidationException(
-                        format("MaatId %s has no common platform data created against Maat application.", caseDetails.getMaatId()));
+            throw new ValidationException(
+                    format("MaatId %s has no common platform data created in MAAT.", caseDetails.getMaatId()));
 
         return Optional.empty();
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/controller/LinkControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/controller/LinkControllerIntegrationTest.java
@@ -124,29 +124,7 @@ public class LinkControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)).andDo(print())
                 .andExpect(status().is4xxClientError())
                 .andExpect(jsonPath("$.message",
-                        is("MaatId 1000 has no common platform data created against Maat application.")));
-    }
-
-    @Test
-    public void testWhenCaseUrnNotExists_Returns400ClientError() throws Exception {
-
-        final Integer maatId = 1000;
-
-        // Create Rep order with maatId
-        repOrderRepository.save(createRepOrderEntity(maatId));
-
-        final CaseDetailsValidate caseDetailsValidate =
-                CaseDetailsValidate
-                        .builder()
-                        .maatId(maatId)
-                        .build();
-
-        String json = objectMapper.writeValueAsString(caseDetailsValidate);
-
-        this.mockMvc.perform(post(LINK_VALIDATE_URI).content(json)
-                .contentType(MediaType.APPLICATION_JSON)).andDo(print())
-                .andExpect(status().is4xxClientError())
-                .andExpect(jsonPath("$.message", is("CaseURN can't be null or empty on request.")));
+                        is("MaatId 1000 has no common platform data created in MAAT.")));
     }
 
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/link/validator/CPDataValidatorTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/link/validator/CPDataValidatorTest.java
@@ -34,14 +34,6 @@ public class CPDataValidatorTest {
         MockitoAnnotations.initMocks(this);
     }
 
-    @Test
-    public void testWhenCaseURNisNullonRequest_throwsException() {
-
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("CaseURN can't be null or empty on request.");
-        CPDataValidator.validate(CaseDetails.builder().maatId(100)
-                .caseUrn(null).build());
-    }
 
     @Test
     public void testWhenCPDataNotExists_throwsException() {
@@ -49,7 +41,7 @@ public class CPDataValidatorTest {
         final int maatId = 1000;
         Mockito.when(repOrderCPDataRepository.findByrepOrderId(maatId)).thenReturn(Optional.empty());
         thrown.expect(ValidationException.class);
-        thrown.expectMessage("MaatId 1000 has no common platform data created against Maat application.");
+        thrown.expectMessage("MaatId 1000 has no common platform data created in MAAT.");
 
         CPDataValidator.validate(CaseDetails.builder().maatId(maatId)
                 .caseUrn("caseURN").build());


### PR DESCRIPTION
Remove caseURN checks on validation endpoint.

https://dsdmoj.atlassian.net/browse/CACP-528

We no more require validate caseURN as linked case from VCD is source. Existing checks is removed.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
