### PR TITLE
Setting the legal aid date when sending a request to CDA.

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/laastatus/builder/CourtDataDTOBuilder.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/laastatus/builder/CourtDataDTOBuilder.java
@@ -53,7 +53,11 @@ public class CourtDataDTOBuilder {
 
             offence.setOffenceId(offenceEntity.map(OffenceEntity::getOffenceId).orElse(null));
 
-
+            log.info("legal status {}, date {}", offence.getLegalAidStatus(), offence.getLegalAidStatusDate());
+            if (!offence.getLegalAidStatus().equals("AP") && offence.getLegalAidStatusDate() == null) {
+                log.info("Offence legal status date {}", offenceEntity.get().getLegalAidStatusDate());
+                offence.setLegalAidStatusDate(offenceEntity.get().getLegalAidStatusDate().toString());
+            }
         });
 
         return CourtDataDTO.builder()


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-380)

MLRA sending a request to post a message for CSA. If the Legal aid status date is not available then maat-API will set this date before sending to CDA. This is the required fields when the application status is not pending. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
