### PR TITLE
Removed MaatId from the SQS payload

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/exception/GlobalAppLoggingHandler.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/exception/GlobalAppLoggingHandler.java
@@ -66,7 +66,7 @@ public class GlobalAppLoggingHandler {
         MDC.put(LoggingData.MESSAGE.getValue(), laaTransactionLogging.toString());
         MDC.put(LoggingData.CASE_URN.getValue(), laaTransactionLogging.getCaseUrn());
         MDC.put(LoggingData.LAA_TRANSACTION_ID.getValue(), laaTransactionLogging.getLaaTransactionId() != null ? laaTransactionLogging.getLaaTransactionId().toString() : "");
-        MDC.put(LoggingData.MAATID.getValue(), laaTransactionLogging.getMaatId().toString());
+        MDC.put(LoggingData.MAATID.getValue(), laaTransactionLogging.getMaatId() != null ? laaTransactionLogging.getMaatId().toString() : "-" );
         log.info("Received a json payload from a queue and converted.");
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hearing/service/HearingResultedService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hearing/service/HearingResultedService.java
@@ -6,6 +6,7 @@ import gov.uk.courtdata.hearing.crowncourt.service.CrownCourtHearingService;
 import gov.uk.courtdata.hearing.impl.HearingResultedImpl;
 import gov.uk.courtdata.hearing.processor.CourtApplicationsPreProcessor;
 import gov.uk.courtdata.hearing.validator.HearingValidationProcessor;
+import gov.uk.courtdata.helper.RepOrderCPDataHelper;
 import gov.uk.courtdata.model.hearing.HearingResulted;
 import gov.uk.courtdata.repository.ReservationsRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,8 @@ public class HearingResultedService {
 
     private final CourtApplicationsPreProcessor courtApplicationsPreProcessor;
 
+    private final RepOrderCPDataHelper repOrderCPDataHelper;
+
     /**
      * Process Work Queue Processing for both Crown & Mags Court.
      * Process Crown Court Outcomes for CC
@@ -38,9 +41,13 @@ public class HearingResultedService {
      */
     public void execute(final HearingResulted hearingResulted) {
 
+        hearingResulted.setMaatId(
+                repOrderCPDataHelper.getMaatIdByDefendantId(hearingResulted.getDefendant().getDefendantId())
+        );
+
         hearingValidationProcessor.validate(hearingResulted);
 
-        if(FunctionType.APPLICATION == hearingResulted.getFunctionType()){
+        if (FunctionType.APPLICATION == hearingResulted.getFunctionType()) {
             courtApplicationsPreProcessor.process(hearingResulted);
         }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/helper/RepOrderCPDataHelper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/helper/RepOrderCPDataHelper.java
@@ -1,0 +1,30 @@
+package gov.uk.courtdata.helper;
+
+import gov.uk.courtdata.entity.RepOrderCPDataEntity;
+import gov.uk.courtdata.exception.ValidationException;
+import gov.uk.courtdata.repository.RepOrderCPDataRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.util.Optional;
+
+@Slf4j
+@Getter
+@Component
+@RequiredArgsConstructor
+public class RepOrderCPDataHelper {
+
+    private final RepOrderCPDataRepository repOrderCPDataRepository;
+
+    public Integer getMaatIdByDefendantId(String defendantId){
+
+        Optional<RepOrderCPDataEntity> repOrderCPDataEntity = repOrderCPDataRepository.findByDefendantId(defendantId);
+
+            if (repOrderCPDataEntity.isPresent() ) {
+                 return repOrderCPDataEntity.get().getRepOrderId();
+            }
+
+        throw new ValidationException(defendantId + " defendantId is invalid and No MAAT-Id associated with this.");
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/model/Unlink.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/model/Unlink.java
@@ -10,11 +10,10 @@ import java.util.UUID;
 @NoArgsConstructor
 public class Unlink {
 
+    private String defendantId;
     private Integer maatId;
     private String userId;
     private Integer reasonId;
     private String otherReasonText;
     private UUID laaTransactionId;
-
-
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderCPDataRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderCPDataRepository.java
@@ -11,4 +11,6 @@ public interface RepOrderCPDataRepository extends JpaRepository<RepOrderCPDataEn
 
     Optional<RepOrderCPDataEntity> findByrepOrderId(Integer repOrderId);
 
+    Optional<RepOrderCPDataEntity> findByDefendantId(String defendantId);
+
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/service/QueueMessageLogService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/service/QueueMessageLogService.java
@@ -39,7 +39,9 @@ public class QueueMessageLogService {
                 QueueMessageLogEntity.builder()
                         .transactionUUID(Optional.ofNullable(uuid).map(JsonElement::getAsString)
                                 .orElseGet(UUID.randomUUID()::toString))
-                        .maatId(maatId.getAsInt())
+                        .maatId(
+                                Optional.ofNullable(maatId).map(JsonElement::getAsInt).orElse(null)
+                        )
                         .type(prepareMessageType(messageType, msgObject))
                         .message(convertAsByte(message))
                         .createdTime(LocalDateTime.now())

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/unlink/processor/UnLinkProcessor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/unlink/processor/UnLinkProcessor.java
@@ -2,6 +2,7 @@ package gov.uk.courtdata.unlink.processor;
 
 import gov.uk.courtdata.entity.RepOrderCPDataEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
+import gov.uk.courtdata.helper.RepOrderCPDataHelper;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.model.UnlinkModel;
 import gov.uk.courtdata.repository.RepOrderCPDataRepository;
@@ -26,7 +27,15 @@ public class UnLinkProcessor {
     private final UnLinkValidationProcessor unlinkValidator;
     private final UnLinkImpl unlinkImpl;
 
+    private final RepOrderCPDataHelper repOrderCPDataHelper;
+
+
     public UnlinkModel process(Unlink unlinkJson) {
+
+        unlinkJson.setMaatId(
+                repOrderCPDataHelper
+                        .getMaatIdByDefendantId(unlinkJson.getDefendantId())
+        );
 
         unlinkValidator.validate(unlinkJson);
         UnlinkModel unlinkModel = UnlinkModel.builder().unlink(unlinkJson).build();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -62,6 +62,7 @@ public class TestEntityDataBuilder {
     public RepOrderCPDataEntity getRepOrderCPDataEntity() {
         return RepOrderCPDataEntity.builder()
                 .repOrderId(1234)
+                .defendantId("556677")
                 .caseUrn("testCaseURN")
                 .build();
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
@@ -2,7 +2,6 @@ package gov.uk.courtdata.builder;
 
 import com.google.gson.Gson;
 import gov.uk.courtdata.dto.CourtDataDTO;
-import gov.uk.courtdata.enums.VerdictCategoryType;
 import gov.uk.courtdata.hearing.dto.*;
 import gov.uk.courtdata.model.CaseDetails;
 import org.springframework.stereotype.Component;
@@ -123,7 +122,7 @@ public class TestModelDataBuilder {
 
     public String getUnLinkString() {
         return "{\n" +
-                " \"maatId\": 1234,\n" +
+                " \"defendantId\": \"556677\",\n" +
                 "  \"laaTransactionId\":\"e439dfc8-664e-4c8e-a999-d756dcf112c2\",\n" +
                 "  \"userId\": \"testUser\",\n" +
                 "  \"reasonId\": 1,\n" +
@@ -133,7 +132,7 @@ public class TestModelDataBuilder {
 
     public String getUnLinkWithOtherReasonString() {
         return "{\n" +
-                " \"maatId\": 1234,\n" +
+                " \"defendantId\": \"556677\",\n" +
                 "  \"laaTransactionId\":\"e439dfc8-664e-4c8e-a999-d756dcf112c2\",\n" +
                 "  \"userId\": \"testUser\",\n" +
                 "  \"reasonId\": 1,\n" +

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/helper/RepOrderCPDataHelperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/helper/RepOrderCPDataHelperTest.java
@@ -1,0 +1,71 @@
+package gov.uk.courtdata.helper;
+
+
+import gov.uk.courtdata.entity.RepOrderCPDataEntity;
+import gov.uk.courtdata.exception.ValidationException;
+import gov.uk.courtdata.repository.RepOrderCPDataRepository;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RepOrderCPDataHelperTest {
+
+    @InjectMocks
+    private RepOrderCPDataHelper repOrderCPDataHelper;
+
+    @Mock
+    private RepOrderCPDataRepository repOrderCPDataRepository;
+
+
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void givenValidDefendantIdWhenFindCalledThenReturnMaatId() {
+
+        RepOrderCPDataEntity repOrderCPDataEntity = RepOrderCPDataEntity.builder()
+                .defendantId("556677")
+                .caseUrn("caseun334")
+                .repOrderId(12345)
+                .inCommonPlatform("Y")
+                .build();
+
+        Mockito.when(repOrderCPDataRepository.findByDefendantId("556677")).thenReturn(Optional.ofNullable(repOrderCPDataEntity));
+
+        Integer maatId = repOrderCPDataHelper.getMaatIdByDefendantId(repOrderCPDataEntity.getDefendantId());
+
+        assertThat(maatId).isEqualTo(12345);
+
+    }
+
+    @Test(expected = ValidationException.class)
+    public void givenInValidDefendantIdWhenFindCalledThenReturnMaatId() {
+
+        RepOrderCPDataEntity repOrderCPDataEntity = RepOrderCPDataEntity.builder()
+                .defendantId("556677")
+                .caseUrn("caseun334")
+                .repOrderId(12345)
+                .inCommonPlatform("Y")
+                .build();
+
+        repOrderCPDataHelper.getMaatIdByDefendantId(repOrderCPDataEntity.getDefendantId());
+    }
+
+
+
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/impl/UnLinkImplIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/impl/UnLinkImplIntegrationTest.java
@@ -9,9 +9,10 @@ import gov.uk.courtdata.entity.UnlinkEntity;
 import gov.uk.courtdata.entity.WqCoreEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
 import gov.uk.courtdata.integration.MockServicesConfig;
-import gov.uk.courtdata.laastatus.client.CourtDataAdapterClient;
+//import gov.uk.courtdata.laastatus.client.CourtDataAdapterClient;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.model.UnlinkModel;
+import gov.uk.courtdata.repository.RepOrderCPDataRepository;
 import gov.uk.courtdata.repository.UnlinkReasonRepository;
 import gov.uk.courtdata.repository.WqCoreRepository;
 import gov.uk.courtdata.repository.WqLinkRegisterRepository;
@@ -47,7 +48,8 @@ public class UnLinkImplIntegrationTest {
     @Autowired
     private TestEntityDataBuilder testEntityDataBuilder;
     @Autowired
-    private CourtDataAdapterClient courtDataAdapterClient;
+    private RepOrderCPDataRepository repOrderCPDataRepository;
+
 
 
     @Before
@@ -55,6 +57,7 @@ public class UnLinkImplIntegrationTest {
         wqCoreRepository.deleteAll();
         wqLinkRegisterRepository.deleteAll();
         unlinkReasonRepository.deleteAll();
+        repOrderCPDataRepository.deleteAll();
     }
 
     @Test
@@ -68,6 +71,7 @@ public class UnLinkImplIntegrationTest {
         RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity();
         unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
         wqLinkRegisterRepository.save(wqLinkRegisterEntity);
+        repOrderCPDataRepository.save(repOrderCPDataEntity);
 
         //when
         unLinkImpl.execute(unlinkModel);
@@ -90,6 +94,7 @@ public class UnLinkImplIntegrationTest {
         RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity();
         unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
         wqLinkRegisterRepository.save(wqLinkRegisterEntity);
+        repOrderCPDataRepository.save(repOrderCPDataEntity);
 
 
         unLinkImpl.execute(unlinkModel);
@@ -104,10 +109,13 @@ public class UnLinkImplIntegrationTest {
     private void assertWQLinkRegister(UnlinkModel unlinkModel) {
 
         Optional<WqLinkRegisterEntity> wqUnLinkRegisterEntity = wqLinkRegisterRepository.findById(unlinkModel.getWqLinkRegisterEntity().getCreatedTxId());
+        Optional<RepOrderCPDataEntity> repOrderCPDataEntity = repOrderCPDataRepository.findByDefendantId(unlinkModel.getUnlink().getDefendantId());
         WqLinkRegisterEntity unLinkRegister = wqUnLinkRegisterEntity.orElse(null);
         assert unLinkRegister != null;
+        assert repOrderCPDataEntity != null;
+
         Unlink unlink = unlinkModel.getUnlink();
-        assertThat(unLinkRegister.getMaatId()).isEqualTo(unlink.getMaatId());
+        assertThat(unLinkRegister.getMaatId()).isEqualTo(repOrderCPDataEntity.get().getRepOrderId());
         assertThat(unLinkRegister.getRemovedUserId()).isEqualTo(unlink.getUserId());
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/impl/UnLinkImplIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/impl/UnLinkImplIntegrationTest.java
@@ -9,7 +9,6 @@ import gov.uk.courtdata.entity.UnlinkEntity;
 import gov.uk.courtdata.entity.WqCoreEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
 import gov.uk.courtdata.integration.MockServicesConfig;
-//import gov.uk.courtdata.laastatus.client.CourtDataAdapterClient;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.model.UnlinkModel;
 import gov.uk.courtdata.repository.RepOrderCPDataRepository;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
@@ -70,8 +70,11 @@ public class UnlinkListenerTest {
         RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity();
         unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
         wqLinkRegisterRepository.save(wqLinkRegisterEntity);
-        repOrderRepository.save(RepOrderEntity.builder().id(1234).caseId("12121").build());
-        repOrderCPDataRepository.save(RepOrderCPDataEntity.builder().repOrderId(1234).build());
+        repOrderRepository.save(RepOrderEntity.builder().id(repOrderCPDataEntity.getRepOrderId()).caseId("12121").build());
+        repOrderCPDataRepository.save(RepOrderCPDataEntity.builder()
+                .defendantId("556677")
+                .repOrderId(1234)
+                .build());
 
         //when
         unlinkListener.receive(testModelDataBuilder.getUnLinkString());
@@ -88,7 +91,7 @@ public class UnlinkListenerTest {
         WqLinkRegisterEntity unLinkRegister = wqUnLinkRegisterEntity.get(0);
         assert unLinkRegister != null;
         Unlink unlink = unlinkModel.getUnlink();
-        assertThat(unLinkRegister.getMaatId()).isEqualTo(unlink.getMaatId());
+        assertThat(unLinkRegister.getMaatId()).isEqualTo(1234);
         assertThat(unLinkRegister.getRemovedUserId()).isEqualTo(unlink.getUserId());
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/unlink/processor/UnLinkProcessorTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/unlink/processor/UnLinkProcessorTest.java
@@ -2,6 +2,7 @@ package gov.uk.courtdata.unlink.processor;
 
 import gov.uk.courtdata.entity.RepOrderCPDataEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
+import gov.uk.courtdata.helper.RepOrderCPDataHelper;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.model.UnlinkModel;
 import gov.uk.courtdata.repository.RepOrderCPDataRepository;
@@ -14,7 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -40,6 +40,9 @@ public class UnLinkProcessorTest {
     @Mock
     private UnLinkImpl unlinkImpl;
 
+    @Mock
+    private RepOrderCPDataHelper repOrderCPDataHelper;
+
     @Test
     public void process() {
 
@@ -50,8 +53,9 @@ public class UnLinkProcessorTest {
         List<WqLinkRegisterEntity> wqLinkRegisterEntityList =
                 Collections.singletonList(WqLinkRegisterEntity.builder().caseUrn("casedfd").build());
 
-        when(wqLinkRegisterRepository.findBymaatId(anyInt()))
-                .thenReturn(wqLinkRegisterEntityList);
+        when(repOrderCPDataHelper.getMaatIdByDefendantId(anyString())).thenReturn(12);
+
+        when(wqLinkRegisterRepository.findBymaatId(anyInt())).thenReturn(wqLinkRegisterEntityList);
 
         Optional<RepOrderCPDataEntity> repOrderCPDataEntity =
                 Optional.of(RepOrderCPDataEntity.builder()
@@ -69,7 +73,8 @@ public class UnLinkProcessorTest {
 
         assertThat(unlinkResponse.getTxId()).isNull();
 
-        assertThat(unlinkResponse.getUnlink().getMaatId()).isEqualTo(5555666);
+        assertThat(unlinkResponse.getUnlink().getDefendantId()).isEqualTo("5555666");
+        assertThat(unlinkResponse.getUnlink().getMaatId()).isEqualTo(12);
         assertThat(unlinkResponse.getUnlink().getUserId()).isEqualTo("1234");
         assertThat(unlinkResponse.getUnlink().getReasonId()).isEqualTo(8877);
 
@@ -83,7 +88,7 @@ public class UnLinkProcessorTest {
 
         return Unlink.builder()
                 .userId("1234")
-                .maatId(5555666)
+                .defendantId("5555666")
                 .otherReasonText("some reason text")
                 .reasonId(8877)
                 .build();


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/lasb-712)

Updated the Unlinking and Hearing resulted/notification listenrs, the change made to remove the maat-id from the payload and added the defendantId. There is no change with the linking request/listener.  



## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
