### PR TITLE
LASB-1054

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/service/FinancialAssessmentService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/service/FinancialAssessmentService.java
@@ -33,8 +33,8 @@ public class FinancialAssessmentService {
     @Transactional(readOnly = true)
     public FinancialAssessmentDTO find(Integer financialAssessmentId) {
         FinancialAssessmentEntity assessmentEntity = financialAssessmentImpl.find(financialAssessmentId);
-        if(assessmentEntity == null){
-            throw new RequestedObjectNotFoundException(String.format("Financial Assessment with id %s not found", financialAssessmentId));
+        if (assessmentEntity == null) {
+            throw new RequestedObjectNotFoundException(String.format("No Financial Assessment found for ID: %s", financialAssessmentId));
         }
         return buildFinancialAssessmentDTO(assessmentEntity);
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/service/PassportAssessmentService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/service/PassportAssessmentService.java
@@ -25,7 +25,7 @@ public class PassportAssessmentService {
     public PassportAssessmentDTO find(Integer passportAssessmentId) {
         PassportAssessmentEntity passportAssessmentEntity = passportAssessmentImpl.find(passportAssessmentId);
         if (passportAssessmentEntity == null) {
-            throw new RequestedObjectNotFoundException(String.format("Passported Assessment with id %s not found", passportAssessmentId));
+            throw new RequestedObjectNotFoundException(String.format("No Passport Assessment found for ID: %s", passportAssessmentId));
         }
         return buildPassportAssessmentDTO(passportAssessmentEntity);
     }
@@ -34,7 +34,7 @@ public class PassportAssessmentService {
     public PassportAssessmentDTO findByRepId(int repId) {
         PassportAssessmentEntity passportAssessmentEntity = passportAssessmentImpl.findByRepId(repId);
         if (passportAssessmentEntity == null) {
-            throw new RequestedObjectNotFoundException(String.format("Passport Assessment with repId %s not found", repId));
+            throw new RequestedObjectNotFoundException(String.format("No Passport Assessment found for REP ID: %s", repId));
         }
         return buildPassportAssessmentDTO(passportAssessmentEntity);
     }
@@ -72,8 +72,7 @@ public class PassportAssessmentService {
     }
 
     PassportAssessmentDTO buildPassportAssessmentDTO(PassportAssessmentEntity assessmentEntity) {
-        PassportAssessmentDTO passportAssessmentDTO = passportAssessmentMapper.passportAssessmentEntityToPassportAssessmentDTO(assessmentEntity);
-        return passportAssessmentDTO;
+        return passportAssessmentMapper.passportAssessmentEntityToPassportAssessmentDTO(assessmentEntity);
     }
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/ChildWeightHistoryEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/ChildWeightHistoryEntity.java
@@ -1,15 +1,14 @@
 package gov.uk.courtdata.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,7 +16,7 @@ import java.time.LocalDateTime;
 @Table(name = "FIN_ASS_CHILD_WEIGHT_HISTORY", schema = "TOGDATA")
 public class ChildWeightHistoryEntity {
     @Id
-    @SequenceGenerator(name = "fin_ass_child_weight_hist_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1)
+    @SequenceGenerator(name = "fin_ass_child_weight_hist_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fin_ass_child_weight_hist_gen_seq")
     @Column(name = "ID", nullable = false)
     private Integer id;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/ChildWeightingsEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/ChildWeightingsEntity.java
@@ -4,13 +4,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Builder
@@ -24,7 +18,7 @@ import java.time.LocalDateTime;
 public class ChildWeightingsEntity {
 
     @Id
-    @SequenceGenerator(name = "fin_ass_child_weighting_seq", sequenceName = "S_FIN_ASS_CHILD_WEIGHTING_ID", allocationSize = 1)
+    @SequenceGenerator(name = "fin_ass_child_weighting_seq", sequenceName = "S_FIN_ASS_CHILD_WEIGHTING_ID", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fin_ass_child_weighting_seq")
     @Column(name = "ID", nullable = false)
     private Integer id;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentDetailEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentDetailEntity.java
@@ -1,10 +1,7 @@
 package gov.uk.courtdata.entity;
 
 import gov.uk.courtdata.enums.Frequency;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -12,7 +9,9 @@ import javax.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -21,7 +20,7 @@ import java.time.LocalDateTime;
 public class FinancialAssessmentDetailEntity {
 
     @Id
-    @SequenceGenerator(name = "fin_ass_det_seq", sequenceName = "S_FIN_ASS_DET_ID", allocationSize = 1)
+    @SequenceGenerator(name = "fin_ass_det_seq", sequenceName = "S_FIN_ASS_DET_ID", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fin_ass_det_seq")
     @Column(name = "ID")
     private Integer id;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentDetailsHistoryEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentDetailsHistoryEntity.java
@@ -8,7 +8,9 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,7 +18,7 @@ import java.time.LocalDateTime;
 @Table(name = "FIN_ASSESSMENT_DETAILS_HISTORY", schema = "TOGDATA")
 public class FinancialAssessmentDetailsHistoryEntity {
     @Id
-    @SequenceGenerator(name = "fin_ass_details_hist_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1)
+    @SequenceGenerator(name = "fin_ass_details_hist_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fin_ass_details_hist_gen_seq")
     @Column(name = "ID", nullable = false)
     private Integer id;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentEntity.java
@@ -1,9 +1,6 @@
 package gov.uk.courtdata.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -11,16 +8,25 @@ import javax.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
 @Table(name = "FINANCIAL_ASSESSMENTS", schema = "TOGDATA")
+@NamedStoredProcedureQuery(
+        name = "post_assessment_processing_cma",
+        procedureName = "togdata.assessments.post_assessment_processing_cma",
+        parameters = {
+                @StoredProcedureParameter(mode = ParameterMode.IN, type = Integer.class, name = "p_rep_id")
+        }
+)
 public class FinancialAssessmentEntity {
 
     @Id
-    @SequenceGenerator(name = "fin_ass_seq", sequenceName = "S_FINA_ASS_ID", allocationSize = 1)
+    @SequenceGenerator(name = "fin_ass_seq", sequenceName = "S_FINA_ASS_ID", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fin_ass_seq")
     @Column(name = "ID")
     private Integer id;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentsHistoryEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentsHistoryEntity.java
@@ -1,9 +1,6 @@
 package gov.uk.courtdata.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
@@ -11,7 +8,9 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -19,7 +18,7 @@ import java.time.LocalDateTime;
 @Table(name = "FINANCIAL_ASSESSMENTS_HISTORY", schema = "TOGDATA")
 public class FinancialAssessmentsHistoryEntity {
     @Id
-    @SequenceGenerator(name = "fin_ass_hist_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1)
+    @SequenceGenerator(name = "fin_ass_hist_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fin_ass_hist_gen_seq")
     @Column(name = "ID", nullable = false)
     private Integer id;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewDetailEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewDetailEntity.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 public class HardshipReviewDetailEntity {
 
     @Id
-    @SequenceGenerator(name = "hardship_review_detail_seq", sequenceName = "S_HARDSHIP_DETAIL_ID", allocationSize = 1)
+    @SequenceGenerator(name = "hardship_review_detail_seq", sequenceName = "S_HARDSHIP_DETAIL_ID", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "hardship_review_detail_seq")
     @Column(name = "ID")
     private Integer id;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewDetailReasonEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewDetailReasonEntity.java
@@ -1,17 +1,16 @@
 package gov.uk.courtdata.entity;
 
 import gov.uk.courtdata.enums.HardshipReviewDetailType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewEntity.java
@@ -25,7 +25,7 @@ public class HardshipReviewEntity {
 
     @Id
     @Column(name = "ID")
-    @SequenceGenerator(name = "hardship_seq", sequenceName = "S_HARDSHIP_ID", allocationSize = 1)
+    @SequenceGenerator(name = "hardship_seq", sequenceName = "S_HARDSHIP_ID", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "hardship_seq")
     private Integer id;
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewProgressEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewProgressEntity.java
@@ -21,7 +21,7 @@ public class HardshipReviewProgressEntity {
 
     @Id
     @Column(name = "ID")
-    @SequenceGenerator(name = "hardship_review_progress_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1)
+    @SequenceGenerator(name = "hardship_review_progress_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "hardship_review_progress_seq")
     private Integer id;
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/IOJAppealEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/IOJAppealEntity.java
@@ -1,16 +1,15 @@
 package gov.uk.courtdata.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,7 +17,7 @@ import java.time.LocalDateTime;
 @Table(name = "IOJ_APPEALS", schema = "TOGDATA")
 public class IOJAppealEntity {
     @Id
-    @SequenceGenerator(name = "ioj_appeal_seq", sequenceName = "S_IOJ_APPEAL_ID", allocationSize = 1)
+    @SequenceGenerator(name = "ioj_appeal_seq", sequenceName = "S_IOJ_APPEAL_ID", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ioj_appeal_seq")
     @Column(name = "ID")
     private Integer id;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/PassportAssessmentEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/PassportAssessmentEntity.java
@@ -1,16 +1,15 @@
 package gov.uk.courtdata.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,7 +17,7 @@ import java.time.LocalDateTime;
 @Table(name = "PASSPORT_ASSESSMENTS", schema = "TOGDATA")
 public class PassportAssessmentEntity {
     @Id
-    @SequenceGenerator(name = "passport_ass_seq", sequenceName = "S_PASSPORT_ID", allocationSize = 1)
+    @SequenceGenerator(name = "passport_ass_seq", sequenceName = "S_PASSPORT_ID", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "passport_ass_seq")
     private Integer id;
     @Column(name = "REP_ID")

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/exception/RestControllerAdviser.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/exception/RestControllerAdviser.java
@@ -89,14 +89,12 @@ public class RestControllerAdviser extends ResponseEntityExceptionHandler {
     /**
      * Handles exceptions where an object is requested but is not found in the database
      *
-     * @param ex
-     * @return
      */
     @ExceptionHandler(RequestedObjectNotFoundException.class)
     public ResponseEntity<ErrorDTO> handleRequestedObjectNotFoundException(RequestedObjectNotFoundException ex) {
-        log.error("Object cannot be found for the given input. Error: {}", ex);
+        log.error(ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorDTO.builder()
-                .code("OBJECT NOT FOUND")
+                .code(HttpStatus.NOT_FOUND.name())
                 .message(ex.getMessage())
                 .build());
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/service/HardshipReviewService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/service/HardshipReviewService.java
@@ -24,7 +24,7 @@ public class HardshipReviewService {
     public HardshipReviewDTO findHardshipReview(final Integer hardshipReviewId) {
         HardshipReviewEntity hardshipReview = hardshipReviewImpl.find(hardshipReviewId);
         if (hardshipReview == null) {
-            throw new RequestedObjectNotFoundException(String.format("Hardship Review with id %s not found", hardshipReviewId));
+            throw new RequestedObjectNotFoundException(String.format("No Hardship Review found for ID: %s", hardshipReviewId));
         }
         return hardshipReviewMapper.HardshipReviewEntityToHardshipReviewDTO(hardshipReview);
     }
@@ -33,7 +33,7 @@ public class HardshipReviewService {
     public HardshipReviewDTO findHardshipReviewByRepId(final int repId) {
         HardshipReviewEntity hardshipReviewEntity = hardshipReviewImpl.findByRepId(repId);
         if (hardshipReviewEntity == null) {
-            throw new RequestedObjectNotFoundException(String.format("Hardship Review with repId %s not found", repId));
+            throw new RequestedObjectNotFoundException(String.format("No Hardship Review found for REP ID: %s", repId));
         }
         return hardshipReviewMapper.HardshipReviewEntityToHardshipReviewDTO(hardshipReviewEntity);
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/iojAppeal/impl/IOJAppealImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/iojAppeal/impl/IOJAppealImpl.java
@@ -2,7 +2,6 @@ package gov.uk.courtdata.iojAppeal.impl;
 
 import gov.uk.courtdata.dto.IOJAppealDTO;
 import gov.uk.courtdata.entity.IOJAppealEntity;
-import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.iojAppeal.mapper.IOJAppealMapper;
 import gov.uk.courtdata.repository.IOJAppealRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +17,11 @@ public class IOJAppealImpl {
     private final IOJAppealMapper iojAppealMapper;
 
     public IOJAppealEntity find(Integer iojAppealId) {
-        return iojAppealRepository.findById(iojAppealId).orElseThrow(() -> new RequestedObjectNotFoundException("No IOJAppeal object found. ID: " + iojAppealId));
+        return iojAppealRepository.getById(iojAppealId);
     }
 
     public IOJAppealEntity findByRepId(int repId) {
-        return iojAppealRepository.findByRepId(repId).orElseThrow(() -> new RequestedObjectNotFoundException("No IOJAppeal object found for repId: " + repId));
+        return iojAppealRepository.findByRepId(repId);
     }
 
     public IOJAppealEntity create(IOJAppealDTO iojAppealDTO) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/iojAppeal/service/IOJAppealService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/iojAppeal/service/IOJAppealService.java
@@ -1,6 +1,8 @@
 package gov.uk.courtdata.iojAppeal.service;
 
 import gov.uk.courtdata.dto.IOJAppealDTO;
+import gov.uk.courtdata.entity.IOJAppealEntity;
+import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.iojAppeal.impl.IOJAppealImpl;
 import gov.uk.courtdata.iojAppeal.mapper.IOJAppealMapper;
 import gov.uk.courtdata.model.iojAppeal.CreateIOJAppeal;
@@ -20,14 +22,19 @@ public class IOJAppealService {
 
     @Transactional(readOnly = true)
     public IOJAppealDTO find(Integer iojAppealId) {
-        var iojAppealEntity = iojAppealImpl.find(iojAppealId);
-
+        IOJAppealEntity iojAppealEntity = iojAppealImpl.find(iojAppealId);
+        if (iojAppealEntity == null) {
+            throw new RequestedObjectNotFoundException(String.format("No IOJ Appeal found for ID: %s", iojAppealId));
+        }
         return iojAppealMapper.toIOJAppealDTO(iojAppealEntity);
     }
 
     @Transactional(readOnly = true)
     public IOJAppealDTO findByRepId(int repId) {
-        var iojAppealEntity = iojAppealImpl.findByRepId(repId);
+        IOJAppealEntity iojAppealEntity = iojAppealImpl.findByRepId(repId);
+        if (iojAppealEntity == null) {
+            throw new RequestedObjectNotFoundException(String.format("No IOJ Appeal found for REP ID: %s", repId));
+        }
         return iojAppealMapper.toIOJAppealDTO(iojAppealEntity);
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/HardshipReviewRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/HardshipReviewRepository.java
@@ -13,5 +13,6 @@ public interface HardshipReviewRepository extends JpaRepository<HardshipReviewEn
     @Query(value = "UPDATE HardshipReviewEntity hr set hr.replaced = 'Y' WHERE hr.repId = :repId and hr.financialAssessmentId <> :financialAssessmentId")
     void updateOldHardshipReviews(@Param("repId") Integer repId, @Param("financialAssessmentId") Integer financialAssessmentId);
 
-    HardshipReviewEntity findByRepId(int repId);
+    @Query(value = "SELECT hr FROM HardshipReviewEntity hr WHERE hr.repId = :repId AND hr.replaced = 'N'")
+    HardshipReviewEntity findByRepId(@Param("repId") Integer repId);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/IOJAppealRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/IOJAppealRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface IOJAppealRepository extends JpaRepository<IOJAppealEntity, Integer> {
 
@@ -16,5 +14,6 @@ public interface IOJAppealRepository extends JpaRepository<IOJAppealEntity, Inte
     @Query(value = "update IOJAppealEntity ioj_ae set ioj_ae.replaced = 'Y' where ioj_ae.repId = :repId and ioj_ae.id <> :iojAppealIDNotToUpdate")
     void setOldIOJAppealsReplaced(@Param("repId") Integer repId, @Param("iojAppealIDNotToUpdate") Integer iojAppealIDNotToUpdate);
 
-    Optional<IOJAppealEntity> findByRepId(int repId);
+    @Query(value = "SELECT ioj_ae FROM IOJAppealEntity ioj_ae WHERE ioj_ae.repId = :repId AND ioj_ae.replaced = 'N'")
+    IOJAppealEntity findByRepId(int repId);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/PassportAssessmentRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/PassportAssessmentRepository.java
@@ -11,15 +11,16 @@ import org.springframework.stereotype.Repository;
 public interface PassportAssessmentRepository extends JpaRepository<PassportAssessmentEntity, Integer> {
 
     @Modifying
-    @Query(value = "UPDATE PASSPORT_ASSESSMENTS pa set pa.REPLACED = 'Y' WHERE pa.REP_ID = :repId", nativeQuery = true)
+    @Query(value = "UPDATE TOGDATA.PASSPORT_ASSESSMENTS pa set pa.REPLACED = 'Y' WHERE pa.REP_ID = :repId", nativeQuery = true)
     void updateAllPreviousPassportAssessmentsAsReplaced(@Param("repId") Integer repId);
 
     @Modifying
-    @Query(value = "UPDATE PASSPORT_ASSESSMENTS pa set pa.REPLACED = 'Y' WHERE pa.ID <> :id AND pa.REP_ID = :repId", nativeQuery = true)
+    @Query(value = "UPDATE TOGDATA.PASSPORT_ASSESSMENTS pa set pa.REPLACED = 'Y' WHERE pa.ID <> :id AND pa.REP_ID = :repId", nativeQuery = true)
     void updatePreviousPassportAssessmentsAsReplaced(@Param("repId") Integer repId, @Param("id") Integer id);
 
-    @Query(value = "SELECT count(*) FROM PASSPORT_ASSESSMENTS pa WHERE pa.REP_ID = :repId AND pa.REPLACED = 'N' AND (pa.VALID IS NULL OR pa.VALID <> 'N') AND pa.PAST_STATUS = 'IN PROGRESS'", nativeQuery = true)
+    @Query(value = "SELECT count(*) FROM TOGDATA.PASSPORT_ASSESSMENTS pa WHERE pa.REP_ID = :repId AND pa.REPLACED = 'N' AND (pa.VALID IS NULL OR pa.VALID <> 'N') AND pa.PAST_STATUS = 'IN PROGRESS'", nativeQuery = true)
     Long findOutstandingPassportAssessments(@Param("repId") Integer repId);
 
-    PassportAssessmentEntity findByRepId(int repId);
+    @Query(value = "SELECT pa FROM PassportAssessmentEntity pa WHERE pa.repId = :repId AND pa.replaced = 'N'")
+    PassportAssessmentEntity findByRepId(@Param("repId") Integer repId);
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/service/PassportAssessmentServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/service/PassportAssessmentServiceTest.java
@@ -68,8 +68,7 @@ public class PassportAssessmentServiceTest {
 
         assertThatExceptionOfType(RequestedObjectNotFoundException.class)
                 .isThrownBy(() -> passportAssessmentService.findByRepId(MOCK_REP_ID))
-                .withMessageContaining("Passport Assessment with repId 5678 not found");
-        verify(passportAssessmentImpl).findByRepId(MOCK_REP_ID);
+                .withMessageContaining("No Passport Assessment found for REP ID: 5678");
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/service/PassportAssessmentServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/service/PassportAssessmentServiceTest.java
@@ -48,6 +48,15 @@ public class PassportAssessmentServiceTest {
     }
 
     @Test
+    public void whenFindIsInvokedWithInvalidId_thenNotFoundExceptionIsThrown() {
+        when(passportAssessmentImpl.find(MOCK_REP_ID)).thenReturn(null);
+
+        assertThatExceptionOfType(RequestedObjectNotFoundException.class)
+                .isThrownBy(() -> passportAssessmentService.find(MOCK_REP_ID))
+                .withMessageContaining("No Passport Assessment found for ID: 5678");
+    }
+
+    @Test
     public void whenFindByRepIdIsInvoked_thenAssessmentIsRetrieved() {
         PassportAssessmentEntity passportAssessmentEntity = PassportAssessmentEntity.builder().id(MOCK_ASSESSMENT_ID).repId(MOCK_REP_ID).build();
         when(passportAssessmentImpl.findByRepId(MOCK_REP_ID)).thenReturn(passportAssessmentEntity);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/service/HardshipReviewServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/service/HardshipReviewServiceTest.java
@@ -2,9 +2,7 @@ package gov.uk.courtdata.hardship.service;
 
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.dto.HardshipReviewDTO;
-import gov.uk.courtdata.dto.PassportAssessmentDTO;
 import gov.uk.courtdata.entity.HardshipReviewEntity;
-import gov.uk.courtdata.entity.PassportAssessmentEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.hardship.impl.HardshipReviewImpl;
 import gov.uk.courtdata.hardship.mapper.HardshipReviewMapper;
@@ -72,8 +70,7 @@ public class HardshipReviewServiceTest {
 
         assertThatExceptionOfType(RequestedObjectNotFoundException.class)
                 .isThrownBy(() -> hardshipReviewService.findHardshipReviewByRepId(MOCK_REP_ID))
-                .withMessageContaining("Hardship Review with repId 621580 not found");
-        verify(hardshipReviewImpl).findByRepId(MOCK_REP_ID);
+                .withMessageContaining("No Hardship Review found for REP ID: 621580");
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/service/HardshipReviewServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/service/HardshipReviewServiceTest.java
@@ -33,7 +33,6 @@ public class HardshipReviewServiceTest {
     private HardshipReviewMapper hardshipReviewMapper;
 
     private static final int MOCK_REP_ID = 621580;
-    private static final int INVALID_REP_ID = 3456;
     private static final Integer MOCK_HARDSHIP_ID = 1000;
 
     @Test
@@ -47,6 +46,15 @@ public class HardshipReviewServiceTest {
 
         verify(hardshipReviewImpl).find(any());
         assertThat(returnedAssessment.getId()).isEqualTo(MOCK_HARDSHIP_ID);
+    }
+
+    @Test
+    public void whenFindIsInvokedWithInvalidRepId_thenNotFoundExceptionIsThrown() {
+        when(hardshipReviewImpl.find(MOCK_REP_ID)).thenReturn(null);
+
+        assertThatExceptionOfType(RequestedObjectNotFoundException.class)
+                .isThrownBy(() -> hardshipReviewService.findHardshipReview(MOCK_REP_ID))
+                .withMessageContaining("No Hardship Review found for ID: 621580");
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/iojAppeal/impl/IOJAppealImplTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/iojAppeal/impl/IOJAppealImplTest.java
@@ -11,12 +11,11 @@ import org.mockito.*;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static gov.uk.courtdata.builder.TestModelDataBuilder.IOJ_APPEAL_ID;
 import static gov.uk.courtdata.builder.TestModelDataBuilder.IOJ_REP_ID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -37,14 +36,14 @@ public class IOJAppealImplTest {
 
     @Test
     public void whenFindIsInvoked_thenAssessmentIsRetrieved() {
-        when(iojAppealRepository.findById(any())).thenReturn(Optional.of(IOJAppealEntity.builder().id(IOJ_APPEAL_ID).build()));
+        when(iojAppealRepository.getById(any())).thenReturn(IOJAppealEntity.builder().id(IOJ_APPEAL_ID).build());
         var iojAppeal = iojAppealImpl.find(IOJ_APPEAL_ID);
         assertEquals(iojAppeal.getId(), IOJ_APPEAL_ID);
     }
 
     @Test
     public void whenFindByRepIdIsInvoked_thenAssessmentIsRetrieved() {
-        when(iojAppealRepository.findByRepId(IOJ_REP_ID)).thenReturn(Optional.of(IOJAppealEntity.builder().id(IOJ_APPEAL_ID).repId(IOJ_REP_ID).build()));
+        when(iojAppealRepository.findByRepId(IOJ_REP_ID)).thenReturn(IOJAppealEntity.builder().id(IOJ_APPEAL_ID).repId(IOJ_REP_ID).build());
         var iojAppeal = iojAppealImpl.findByRepId(IOJ_REP_ID);
         assertEquals(iojAppeal.getId(), IOJ_APPEAL_ID);
         assertEquals(iojAppeal.getRepId(), IOJ_REP_ID);
@@ -64,17 +63,17 @@ public class IOJAppealImplTest {
     }
 
     @Test
-    public void whenSetOldIOJAppealReplaced_thenAllIOJAppealRecordsWithGivenREP_IDAreSetToReplaced(){
+    public void whenSetOldIOJAppealReplaced_thenAllIOJAppealRecordsWithGivenREP_IDAreSetToReplaced() {
 
         iojAppealImpl.setOldIOJAppealsReplaced(IOJ_REP_ID, 124);
 
-        verify(iojAppealRepository).setOldIOJAppealsReplaced(IOJ_REP_ID,124);
+        verify(iojAppealRepository).setOldIOJAppealsReplaced(IOJ_REP_ID, 124);
     }
 
     @Test
     public void whenUpdateIsInvoked_thenIOJAppealIsUpdated() {
         var iojAppealDTO = TestModelDataBuilder.getIOJAppealDTO();
-        var dateModified = LocalDateTime.of(2022,1,1,10,0);
+        var dateModified = LocalDateTime.of(2022, 1, 1, 10, 0);
         var updatedIOJAppealEntity = TestEntityDataBuilder.getIOJAppealEntity(dateModified);
 
         when(iojAppealRepository.getById(any())).thenReturn(updatedIOJAppealEntity);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/iojAppeal/service/IOJAppealServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/iojAppeal/service/IOJAppealServiceTest.java
@@ -46,6 +46,15 @@ public class IOJAppealServiceTest {
     }
 
     @Test
+    public void whenFindIsInvokedWithInvalidId_thenNotFoundExceptionIsThrown() {
+        when(iojAppealImpl.find(IOJ_REP_ID)).thenReturn(null);
+
+        assertThatExceptionOfType(RequestedObjectNotFoundException.class)
+                .isThrownBy(() -> iojAppealService.find(IOJ_REP_ID))
+                .withMessageContaining("No IOJ Appeal found for ID: 5635978");
+    }
+
+    @Test
     public void whenFindByRepIdIsInvoked_thenIOJAppealIsRetrieved() {
         IOJAppealEntity iojAppealEntity = IOJAppealEntity.builder().id(IOJ_APPEAL_ID).repId(IOJ_REP_ID).build();
         when(iojAppealImpl.findByRepId(IOJ_REP_ID)).thenReturn(iojAppealEntity);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/iojAppeal/service/IOJAppealServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/iojAppeal/service/IOJAppealServiceTest.java
@@ -62,12 +62,11 @@ public class IOJAppealServiceTest {
 
     @Test
     public void whenFindByRepIdIsInvokedWithInvalidRepId_thenNotFoundExceptionIsThrown() {
-        when(iojAppealImpl.findByRepId(IOJ_REP_ID)).thenThrow(new RequestedObjectNotFoundException("No IOJAppeal object found for repId: " + IOJ_REP_ID));
+        when(iojAppealImpl.findByRepId(IOJ_REP_ID)).thenReturn(null);
 
         assertThatExceptionOfType(RequestedObjectNotFoundException.class)
                 .isThrownBy(() -> iojAppealService.findByRepId(IOJ_REP_ID))
-                .withMessageContaining("No IOJAppeal object found for repId: 5635978");
-        verify(iojAppealImpl).findByRepId(IOJ_REP_ID);
+                .withMessageContaining("No IOJ Appeal found for REP ID: 5635978");
     }
 
     @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1054)

- Fixed error where queries accessing sequences in the TOGDATA schema were being generated incorrectly by Hibernate (owner schema needs to be referenced).
- Fixed issues with the Hardship Review, Passport Assessment and IOJ Appeal findByRepID endpoints which were only expecting a single record to be retrieved from the DB.
- Refactored the IOJ service and Impl to ensure consistency with other areas of the API.
- Improved error reporting to ensure the console isn't filled with stack traces each and every time a record cannot be found in the database.
- Added additional test cases to cover missing scenarios around exceptions handling.
- Removed @Data annotations as this can cause performance issues.
