### PR TITLE
Increase Hikari maximum pool size to 50

### DIFF
--- a/maat-court-data-api/src/main/resources/application.yaml
+++ b/maat-court-data-api/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
     password: ${DATASOURCE_PASSWORD}
     driver-class-name: oracle.jdbc.OracleDriver
     hikari:
-      maximum-pool-size: 25
+      maximum-pool-size: 50
 
   liquibase:
     enabled: false


### PR DESCRIPTION
## What

Increase the Hikari maximum pool size to 50 to prevent the service from running out of available connections in production.
