### PR TITLE
Remove link in CloudFormation template

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -500,8 +500,6 @@ Resources:
               awslogs-stream-prefix: !Sub '${pAppName}-app'
           PortMappings:
             - ContainerPort: 8090
-          Links:
-            - xray-daemon
           Secrets:
             - Name: DATASOURCE_USERNAME
               ValueFrom: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/maat-cd-api/DATASOURCE_USERNAME'


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-998)

Remove link in CloudFormation template causing the following error in AWS:

`Invalid request provided: Create TaskDefinition: Links are not supported when networkMode=awsvpc.`