### PR TITLE
Update CPU and Memory Resources in TaskDefinition

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -465,8 +465,8 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: !Join [ '', [ !Ref pAppName, '-app' ] ]
-      Cpu: !If [ cNonProd, 512, 512 ]
-      Memory: !If [ cNonProd, 1024, 2048 ]
+      Cpu: !If [ cNonProd, 1024, 1024 ]
+      Memory: !If [ cNonProd, 2048, 3072 ]
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - !Ref pLaunchType
@@ -488,10 +488,10 @@ Resources:
             - ContainerPort: 2000
               Protocol: udp
         - Name: !Ref pAppName
-          Cpu: !If [ cNonProd, 512, 512 ]
+          Cpu: !If [ cNonProd, 992, 992 ]
           Essential: true
           Image: !Join [':', [!Ref pECSRepositoryURL, !Ref pDockerImageTag ]]
-          Memory: !If [ cNonProd, 1024, 2048 ]
+          Memory: !If [ cNonProd, 1792, 2816 ]
           LogConfiguration:
             LogDriver: awslogs
             Options:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-998)

Change was made to address the following error when deploying the application in AWS:

`The sum of all container 'cpu' values cannot be greater than the value of the task 'cpu'`

This was discussed with OPS who suggested upping the available resources.