### PR TITLE
LCAM-192

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/impl/PassportAssessmentImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/impl/PassportAssessmentImpl.java
@@ -29,7 +29,7 @@ public class PassportAssessmentImpl {
     }
 
     public PassportAssessmentEntity findByRepId(int repId) {
-        return passportAssessmentRepository.findByRepId(repId);
+        return passportAssessmentRepository.findByRepId(repId).orElse(null);
     }
 
     public PassportAssessmentEntity update(PassportAssessmentDTO passportAssessmentDTO) {
@@ -75,13 +75,13 @@ public class PassportAssessmentImpl {
 
     public void setOldPassportAssessmentAsReplaced(PassportAssessmentEntity passportAssessment, Integer financialAssessmentId) {
         passportAssessmentRepository.updatePreviousPassportAssessmentsAsReplaced(
-                passportAssessment.getRepId(), passportAssessment.getId()
+                passportAssessment.getRepOrder().getId(), passportAssessment.getId()
         );
         financialAssessmentRepository.updateAllPreviousFinancialAssessmentsAsReplaced(
-                passportAssessment.getRepId()
+                passportAssessment.getRepOrder().getId()
         );
         hardshipReviewRepository.updateOldHardshipReviews(
-                passportAssessment.getRepId(), financialAssessmentId
+                passportAssessment.getRepOrder().getId(), financialAssessmentId
         );
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/mapper/PassportAssessmentMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/mapper/PassportAssessmentMapper.java
@@ -5,18 +5,22 @@ import gov.uk.courtdata.entity.PassportAssessmentEntity;
 import gov.uk.courtdata.model.assessment.CreatePassportAssessment;
 import gov.uk.courtdata.model.assessment.UpdatePassportAssessment;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE, componentModel = "spring", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface PassportAssessmentMapper {
 
-    PassportAssessmentDTO passportAssessmentEntityToPassportAssessmentDTO(final PassportAssessmentEntity passportAssessment);
-
     PassportAssessmentDTO updatePassportAssessmentToPassportAssessmentDTO(final UpdatePassportAssessment assessment);
 
     PassportAssessmentDTO createPassportAssessmentToPassportAssessmentDTO(final CreatePassportAssessment assessment);
 
+    @Mapping(target = "repId", source = "repOrder.id")
+    PassportAssessmentDTO passportAssessmentEntityToPassportAssessmentDTO(final PassportAssessmentEntity passportAssessment);
+
+    @Mapping(target = "repOrder.id", source = "repId")
     PassportAssessmentEntity passportAssessmentDtoToPassportAssessmentEntity(final PassportAssessmentDTO passportAssessment);
+
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/service/PassportAssessmentService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/service/PassportAssessmentService.java
@@ -68,7 +68,9 @@ public class PassportAssessmentService {
         log.info("Creating new passport assessment record");
         PassportAssessmentEntity assessmentEntity = passportAssessmentImpl.create(passportAssessmentDTO);
         log.info("Setting outdated records as replaced");
-        passportAssessmentImpl.setOldPassportAssessmentAsReplaced(assessmentEntity, passportAssessmentDTO.getFinancialAssessmentId());
+        passportAssessmentImpl.setOldPassportAssessmentAsReplaced(
+                assessmentEntity, createPassportAssessment.getFinancialAssessmentId()
+        );
         log.info("Create Passport Assessment - Transaction Processing - End");
         return buildPassportAssessmentDTO(assessmentEntity);
     }
@@ -76,5 +78,4 @@ public class PassportAssessmentService {
     PassportAssessmentDTO buildPassportAssessmentDTO(PassportAssessmentEntity assessmentEntity) {
         return passportAssessmentMapper.passportAssessmentEntityToPassportAssessmentDTO(assessmentEntity);
     }
-
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/validator/FinancialAssessmentIdValidator.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/validator/FinancialAssessmentIdValidator.java
@@ -1,7 +1,6 @@
 package gov.uk.courtdata.assessment.validator;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
-import gov.uk.courtdata.entity.FinancialAssessmentEntity;
 import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.repository.FinancialAssessmentRepository;
 import gov.uk.courtdata.validator.IValidator;
@@ -23,14 +22,12 @@ public class FinancialAssessmentIdValidator implements IValidator<Void, Integer>
     public Optional<Void> validate(final Integer assessmentId) {
 
         if (assessmentId != null && assessmentId > 0) {
-            Optional<FinancialAssessmentEntity> assessmentEntity = financialAssessmentRepository.findById(assessmentId);
-            if (assessmentEntity.isEmpty())
+            if (!financialAssessmentRepository.existsById(assessmentId))
                 throw new ValidationException(assessmentId + " is invalid");
             return Optional.empty();
 
         } else {
             throw new ValidationException("Financial Assessment id is required");
         }
-
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/PassportAssessmentDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/PassportAssessmentDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 
 @Data
@@ -13,7 +14,6 @@ import java.time.LocalDateTime;
 public class PassportAssessmentDTO {
 
     private Integer id;
-    private Integer financialAssessmentId;
     private Integer repId;
     private String nworCode;
     private LocalDateTime dateCreated;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/RepOrderDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/RepOrderDTO.java
@@ -31,5 +31,7 @@ public class RepOrderDTO {
     private String crownRepOrderType;
     private LocalDateTime assessmentDateCompleted;
     @Builder.Default
+    private List<PassportAssessmentDTO> passportAssessments = new ArrayList<>();
+    @Builder.Default
     private List<FinancialAssessmentDTO> financialAssessments = new ArrayList<>();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentEntity.java
@@ -40,8 +40,9 @@ public class FinancialAssessmentEntity implements Serializable {
     @Column(name = "ID")
     private Integer id;
 
+    @ToString.Exclude
     @JsonBackReference
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "REP_ID", nullable = false, updatable = false)
     private RepOrderEntity repOrder;
 
@@ -53,7 +54,7 @@ public class FinancialAssessmentEntity implements Serializable {
 
     @ToString.Exclude
     @Fetch(FetchMode.JOIN)
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(optional = false)
     @JoinColumn(name = "NWOR_CODE", nullable = false)
     private NewWorkReasonEntity newWorkReason;
 
@@ -165,7 +166,7 @@ public class FinancialAssessmentEntity implements Serializable {
     @ToString.Exclude
     @Fetch(FetchMode.JOIN)
     @JsonManagedReference
-    @OneToMany(mappedBy = "financialAssessment", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "financialAssessment", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<FinancialAssessmentDetailEntity> assessmentDetails = new ArrayList<>();
 
     public void addAssessmentDetail(FinancialAssessmentDetailEntity assessmentDetailEntity) {
@@ -178,7 +179,7 @@ public class FinancialAssessmentEntity implements Serializable {
 
     @ToString.Exclude
     @JsonManagedReference
-    @OneToMany(mappedBy = "financialAssessment", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "financialAssessment", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<ChildWeightingsEntity> childWeightings = new ArrayList<>();
 
     public void addChildWeighting(ChildWeightingsEntity childWeightingsEntity) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentsHistoryEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FinancialAssessmentsHistoryEntity.java
@@ -48,7 +48,7 @@ public class FinancialAssessmentsHistoryEntity {
 
     @ToString.Exclude
     @Fetch(FetchMode.JOIN)
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(optional = false)
     @JoinColumn(name = "NWOR_CODE", nullable = false)
     private NewWorkReasonEntity newWorkReason;
 
@@ -210,9 +210,9 @@ public class FinancialAssessmentsHistoryEntity {
 
     @Builder.Default()
     @ToString.Exclude()
-    @Fetch(FetchMode.JOIN)
     @JsonManagedReference
-    @OneToMany(mappedBy = "financialAssessmentsHistory", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @Fetch(FetchMode.JOIN)
+    @OneToMany(mappedBy = "financialAssessmentsHistory", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FinancialAssessmentDetailsHistoryEntity> assessmentDetails = new ArrayList<>();
 
     public void addFinancialAssessmentDetailsHistoryEntity(FinancialAssessmentDetailsHistoryEntity assessmentDetail) {
@@ -223,7 +223,7 @@ public class FinancialAssessmentsHistoryEntity {
     @Builder.Default()
     @ToString.Exclude()
     @JsonManagedReference
-    @OneToMany(mappedBy = "financialAssessmentHistory", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "financialAssessmentHistory", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChildWeightHistoryEntity> childWeightings = new ArrayList<>();
 
     public void addChildWeightHistoryEntity(ChildWeightHistoryEntity childWeighting) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewDetailEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewDetailEntity.java
@@ -92,7 +92,7 @@ public class HardshipReviewDetailEntity {
 
     @ToString.Exclude
     @Fetch(FetchMode.JOIN)
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(optional = false)
     @JoinColumn(name = "HRDR_ID", nullable = false)
     private HardshipReviewDetailReasonEntity detailReason;
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewEntity.java
@@ -104,14 +104,14 @@ public class HardshipReviewEntity {
 
     @ToString.Exclude
     @Fetch(FetchMode.JOIN)
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(optional = false)
     @JoinColumn(name = "NWOR_CODE", nullable = false)
     private NewWorkReasonEntity newWorkReason;
 
     @ToString.Exclude
     @Fetch(FetchMode.JOIN)
     @JsonManagedReference
-    @OneToMany(mappedBy = "hardshipReview", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "hardshipReview", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<HardshipReviewDetailEntity> reviewDetails = new ArrayList<>();
 
     public void addReviewDetail(HardshipReviewDetailEntity detailEntity) {
@@ -129,7 +129,7 @@ public class HardshipReviewEntity {
 
     @ToString.Exclude
     @JoinColumn(name = "HARE_ID", nullable = false)
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<HardshipReviewProgressEntity> reviewProgressItems = new ArrayList<>();
 
     public void addReviewProgressItem(HardshipReviewProgressEntity progressEntity) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/PassportAssessmentEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/PassportAssessmentEntity.java
@@ -109,6 +109,4 @@ public class PassportAssessmentEntity {
     private String whoDWPChecked;
     @Column(name = "RT_CODE")
     private String rtCode;
-    @Transient
-    private Integer financialAssessmentId;
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/PassportAssessmentEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/PassportAssessmentEntity.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -20,8 +21,10 @@ public class PassportAssessmentEntity {
     @SequenceGenerator(name = "passport_ass_seq", sequenceName = "S_PASSPORT_ID", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "passport_ass_seq")
     private Integer id;
-    @Column(name = "REP_ID")
-    private Integer repId;
+    @JsonBackReference
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "REP_ID", nullable = false, updatable = false)
+    private RepOrderEntity repOrder;
     @Column(name = "NWOR_CODE")
     private String nworCode;
     @CreationTimestamp

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/RepOrderEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/RepOrderEntity.java
@@ -1,8 +1,6 @@
 package gov.uk.courtdata.entity;
 
 import lombok.*;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -64,7 +62,11 @@ public class RepOrderEntity {
     private LocalDateTime assessmentDateCompleted;
 
     @ToString.Exclude
-    @Fetch(FetchMode.JOIN)
+    @OneToMany(mappedBy = "repOrder", fetch = FetchType.LAZY)
+    private final List<PassportAssessmentEntity> passportAssessments = new ArrayList<>();
+
+    @ToString.Exclude
     @OneToMany(mappedBy = "repOrder", fetch = FetchType.LAZY)
     private final List<FinancialAssessmentEntity> financialAssessments = new ArrayList<>();
+
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repOrder/mapper/RepOrderMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repOrder/mapper/RepOrderMapper.java
@@ -1,11 +1,9 @@
 package gov.uk.courtdata.repOrder.mapper;
 
 import gov.uk.courtdata.dto.FinancialAssessmentDTO;
+import gov.uk.courtdata.dto.PassportAssessmentDTO;
 import gov.uk.courtdata.dto.RepOrderDTO;
-import gov.uk.courtdata.entity.ChildWeightingsEntity;
-import gov.uk.courtdata.entity.FinancialAssessmentDetailEntity;
-import gov.uk.courtdata.entity.FinancialAssessmentEntity;
-import gov.uk.courtdata.entity.RepOrderEntity;
+import gov.uk.courtdata.entity.*;
 import gov.uk.courtdata.model.assessment.ChildWeightings;
 import gov.uk.courtdata.model.assessment.FinancialAssessmentDetails;
 import org.mapstruct.*;
@@ -21,15 +19,13 @@ public interface RepOrderMapper {
 
     RepOrderDTO RepOrderEntityToRepOrderDTO(final RepOrderEntity repOrder);
 
+    @Mapping(target = "repId", source = "repOrder.id")
     FinancialAssessmentDTO FinancialAssessmentEntityToFinancialAssessmentDTO(final FinancialAssessmentEntity financialAssessment);
-
-    FinancialAssessmentDetailEntity FinancialAssessmentDetailsToFinancialAssessmentDetailsEntity(final FinancialAssessmentDetails details);
-
-    FinancialAssessmentEntity FinancialAssessmentDTOToFinancialAssessmentEntity(final FinancialAssessmentDTO financialAssessment);
 
     FinancialAssessmentDetails FinancialAssessmentDetailsEntityToFinancialAssessmentDetails(final FinancialAssessmentDetailEntity detailsEntity);
 
-    ChildWeightingsEntity ChildWeightingsToChildWeightingsEntity(final ChildWeightings childWeightings);
+    @Mapping(target = "repId", source = "repOrder.id")
+    PassportAssessmentDTO PassportAssessmentEntityToPassportAssessmentDTO(final PassportAssessmentEntity passportAssessment);
 
     ChildWeightings ChildWeightingsEntityToChildWeightings(final ChildWeightingsEntity childWeightingsEntity);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/PassportAssessmentRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/PassportAssessmentRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PassportAssessmentRepository extends JpaRepository<PassportAssessmentEntity, Integer> {
 
@@ -21,6 +23,6 @@ public interface PassportAssessmentRepository extends JpaRepository<PassportAsse
     @Query(value = "SELECT count(*) FROM TOGDATA.PASSPORT_ASSESSMENTS pa WHERE pa.REP_ID = :repId AND pa.REPLACED = 'N' AND (pa.VALID IS NULL OR pa.VALID <> 'N') AND pa.PAST_STATUS = 'IN PROGRESS'", nativeQuery = true)
     Long findOutstandingPassportAssessments(@Param("repId") Integer repId);
 
-    @Query(value = "SELECT pa FROM PassportAssessmentEntity pa WHERE pa.repId = :repId AND pa.replaced = 'N'")
-    PassportAssessmentEntity findByRepId(@Param("repId") Integer repId);
+    @Query(value = "SELECT * FROM TOGDATA.PASSPORT_ASSESSMENTS pa WHERE pa.REP_ID = :repId AND pa.REPLACED = 'N'", nativeQuery = true)
+    Optional<PassportAssessmentEntity> findByRepId(@Param("repId") Integer repId);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/validator/PassportAssessmentIdValidator.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/validator/PassportAssessmentIdValidator.java
@@ -1,7 +1,6 @@
 package gov.uk.courtdata.validator;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
-import gov.uk.courtdata.entity.PassportAssessmentEntity;
 import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.repository.PassportAssessmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,14 +21,12 @@ public class PassportAssessmentIdValidator implements IValidator<Void, Integer> 
     public Optional<Void> validate(final Integer passportAssessmentId) {
 
         if (passportAssessmentId != null && passportAssessmentId > 0) {
-            Optional<PassportAssessmentEntity> passportAssessmentEntity = passportAssessmentRepository.findById(passportAssessmentId);
-            if (passportAssessmentEntity.isEmpty())
+            if (!passportAssessmentRepository.existsById(passportAssessmentId))
                 throw new ValidationException(passportAssessmentId + " is invalid");
             return Optional.empty();
 
         } else {
             throw new ValidationException("Passport Assessment Id is required");
         }
-
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/impl/PassportAssessmentImplTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/impl/PassportAssessmentImplTest.java
@@ -5,6 +5,7 @@ import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.dto.PassportAssessmentDTO;
 import gov.uk.courtdata.entity.PassportAssessmentEntity;
+import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.repository.PassportAssessmentRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +13,7 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -33,7 +35,7 @@ public class PassportAssessmentImplTest {
     private ArgumentCaptor<PassportAssessmentEntity> passportAssessmentEntityArgumentCaptor;
 
     private static final int MOCK_REP_ID = 5678;
-    
+
     private static final int MOCK_ASSESSMENT_ID = 1000;
 
 
@@ -47,12 +49,19 @@ public class PassportAssessmentImplTest {
     @Test
     public void whenFindByRepIdIsInvoked_thenAssessmentIsRetrieved() {
         when(passportAssessmentRepository.findByRepId(MOCK_REP_ID))
-                .thenReturn(PassportAssessmentEntity.builder().id(MOCK_ASSESSMENT_ID).repId(MOCK_REP_ID).build());
+                .thenReturn(
+                        Optional.of(
+                                PassportAssessmentEntity.builder()
+                                        .id(MOCK_ASSESSMENT_ID)
+                                        .repOrder(RepOrderEntity.builder().id(MOCK_REP_ID).build())
+                                        .build()
+                        )
+                );
 
         PassportAssessmentEntity returned = passportAssessmentImpl.findByRepId(MOCK_REP_ID);
 
         assertThat(returned.getId()).isEqualTo(MOCK_ASSESSMENT_ID);
-        assertThat(returned.getRepId()).isEqualTo(MOCK_REP_ID);
+        assertThat(returned.getRepOrder().getId()).isEqualTo(MOCK_REP_ID);
     }
 
     @Test
@@ -65,7 +74,7 @@ public class PassportAssessmentImplTest {
 
         verify(passportAssessmentRepository).save(passportAssessmentEntityArgumentCaptor.capture());
 
-        assertThat(passportAssessmentEntityArgumentCaptor.getValue().getRepId()).isEqualTo(passportAssessment.getRepId());
+        assertThat(passportAssessmentEntityArgumentCaptor.getValue().getRepOrder().getId()).isEqualTo(passportAssessment.getRepId());
         assertThat(passportAssessmentEntityArgumentCaptor.getValue().getPartnerBenefitClaimed()).isEqualTo("Y");
         assertThat(passportAssessmentEntityArgumentCaptor.getValue().getUserCreated()).isEqualTo("test-f");
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/service/PassportAssessmentServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/service/PassportAssessmentServiceTest.java
@@ -28,14 +28,17 @@ import static org.mockito.Mockito.*;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class PassportAssessmentServiceTest {
 
-    private static final int MOCK_REP_ID = 5678;
     private static final Integer MOCK_ASSESSMENT_ID = 1000;
-    @InjectMocks
-    private PassportAssessmentService passportAssessmentService;
+    private static final int MOCK_REP_ID = TestEntityDataBuilder.REP_ID;
+
     @Mock
     private PassportAssessmentImpl passportAssessmentImpl;
+
     @Mock
     private PassportAssessmentMapper passportAssessmentMapper;
+
+    @InjectMocks
+    private PassportAssessmentService passportAssessmentService;
 
     @Test
     public void whenFindIsInvoked_thenAssessmentIsRetrieved() {
@@ -61,7 +64,10 @@ public class PassportAssessmentServiceTest {
 
     @Test
     public void whenFindByRepIdIsInvoked_thenAssessmentIsRetrieved() {
-        PassportAssessmentEntity passportAssessmentEntity = PassportAssessmentEntity.builder().id(MOCK_ASSESSMENT_ID).repId(MOCK_REP_ID).build();
+        PassportAssessmentEntity passportAssessmentEntity = PassportAssessmentEntity.builder()
+                .id(MOCK_ASSESSMENT_ID)
+                .repOrder(TestEntityDataBuilder.getRepOrder())
+                .build();
         when(passportAssessmentImpl.findByRepId(MOCK_REP_ID)).thenReturn(passportAssessmentEntity);
         when(passportAssessmentMapper.passportAssessmentEntityToPassportAssessmentDTO(passportAssessmentEntity))
                 .thenReturn(PassportAssessmentDTO.builder().id(MOCK_ASSESSMENT_ID).repId(MOCK_REP_ID).build());

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/validator/FinancialAssessmentIdValidatorTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/validator/FinancialAssessmentIdValidatorTest.java
@@ -1,6 +1,5 @@
 package gov.uk.courtdata.assessment.validator;
 
-import gov.uk.courtdata.entity.FinancialAssessmentEntity;
 import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.repository.FinancialAssessmentRepository;
 import org.junit.jupiter.api.Assertions;
@@ -14,7 +13,8 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.any;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,27 +28,31 @@ public class FinancialAssessmentIdValidatorTest {
 
     @Test
     public void testWhenFinancialAssessmentIdIsNull_thenThrowsException() {
-        ValidationException validationException = Assertions.assertThrows(ValidationException.class,
-                () -> financialAssessmentIdValidator.validate(null));
-        assertThat(validationException.getMessage()).isEqualTo("Financial Assessment id is required");
+        assertThatThrownBy(
+                () -> financialAssessmentIdValidator.validate(null)
+        ).isInstanceOf(ValidationException.class)
+                .hasMessage("Financial Assessment id is required");
     }
 
     @Test
     public void testWhenFinancialAssessmentIdIsInvalid_thenThrowsException() {
-        ValidationException validationException = Assertions.assertThrows(ValidationException.class,
-                () -> financialAssessmentIdValidator.validate(-1));
-        assertThat(validationException.getMessage()).isEqualTo("Financial Assessment id is required");
+        assertThatThrownBy(
+                () -> financialAssessmentIdValidator.validate(-1)
+        ).isInstanceOf(ValidationException.class)
+                .hasMessage("Financial Assessment id is required");
     }
 
     @Test
     public void testWhenFinancialAssessmentIdExists_thenValidationPasses() {
-        when(financialAssessmentRepository.findById(any())).thenReturn(java.util.Optional.of(new FinancialAssessmentEntity()));
+        when(financialAssessmentRepository.existsById(anyInt()))
+                .thenReturn(true);
         assertThat(financialAssessmentIdValidator.validate(1000)).isEqualTo(Optional.empty());
     }
 
     @Test
     public void testWhenFinancialAssessmentIdDoesNotExist_thenThrowsException() {
-        when(financialAssessmentRepository.findById(any())).thenReturn(Optional.empty());
+        when(financialAssessmentRepository.existsById(anyInt()))
+                .thenReturn(false);
         ValidationException validationException = Assertions.assertThrows(ValidationException.class,
                 () -> financialAssessmentIdValidator.validate(1000));
         assertThat(validationException.getMessage()).isEqualTo(format("%d is invalid", 1000));

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -147,7 +147,7 @@ public class TestEntityDataBuilder {
     public static PassportAssessmentEntity getPassportAssessmentEntity() {
         return PassportAssessmentEntity.builder()
                 .id(1000)
-                .repId(REP_ID)
+                .repOrder(getPopulatedRepOrder(REP_ID))
                 .nworCode("FMA")
                 .dateCreated(LocalDateTime.parse("2021-10-09T15:01:25"))
                 .userCreated("test-f")

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
@@ -369,7 +369,6 @@ public class TestModelDataBuilder {
         return PassportAssessmentDTO.builder()
                 .repId(REP_ID)
                 .nworCode("FMA")
-                .financialAssessmentId(FINANCIAL_ASSESSMENT_ID)
                 .dateCreated(LocalDateTime.parse("2021-10-09T15:01:25"))
                 .userCreated("test-f")
                 .cmuId(30)

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/FinancialAssessmentControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/FinancialAssessmentControllerIntegrationTest.java
@@ -121,7 +121,7 @@ public class FinancialAssessmentControllerIntegrationTest extends MockMvcIntegra
 
         passportAssessmentRepository.save(
                 PassportAssessmentEntity.builder()
-                        .repId(REP_ID_WITH_OUTSTANDING_PASSPORT_ASSESSMENTS)
+                        .repOrder(TestEntityDataBuilder.getPopulatedRepOrder(REP_ID_WITH_OUTSTANDING_PASSPORT_ASSESSMENTS))
                         .pastStatus("IN PROGRESS")
                         .build());
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/PassportAssessmentControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/PassportAssessmentControllerIntegrationTest.java
@@ -5,10 +5,7 @@ import gov.uk.courtdata.assessment.mapper.PassportAssessmentMapper;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.dto.PassportAssessmentDTO;
-import gov.uk.courtdata.entity.FinancialAssessmentEntity;
-import gov.uk.courtdata.entity.HardshipReviewEntity;
-import gov.uk.courtdata.entity.NewWorkReasonEntity;
-import gov.uk.courtdata.entity.PassportAssessmentEntity;
+import gov.uk.courtdata.entity.*;
 import gov.uk.courtdata.integration.MockNewWorkReasonRepository;
 import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.model.assessment.CreatePassportAssessment;
@@ -41,7 +38,6 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
 
     private final String BASE_URL = "/api/internal/v1/assessment/passport-assessments/";
     private final String ASSESSMENT_URL = BASE_URL + "{passportAssessmentId}";
-    private final Integer REP_ID_WITH_NO_OUTSTANDING_ASSESSMENTS = 1111;
     private final String ASSESSMENT_BY_REP_ID_URL = BASE_URL + "repId/{repId}";
     private final Integer INVALID_ASSESSMENT_ID = 999;
 
@@ -77,13 +73,22 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
         LocalDateTime testCreationDate = LocalDateTime.of(2022, 1, 1, 12, 0);
         String testUser = "test-f";
 
-        repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder(REP_ID_WITH_NO_OUTSTANDING_ASSESSMENTS));
+        Integer REP_ID_WITH_NO_OUTSTANDING_ASSESSMENTS = 1111;
+        RepOrderEntity noOutstandingRepOrder =
+                TestEntityDataBuilder.getPopulatedRepOrder(REP_ID_WITH_NO_OUTSTANDING_ASSESSMENTS);
+        repOrderRepository.save(noOutstandingRepOrder);
 
-        NewWorkReasonEntity existingNewWorkReason = newWorkReasonRepository.save(TestEntityDataBuilder.getFmaNewWorkReasonEntity());
+        Integer REP_ID_WITH_COMPLETED_ASSESSMENT = 2222;
+        RepOrderEntity completedRepOrder =
+                TestEntityDataBuilder.getPopulatedRepOrder(REP_ID_WITH_COMPLETED_ASSESSMENT);
+        repOrderRepository.save(completedRepOrder);
+
+        NewWorkReasonEntity existingNewWorkReason =
+                newWorkReasonRepository.save(TestEntityDataBuilder.getFmaNewWorkReasonEntity());
 
         existingPassportAssessmentEntity = passportAssessmentRepository.save(
                 PassportAssessmentEntity.builder()
-                        .repId(REP_ID_WITH_NO_OUTSTANDING_ASSESSMENTS)
+                        .repOrder(noOutstandingRepOrder)
                         .assessmentDate(testCreationDate)
                         .userCreated(testUser)
                         .pastStatus("IN PROGRESS")
@@ -92,7 +97,7 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
 
         completePassportAssessmentEntity = passportAssessmentRepository.save(
                 PassportAssessmentEntity.builder()
-                        .repId(2222)
+                        .repOrder(completedRepOrder)
                         .assessmentDate(testCreationDate)
                         .userCreated(testUser)
                         .replaced("N")
@@ -142,7 +147,7 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
     public void givenAValidRepId_whenGetAssessmentByRepIdIsInvoked_theCorrectResponseIsReturned() throws Exception {
         runSuccessScenario(
                 passportAssessmentMapper.passportAssessmentEntityToPassportAssessmentDTO(existingPassportAssessmentEntity),
-                get(ASSESSMENT_BY_REP_ID_URL, existingPassportAssessmentEntity.getRepId()));
+                get(ASSESSMENT_BY_REP_ID_URL, existingPassportAssessmentEntity.getRepOrder().getId()));
     }
 
     @Test
@@ -187,7 +192,7 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
 
     @Test
     public void givenAValidPassportAssessmentBody_whenCreateAssessmentIsInvoked_theCorrectResponseIsReturned() throws Exception {
-        Integer repId = existingPassportAssessmentEntity.getRepId();
+        Integer repId = existingPassportAssessmentEntity.getRepOrder().getId();
         CreatePassportAssessment body = TestModelDataBuilder.getCreatePassportAssessment();
         body.setRepId(repId);
         body.setFinancialAssessmentId(existingFinancialAssessmentEntity.getId());
@@ -222,7 +227,7 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
         List<PassportAssessmentEntity> matchingPassportAssessments =
                 passportAssessmentRepository.findAll()
                         .stream()
-                        .filter(assessment -> assessment.getRepId().equals(repId))
+                        .filter(assessment -> assessment.getRepOrder().getId().equals(repId))
                         .collect(Collectors.toList());
 
         assertThat(matchingPassportAssessments.size()).isEqualTo(2);
@@ -305,7 +310,7 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
     @Test
     public void givenACompleteAssessmentToUpdate_whenUpdateAssessmentIsInvoked_theCorrectResponseIsReturned() throws Exception {
         UpdatePassportAssessment body = TestModelDataBuilder.getUpdatePassportAssessment();
-        body.setRepId(completePassportAssessmentEntity.getRepId());
+        body.setRepId(completePassportAssessmentEntity.getRepOrder().getId());
         body.setId(completePassportAssessmentEntity.getId());
 
         runUpdatePassportAssessmentErrorScenario("User cannot modify a completed assessment", body);
@@ -315,7 +320,7 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
     @Disabled("This test will fail until LCAM-89 is fixed.")
     public void givenAValidPassportAssessmentBody_whenUpdateAssessmentIsInvoked_theCorrectResponseIsReturned() throws Exception {
         Integer id = existingPassportAssessmentEntity.getId();
-        Integer repId = existingPassportAssessmentEntity.getRepId();
+        Integer repId = existingPassportAssessmentEntity.getRepOrder().getId();
         UpdatePassportAssessment body = TestModelDataBuilder.getUpdatePassportAssessment();
         body.setRepId(repId);
         body.setId(id);
@@ -334,7 +339,7 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
         List<PassportAssessmentEntity> matchingPassportAssessments =
                 passportAssessmentRepository.findAll()
                         .stream()
-                        .filter(assessment -> assessment.getRepId().equals(repId))
+                        .filter(assessment -> assessment.getRepOrder().getId().equals(repId))
                         .collect(Collectors.toList());
 
         assertThat(matchingPassportAssessments.size()).isEqualTo(1);
@@ -352,7 +357,7 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
 
     private void assertPassportAssessmentsEqual(PassportAssessmentDTO expectedPassportAssessment, PassportAssessmentEntity passportAssessmentEntity) {
         assertThat(passportAssessmentEntity.getId()).isEqualTo(expectedPassportAssessment.getId());
-        assertThat(passportAssessmentEntity.getRepId()).isEqualTo(expectedPassportAssessment.getRepId());
+        assertThat(passportAssessmentEntity.getRepOrder().getId()).isEqualTo(expectedPassportAssessment.getRepId());
         assertThat(passportAssessmentEntity.getCmuId()).isEqualTo(expectedPassportAssessment.getCmuId());
         assertThat(passportAssessmentEntity.getNworCode()).isEqualTo(expectedPassportAssessment.getNworCode());
         assertThat(passportAssessmentEntity.getPastStatus()).isEqualTo(expectedPassportAssessment.getPastStatus());

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/PassportAssessmentControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/PassportAssessmentControllerIntegrationTest.java
@@ -195,7 +195,6 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
         PassportAssessmentDTO expectedResponse = TestModelDataBuilder.getPassportAssessmentDTO();
         expectedResponse.setRepId(repId);
         expectedResponse.setUserModified(null);
-        expectedResponse.setFinancialAssessmentId(existingFinancialAssessmentEntity.getId());
 
         MvcResult result =
                 runSuccessScenario(post(BASE_URL).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(body)));


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-192)

- OneToMany JPA relationship between RepOrders and Passport Assessments
- When a RepOrder is retrieved, it will include all of the associated assessments of varying types
- Optimised query performance with lazy loading where possible.
