### PR TITLE
LASB 1886 - Fix JSONNull error queue message log service

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/service/QueueMessageLogService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/service/QueueMessageLogService.java
@@ -41,15 +41,12 @@ public class QueueMessageLogService {
                         .getAsJsonObject().get("maat_reference")
                 : msgObject.get("maatId");
 
-        JsonElement laaTransactionUUID = msgObject.has("metadata") ?
-                msgObject.get("metadata").getAsJsonObject().get("laaTransactionId") :
-                msgObject.get("laaTransactionId");
+        String laaTransactionId = extractLaaTransactionId(msgObject);
 
         QueueMessageLogEntity queueMessageLogEntity =
                 QueueMessageLogEntity.builder()
                         .transactionUUID(UUID.randomUUID().toString())
-                        .laaTransactionId(Optional.ofNullable(laaTransactionUUID).map(JsonElement::getAsString)
-                                .orElse(null))
+                        .laaTransactionId(laaTransactionId)
                         .maatId(Optional
                                 .ofNullable(maatId)
                                 .map(JsonElement::getAsInt)
@@ -60,6 +57,18 @@ public class QueueMessageLogService {
                         .build();
 
         queueMessageLogRepository.save(queueMessageLogEntity);
+    }
+
+    private String extractLaaTransactionId(JsonObject msgObject) {
+        JsonElement laaTransactionUUID = msgObject.has("metadata") ?
+                msgObject.get("metadata").getAsJsonObject().get("laaTransactionId") :
+                msgObject.get("laaTransactionId");
+
+        if (laaTransactionUUID == null || laaTransactionUUID.isJsonNull()) {
+            return null;
+        }
+
+        return laaTransactionUUID.getAsString();
     }
 
 


### PR DESCRIPTION
## What

- [x] createLog method updated to handle a null `laaTransactionId` within the metadata JSONElement (`$.metadata.laaTransactionId == null`)
- [x] Unit tests expanded to cover this scenario.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1886)

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
