### PR TITLE
Updated SQS listener from JMS to Spring cloud SQS for Link and unlink

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/link/service/CreateLinkListener.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/link/service/CreateLinkListener.java
@@ -4,6 +4,7 @@ import com.amazonaws.xray.spring.aop.XRayEnabled;
 import com.google.gson.Gson;
 import gov.uk.courtdata.enums.LoggingData;
 import gov.uk.courtdata.enums.MessageType;
+import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.model.CaseDetails;
 import gov.uk.courtdata.service.QueueMessageLogService;
 import io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy;
@@ -11,9 +12,8 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
-import org.springframework.jms.JmsException;
-import org.springframework.jms.annotation.JmsListener;
-import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 
@@ -32,15 +32,21 @@ public class CreateLinkListener {
 
     private final QueueMessageLogService queueMessageLogService;
 
-    @SqsListener(value = "${cloud-platform.aws.sqs.queue.link}", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
-    public void receive(@Payload final String message, @Header("SenderId") final String senderId) {
+    @SqsListener(value = "${cloud-platform.aws.sqs.queue.link}",
+            deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+    public void receive(@Payload final String message,
+                        final @Headers MessageHeaders headers) {
 
-        log.info("link request received from sender-id {}", senderId);
-        MDC.put(LoggingData.REQUEST_TYPE.getValue(), MessageType.LINK.name());
+        try {
+            log.debug("message-id {}", headers.get("MessageId"));
+            MDC.put(LoggingData.REQUEST_TYPE.getValue(), MessageType.LINK.name());
 
-        queueMessageLogService.createLog(MessageType.LINK,message);
-        CaseDetails linkMessage = gson.fromJson(message, CaseDetails.class);
+            queueMessageLogService.createLog(MessageType.LINK, message);
+            CaseDetails linkMessage = gson.fromJson(message, CaseDetails.class);
 
-        createLinkService.saveAndLink(linkMessage);
+            createLinkService.saveAndLink(linkMessage);
+        } catch (ValidationException exception) {
+            log.warn(exception.getMessage());
+        }
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/unlink/service/UnlinkListener.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/unlink/service/UnlinkListener.java
@@ -4,13 +4,17 @@ import com.amazonaws.xray.spring.aop.XRayEnabled;
 import com.google.gson.Gson;
 import gov.uk.courtdata.enums.LoggingData;
 import gov.uk.courtdata.enums.MessageType;
+import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.service.QueueMessageLogService;
 import gov.uk.courtdata.unlink.processor.UnLinkProcessor;
+import io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy;
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
-import org.springframework.jms.annotation.JmsListener;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 
@@ -27,13 +31,19 @@ public class UnlinkListener {
 
     private final QueueMessageLogService queueMessageLogService;
 
+    @SqsListener(value = "${cloud-platform.aws.sqs.queue.unlink}",
+            deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+    public void receive(@Payload final String message,
+                        final @Headers MessageHeaders headers) {
 
-    @JmsListener(destination = "${cloud-platform.aws.sqs.queue.unlink}")
-    public void receive(@Payload final String message) {
-
-        MDC.put(LoggingData.REQUEST_TYPE.getValue(), MessageType.UNLINK.name());
-        queueMessageLogService.createLog(MessageType.UNLINK, message);
-        Unlink unlink = gson.fromJson(message, Unlink.class);
-        unLinkProcessor.process(unlink);
+        try {
+            log.debug("message-id {}", headers.get("MessageId"));
+            MDC.put(LoggingData.REQUEST_TYPE.getValue(), MessageType.UNLINK.name());
+            queueMessageLogService.createLog(MessageType.UNLINK, message);
+            Unlink unlink = gson.fromJson(message, Unlink.class);
+            unLinkProcessor.process(unlink);
+        } catch (ValidationException exception) {
+            log.warn(exception.getMessage());
+        }
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkListenerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkListenerIntegrationTest.java
@@ -4,7 +4,6 @@ package gov.uk.courtdata.integration.link.service;
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
-import gov.uk.courtdata.config.SpringCloudAwsConfig;
 import gov.uk.courtdata.dto.CourtDataDTO;
 import gov.uk.courtdata.entity.CourtHouseCodesEntity;
 import gov.uk.courtdata.entity.RepOrderCPDataEntity;
@@ -19,10 +18,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -85,7 +87,11 @@ public class CreateLinkListenerIntegrationTest {
         String saveAndLinkMessage = testModelDataBuilder.getSaveAndLinkString();
 
         //when
-        createLinkListener.receive(saveAndLinkMessage, "2");
+        Map<String, Object> header = new HashMap<>();
+        header.put("MessageId", "AIDAIU3GACVJITZULQ2RQ");
+        MessageHeaders headers = new MessageHeaders(header);
+        //when
+        createLinkListener.receive(saveAndLinkMessage, headers);
 
         //then
         CourtDataDTO courtDataDTO = testModelDataBuilder.getSaveAndLinkModelRaw();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkListenerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkListenerIntegrationTest.java
@@ -103,6 +103,28 @@ public class CreateLinkListenerIntegrationTest {
 
     }
 
+    @Test
+    public void givenNewMessageInSqs_whenMaatIsNull_thenThrowException() {
+
+        //given
+        repOrderDataRepository.save(testEntityDataBuilder.getRepOrderEntity());
+        repOrderRepository.save(TestEntityDataBuilder.getRepOrder());
+        courtHouseCodesRepository.save(CourtHouseCodesEntity.builder().code("B16BG").effectiveDateFrom(LocalDateTime.now()).build());
+        solicitorMAATDataRepository.save(testEntityDataBuilder.getSolicitorMAATDataEntity());
+        defendantMAATDataRepository.save(testEntityDataBuilder.getDefendantMAATDataEntity());
+
+       String saveAndLinkMessage = getSaveAndLinkString();
+
+        //when
+        Map<String, Object> header = new HashMap<>();
+        header.put("MessageId", "AIDAIU3GACVJITZULQ2RQ");
+        MessageHeaders headers = new MessageHeaders(header);
+        //when
+        createLinkListener.receive(saveAndLinkMessage, headers);
+        //then
+        assertThat(wqLinkRegisterRepository.findAll().size()).isEqualTo(0);
+    }
+
     private void verifyRepOrder(CourtDataDTO courtDataDTO) {
         // Verify CP Rep Order Record is created
         final CaseDetails caseDetails = courtDataDTO.getCaseDetails();
@@ -122,7 +144,20 @@ public class CreateLinkListenerIntegrationTest {
         assert wqLinkRegisterEntity != null;
         assertThat(wqLinkRegisterEntity.getMaatId()).isEqualTo(courtDataDTO.getCaseDetails().getMaatId());
     }
+    public String getSaveAndLinkString() {
+        return "{\n" +
 
-
+                "  \"category\": 12,\n" +
+                "  \"laaTransactionId\":\"e439dfc8-664e-4c8e-a999-d756dcf112c2\",\n" +
+                "  \"caseUrn\":\"caseurn1\",\n" +
+                "  \"asn\": \"123456754\",\n" +
+                "  \"docLanguage\": \"EN\",\n" +
+                "  \"caseCreationDate\": \"2019-08-16\",\n" +
+                "  \"cjsAreaCode\": \"16\",\n" +
+                "  \"createdUser\": \"testUser\",\n" +
+                "  \"cjsLocation\": \"B16BG\",\n" +
+                "  \"isActive\" : true\n" +
+                "}";
+    }
 }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
@@ -19,9 +19,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -89,7 +92,11 @@ public class UnlinkListenerTest {
                 .build());
 
         //when
-        unlinkListener.receive(testModelDataBuilder.getUnLinkString());
+        Map<String, Object> header = new HashMap<>();
+        header.put("MessageId","AIDAIU3GACVJITZULQ2RQ");
+        MessageHeaders headers = new MessageHeaders(header);
+        unlinkListener.receive(testModelDataBuilder.getUnLinkString(), headers);
+
 
         //then
         assertWQLinkRegister(unlinkModel);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
@@ -4,9 +4,13 @@ import com.google.gson.Gson;
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
+import gov.uk.courtdata.dto.CourtDataDTO;
+import gov.uk.courtdata.entity.CourtHouseCodesEntity;
 import gov.uk.courtdata.entity.RepOrderCPDataEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
+import gov.uk.courtdata.exception.MAATCourtDataException;
+import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.courtdataadapter.client.CourtDataAdapterClient;
 import gov.uk.courtdata.model.Unlink;
@@ -14,6 +18,7 @@ import gov.uk.courtdata.model.UnlinkModel;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.unlink.service.UnlinkListener;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +108,36 @@ public class UnlinkListenerTest {
         assertWQLinkRegister(unlinkModel);
 
         queueMessageLogTestHelper.assertQueueMessageLogged(testModelDataBuilder.getUnLinkString(), 1, "e439dfc8-664e-4c8e-a999-d756dcf112c2", 1234);
+
+    }
+
+    @Test
+    public void givenNewMessageInSqs_whenMaatIsInvalid_thenThrowException() throws Exception{
+
+        Unlink unlink = gson.fromJson(testModelDataBuilder.getUnLinkString(), Unlink.class);
+        UnlinkModel unlinkModel = UnlinkModel.builder().unlink(unlink).build();
+        WqLinkRegisterEntity wqLinkRegisterEntity = testEntityDataBuilder.getWqLinkRegisterEntity();
+        unlinkModel.setWqLinkRegisterEntity(wqLinkRegisterEntity);
+        RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity();
+        unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
+        wqLinkRegisterEntity.setMaatId(88999);
+        wqLinkRegisterRepository.save(wqLinkRegisterEntity);
+        repOrderRepository.save(RepOrderEntity.builder().id(repOrderCPDataEntity.getRepOrderId()).caseId("12121").build());
+        repOrderCPDataRepository.save(RepOrderCPDataEntity.builder()
+                .defendantId("556677")
+                .repOrderId(1234)
+                .build());
+
+        //when
+        Map<String, Object> header = new HashMap<>();
+        header.put("MessageId","AIDAIU3GACVJITZULQ2RQ");
+        MessageHeaders headers = new MessageHeaders(header);
+
+        MAATCourtDataException error = Assert.assertThrows(
+                MAATCourtDataException.class,
+                () -> unlinkListener.receive(testModelDataBuilder.getUnLinkString(), headers));
+
+        Assert.assertEquals("MAAT Id : 1234 not linked.", error.getMessage());
 
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/link/service/CreateLinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/link/service/CreateLinkListenerTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.MessageHeaders;
+
+import java.util.HashMap;
 
 import static org.mockito.Mockito.*;
 
@@ -32,7 +35,7 @@ public class CreateLinkListenerTest {
         String message = "Test JSON";
         //when
         when(gson.fromJson(message, CaseDetails.class)).thenReturn(caseDetails);
-        createLinkListener.receive(message, "1");
+        createLinkListener.receive(message, new MessageHeaders(new HashMap<>()));
         //then
         verify(createLinkService, times(1)).saveAndLink(caseDetails);
         verify(queueMessageLogService, times(1)).createLog(MessageType.LINK, message);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/link/service/CreateLinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/link/service/CreateLinkListenerTest.java
@@ -2,10 +2,13 @@ package gov.uk.courtdata.link.service;
 
 import com.google.gson.Gson;
 import gov.uk.courtdata.enums.MessageType;
+import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.model.CaseDetails;
 import gov.uk.courtdata.service.QueueMessageLogService;
+import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,6 +31,9 @@ public class CreateLinkListenerTest {
     @Mock
     private QueueMessageLogService queueMessageLogService;
 
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
     @Test
     public void givenJSONMessageIsReceived_whenCreateLinkListenerIsInvoked_thenCreateLinkServiceIsCalled() {
         //given
@@ -39,5 +45,15 @@ public class CreateLinkListenerTest {
         //then
         verify(createLinkService, times(1)).saveAndLink(caseDetails);
         verify(queueMessageLogService, times(1)).createLog(MessageType.LINK, message);
+    }
+    @Test
+    public void givenJSONMessageIsReceived_whenCreateLinkListenerThrowException_thenCreateLinkServiceIsCalled() {
+        //given
+        CaseDetails caseDetails = CaseDetails.builder().build();
+        String message = "Test JSON";
+        //when
+        when(gson.fromJson(message, CaseDetails.class)).thenReturn(caseDetails);
+        exceptionRule.expect(ValidationException.class);
+        createLinkListener.receive(message, new MessageHeaders(new HashMap<>()));
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/unlink/service/UnlinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/unlink/service/UnlinkListenerTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.MessageHeaders;
+
+import java.util.HashMap;
 
 import static org.mockito.Mockito.*;
 
@@ -36,7 +39,7 @@ public class UnlinkListenerTest {
                 .maatId(1111111)
                 .build();
         when(gson.fromJson(message, Unlink.class)).thenReturn(unlink);
-        unlinkListener.receive(message);
+        unlinkListener.receive(message, new MessageHeaders(new HashMap<>()));
 
         verify(unLinkProcessor).process(any());
         verify(queueMessageLogService).createLog(MessageType.UNLINK, message);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/lasb-1926)

Updated the code for linking to manage the duplicate and added a try-catch in the case of a validation error. For any other failure the message will be posted back to the SQS but for validation, it will finish the call. This is the same for both linking and unblinking. 

Upgraded the Unlinking SQS listener from JMS to Spring cloud SQS. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
