### PR TITLE
LASB-1970: Large x-ray segments causing IOExceptions.

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/aspect/XRayInspector.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/aspect/XRayInspector.java
@@ -28,22 +28,6 @@ public class XRayInspector extends AbstractXRayInterceptor {
     private String AWS_XRAY_SEGMENT_NAME;
 
     @Override
-    protected Map<String, Map<String, Object>> generateMetadata(ProceedingJoinPoint proceedingJoinPoint, Subsegment subsegment) {
-        Map<String, Map<String, Object>> metadata = super.generateMetadata(proceedingJoinPoint, subsegment);
-
-        Map<String, Object> argumentsInfo = new HashMap<>();
-
-        Object[] methodArgs = proceedingJoinPoint.getArgs();
-        if (methodArgs != null) {
-            Arrays.stream(methodArgs)
-                    .filter(Objects::nonNull)
-                    .forEach(arg -> argumentsInfo.put(arg.getClass().getSimpleName(), arg));
-            metadata.put("Arguments", argumentsInfo);
-        }
-        return metadata;
-    }
-
-    @Override
     @Pointcut(
             "@within(com.amazonaws.xray.spring.aop.XRayEnabled) && " +
                     "(bean(*Controller) || bean(*Service) || bean(*Validator) || bean(*Impl) || bean(*Processor))"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1970)

- [x] Removed the override method that populates the segment metadata with all the data from the input class as this was causing the segment to be too large.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
