### PR TITLE
LASB-1965: Update transaction id header name fo CDA calls

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/constants/CourtDataConstants.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/constants/CourtDataConstants.java
@@ -40,6 +40,7 @@ public final class CourtDataConstants {
     public static final Integer COMMITTAL_FOR_TRIAL_SUB_TYPE = 2;
     public static final Integer COMMITTAL_FOR_SENTENCE_SUB_TYPE = 1;
     public static final String LAA_TRANSACTION_ID = "Laa-Transaction-Id";
+    public static final String CDA_TRANSACTION_ID_HEADER = "X-Request-ID";
     public static final int ORACLE_VARCHAR_MAX = 4000;
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/courtdataadapter/client/CourtDataAdapterClient.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/courtdataadapter/client/CourtDataAdapterClient.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static gov.uk.courtdata.constants.CourtDataConstants.CDA_TRANSACTION_ID_HEADER;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -60,7 +62,7 @@ public class CourtDataAdapterClient {
                 .get()
                 .uri(uriBuilder ->
                         uriBuilder.path(courtDataAdapterClientConfig.getHearingUrl()).queryParam("publish_to_queue", true).build(hearingId))
-                .headers(httpHeaders -> httpHeaders.setAll(Map.of("X-Request-ID", laaTransactionId)))
+                .headers(httpHeaders -> httpHeaders.setAll(Map.of(CDA_TRANSACTION_ID_HEADER, laaTransactionId)))
                 .retrieve().toBodilessEntity()
                 .onErrorMap(error -> new MAATCourtDataException(String.format("Error triggering CDA processing for hearing '%s'.%s", hearingId, error.getMessage())))
                 .doOnSuccess(response -> log.info("Processing trigger successfully for hearing '{}'", hearingId))

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/laastatus/builder/RepOrderUpdateMessageBuilder.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/laastatus/builder/RepOrderUpdateMessageBuilder.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static gov.uk.courtdata.constants.CourtDataConstants.CDA_TRANSACTION_ID_HEADER;
+
 
 @Component
 @AllArgsConstructor
@@ -48,7 +50,7 @@ public class RepOrderUpdateMessageBuilder {
     public Map<String, String> buildHeaders(CourtDataDTO courtDataDTO) {
         Map<String, String> headers = new HashMap<>();
         final UUID laaTransactionId = courtDataDTO.getCaseDetails().getLaaTransactionId();
-        headers.put("Laa-Transaction-Id", laaTransactionId != null ? laaTransactionId.toString() : null);
+        headers.put(CDA_TRANSACTION_ID_HEADER, laaTransactionId != null ? laaTransactionId.toString() : null);
         headers.put("Laa-Status-Transaction-Id", String.valueOf(courtDataDTO.getTxId()));
         return headers;
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/laastatus/controller/LaaStatusUpdateController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/laastatus/controller/LaaStatusUpdateController.java
@@ -73,7 +73,7 @@ public class LaaStatusUpdateController {
                 log.info("LAA Status Update Validation Failed - Messages {}", messageCollection.getMessages());
             }
         } catch (Exception exception) {
-            throw new MAATCourtDataException("MAAT APT Call failed " + exception.getMessage());
+            throw new MAATCourtDataException("MAAT API Call failed - " + exception.getMessage());
         }
         return messageCollection;
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/laastatus/service/LaaStatusUpdateControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/laastatus/service/LaaStatusUpdateControllerIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static gov.uk.courtdata.constants.CourtDataConstants.CDA_TRANSACTION_ID_HEADER;
 import static gov.uk.courtdata.constants.CourtDataConstants.WQ_UPDATE_CASE_EVENT;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -120,18 +121,18 @@ public class LaaStatusUpdateControllerIntegrationTest extends MockMvcIntegration
     public void givenNullMaatIdInCaseDetails_whenUpdateLAAStatusIsInvoked_theCorrectErrorIsReturned() throws Exception {
         String testPayload = objectMapper
                 .writeValueAsString(CaseDetails.builder().laaTransactionId(UUID.fromString(LAA_TRANSACTION_ID)).build());
-        assertTrue(runServerErrorScenario("MAAT APT Call failed MAAT ID is required.", getPostRequest(testPayload)));
+        assertTrue(runServerErrorScenario("MAAT API Call failed - MAAT ID is required.", getPostRequest(testPayload)));
     }
 
     @Test
     public void givenAMissingMaatIdInCaseDetails_whenUpdateLAAStatusIsInvoked_theCorrectErrorIsReturned() throws Exception {
         String payloadMissingMaatId = String.format("{\"laaTransactionId\":\"%s\"}", LAA_TRANSACTION_ID);
-        assertTrue(runServerErrorScenario("MAAT APT Call failed MAAT ID is required.", getPostRequest(payloadMissingMaatId)));
+        assertTrue(runServerErrorScenario("MAAT API Call failed - MAAT ID is required.", getPostRequest(payloadMissingMaatId)));
     }
 
     @Test
     public void givenAnInvalidMaatIdInCaseDetails_whenUpdateLAAStatusIsInvoked_theCorrectErrorIsReturned() throws Exception {
-        runValidationFailureScenario(String.format("MAAT APT Call failed MAAT/REP ID: %d is invalid.", TEST_MAAT_ID));
+        runValidationFailureScenario(String.format("MAAT API Call failed - MAAT/REP ID: %d is invalid.", TEST_MAAT_ID));
         assertThat(mockCdaWebServer.getRequestCount())
                 .isEqualTo(0);
     }
@@ -139,7 +140,7 @@ public class LaaStatusUpdateControllerIntegrationTest extends MockMvcIntegration
     @Test
     public void givenAMaatIdThatIsNotLinked_whenUpdateLAAStatusIsInvoked_theCorrectErrorIsReturned() throws Exception {
         createTestRepoOrder();
-        runValidationFailureScenario(String.format("MAAT APT Call failed MAAT Id : %s not linked.", TEST_MAAT_ID));
+        runValidationFailureScenario(String.format("MAAT API Call failed - MAAT Id : %s not linked.", TEST_MAAT_ID));
         assertThat(mockCdaWebServer.getRequestCount())
                 .isEqualTo(0);
     }
@@ -148,7 +149,7 @@ public class LaaStatusUpdateControllerIntegrationTest extends MockMvcIntegration
     public void givenAMaatIdWithMultipleLinks_whenUpdateLAAStatusIsInvoked_theCorrectErrorIsReturned() throws Exception {
         createTestRepoOrder();
         createTestLinkData(2);
-        runValidationFailureScenario(String.format("MAAT APT Call failed Multiple Links found for  MAAT Id : %s", TEST_MAAT_ID));
+        runValidationFailureScenario(String.format("MAAT API Call failed - Multiple Links found for  MAAT Id : %s", TEST_MAAT_ID));
         assertThat(mockCdaWebServer.getRequestCount())
                 .isEqualTo(0);
     }
@@ -157,7 +158,7 @@ public class LaaStatusUpdateControllerIntegrationTest extends MockMvcIntegration
     public void givenAMaatIdNoLinkedSolicitor_whenUpdateLAAStatusIsInvoked_theCorrectErrorIsReturned() throws Exception {
         createTestRepoOrder();
         createTestLinkData(1);
-        runValidationFailureScenario(String.format("MAAT APT Call failed Solicitor not found for maatId %s", TEST_MAAT_ID));
+        runValidationFailureScenario(String.format("MAAT API Call failed - Solicitor not found for maatId %s", TEST_MAAT_ID));
         assertThat(mockCdaWebServer.getRequestCount())
                 .isEqualTo(0);
     }
@@ -168,7 +169,7 @@ public class LaaStatusUpdateControllerIntegrationTest extends MockMvcIntegration
         createTestLinkData(1);
         createSolicitorData("");
         createDefendantData();
-        runValidationFailureScenario(String.format("MAAT APT Call failed Solicitor account code not available for maatId %s.", TEST_MAAT_ID));
+        runValidationFailureScenario(String.format("MAAT API Call failed - Solicitor account code not available for maatId %s.", TEST_MAAT_ID));
         assertThat(mockCdaWebServer.getRequestCount())
                 .isEqualTo(0);
     }
@@ -178,7 +179,7 @@ public class LaaStatusUpdateControllerIntegrationTest extends MockMvcIntegration
         createTestRepoOrder();
         createTestLinkData(1);
         createSolicitorData("test-account-code");
-        runValidationFailureScenario("MAAT APT Call failed MAAT Defendant details not found.");
+        runValidationFailureScenario("MAAT API Call failed - MAAT Defendant details not found.");
         assertThat(mockCdaWebServer.getRequestCount())
                 .isEqualTo(0);
     }
@@ -387,7 +388,7 @@ public class LaaStatusUpdateControllerIntegrationTest extends MockMvcIntegration
                 generateExpectedLaaStatusObject(inputCaseDetails, offence, solicitor, repOrderCPDataEntity));
 
         Map<String, String> expectedHeaders = Map.ofEntries(
-                new SimpleEntry<>("Laa-Transaction-Id", LAA_TRANSACTION_ID),
+                new SimpleEntry<>(CDA_TRANSACTION_ID_HEADER, LAA_TRANSACTION_ID),
                 new SimpleEntry<>("Laa-Status-Transaction-Id", "null"));
 
         RecordedRequest receivedRequest = mockCdaWebServer.takeRequest();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/laastatus/builder/RepOrderUpdateMessageBuilderTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/laastatus/builder/RepOrderUpdateMessageBuilderTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static gov.uk.courtdata.constants.CourtDataConstants.CDA_TRANSACTION_ID_HEADER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -183,7 +184,7 @@ RepOrderUpdateMessageBuilderTest {
 
         //then
         assertAll("VerifyHeaders",
-                () -> assertEquals("6f5b34ea-e038-4f1c-bfe5-d6bf622444f0", headers.get("Laa-Transaction-Id")),
+                () -> assertEquals("6f5b34ea-e038-4f1c-bfe5-d6bf622444f0", headers.get(CDA_TRANSACTION_ID_HEADER)),
                 () -> assertEquals("123456", headers.get("Laa-Status-Transaction-Id")));
     }
 
@@ -200,7 +201,7 @@ RepOrderUpdateMessageBuilderTest {
 
         //then
         assertAll("VerifyHeaders",
-                () -> assertNull(headers.get("Laa-Transaction-Id")),
+                () -> assertNull(headers.get(CDA_TRANSACTION_ID_HEADER)),
                 () -> assertEquals("123456", headers.get("Laa-Status-Transaction-Id")));
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1965)

- [x] Updated all remaining references to the `laa-transaction-id` header used in CDA calls to the `X-Request-ID` header CDA expects.
- [x] Corrected a type in the `MAATCourtDataException`error message thrown in the `LaaStatusUpdateController`.
- [x] Update unit and integration tests. 

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
