### PR TITLE
Fix build timeouts in AWS pipeline

### DIFF
--- a/aws/pipeline/maat-cd-api-deployment-pipeline.template
+++ b/aws/pipeline/maat-cd-api-deployment-pipeline.template
@@ -236,7 +236,7 @@ Resources:
           - Name: SONARQUBE_TOKEN
             Type: PARAMETER_STORE
             Value: /maat-cd-api/SONARQUBE_TOKEN
-      TimeoutInMinutes: 15
+      TimeoutInMinutes: 20
 
   Pipeline:
     Type: AWS::CodePipeline::Pipeline

--- a/aws/pipeline/maat-cd-api-deployment-pipeline.template
+++ b/aws/pipeline/maat-cd-api-deployment-pipeline.template
@@ -236,7 +236,7 @@ Resources:
           - Name: SONARQUBE_TOKEN
             Type: PARAMETER_STORE
             Value: /maat-cd-api/SONARQUBE_TOKEN
-      TimeoutInMinutes: 20
+      TimeoutInMinutes: 25
 
   Pipeline:
     Type: AWS::CodePipeline::Pipeline


### PR DESCRIPTION
## What

Increased build timeout to 25 mins to prevent code pipeline timeout at 15 minutes.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
