### PR TITLE
LASB-1982 Create RepositoryUtil test utility to standardise clearing down repos correctly after each test

### DIFF
--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/FinancialAssessmentControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/FinancialAssessmentControllerIntegrationTest.java
@@ -17,6 +17,7 @@ import gov.uk.courtdata.model.assessment.FinancialAssessmentDetails;
 import gov.uk.courtdata.model.assessment.UpdateFinancialAssessment;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,16 +83,16 @@ public class FinancialAssessmentControllerIntegrationTest extends MockMvcIntegra
 
     @AfterEach
     public void clearUp() {
-        hardshipReviewRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        childWeightingsRepository.deleteAll();
-        financialAssessmentDetailsRepository.deleteAll();
-        financialAssessmentsHistoryRepository.deleteAll();
-        financialAssessmentDetailsHistoryRepository.deleteAll();
-        childWeightHistoryRepository.deleteAll();
-        financialAssessmentRepository.deleteAll();
-        newWorkReasonRepository.deleteAll();
-        repOrderRepository.deleteAll();
+        RepositoryUtil.clearUp(hardshipReviewRepository,
+                passportAssessmentRepository,
+                childWeightingsRepository,
+                financialAssessmentDetailsRepository,
+                financialAssessmentsHistoryRepository,
+                financialAssessmentDetailsHistoryRepository,
+                childWeightHistoryRepository,
+                financialAssessmentRepository,
+                newWorkReasonRepository,
+                repOrderRepository);
     }
 
     private void setupTestData() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/PassportAssessmentControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/PassportAssessmentControllerIntegrationTest.java
@@ -15,6 +15,7 @@ import gov.uk.courtdata.repository.HardshipReviewRepository;
 import gov.uk.courtdata.repository.PassportAssessmentRepository;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -65,11 +66,11 @@ public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrat
     }
 
     private void setupTestData() {
-        financialAssessmentRepository.deleteAll();
-        hardshipReviewRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        newWorkReasonRepository.deleteAll();
-        repOrderRepository.deleteAll();
+        RepositoryUtil.clearUp(financialAssessmentRepository,
+                hardshipReviewRepository,
+                passportAssessmentRepository,
+                newWorkReasonRepository,
+                repOrderRepository);
 
         LocalDateTime testCreationDate = LocalDateTime.of(2022, 1, 1, 12, 0);
         String testUser = "test-f";

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/authorization/AuthorizationControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/authorization/AuthorizationControllerIntegrationTest.java
@@ -6,6 +6,7 @@ import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.model.authorization.AuthorizationResponse;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,10 +55,11 @@ public class AuthorizationControllerIntegrationTest extends MockMvcIntegrationTe
     }
 
     private void setupTestData() {
-        roleActionsRepository.deleteAll();
-        reservationsRepository.deleteAll();
-        roleWorkReasonsRepository.deleteAll();
-        userRolesRepository.deleteAll();
+        RepositoryUtil.clearUp(roleActionsRepository,
+                reservationsRepository,
+                roleWorkReasonsRepository,
+                userRolesRepository,
+                userRepository);
 
         String AUTHORISED_ROLE = "VALID_ROLE";
         String DISABLED_ROLE = "DISABLED_ROLE";

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/contribution/ContributionsControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/contribution/ContributionsControllerIntegrationTest.java
@@ -6,16 +6,17 @@ import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.contribution.model.CreateContributions;
 import gov.uk.courtdata.contribution.model.UpdateContributions;
+import gov.uk.courtdata.contribution.repository.ContributionsRepository;
 import gov.uk.courtdata.dto.ContributionsDTO;
 import gov.uk.courtdata.entity.ContributionFilesEntity;
 import gov.uk.courtdata.entity.ContributionsEntity;
 import gov.uk.courtdata.entity.CorrespondenceEntity;
 import gov.uk.courtdata.integration.MockServicesConfig;
-import gov.uk.courtdata.contribution.repository.ContributionsRepository;
 import gov.uk.courtdata.repository.ContributionFilesRepository;
 import gov.uk.courtdata.repository.CorrespondenceRepository;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -87,8 +88,10 @@ public class ContributionsControllerIntegrationTest extends MockMvcIntegrationTe
     @AfterEach
     public void clearUp() {
         contributionsEntity = null;
-        contributionsRepository.deleteAll();
-        repOrderRepository.deleteAll();
+        RepositoryUtil.clearUp(contributionsRepository,
+                contributionFilesRepository,
+                correspondenceRepository,
+                repOrderRepository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/correspondence/CorrespondenceStateControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/correspondence/CorrespondenceStateControllerIntegrationTest.java
@@ -8,6 +8,7 @@ import gov.uk.courtdata.entity.CorrespondenceStateEntity;
 import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.repository.CorrespondenceStateRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -49,7 +50,7 @@ public class CorrespondenceStateControllerIntegrationTest extends MockMvcIntegra
 
     @AfterEach
     public void clearUp() {
-        repository.deleteAll();
+        RepositoryUtil.clearUp(repository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/hardship/HardshipControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/hardship/HardshipControllerIntegrationTest.java
@@ -17,6 +17,7 @@ import gov.uk.courtdata.model.NewWorkReason;
 import gov.uk.courtdata.model.hardship.*;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,13 +74,13 @@ public class HardshipControllerIntegrationTest extends MockMvcIntegrationTest {
     public void setUp() throws Exception {
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
-        hardshipReviewRepository.deleteAll();
-        hardshipReviewDetailRepository.deleteAll();
-        hardshipReviewDetailReasonRepository.deleteAll();
-        financialAssessmentRepository.deleteAll();
-        mockNewWorkReasonRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        repOrderRepository.deleteAll();
+        RepositoryUtil.clearUp(hardshipReviewRepository,
+                hardshipReviewDetailRepository,
+                hardshipReviewDetailReasonRepository,
+                financialAssessmentRepository,
+                mockNewWorkReasonRepository,
+                passportAssessmentRepository,
+                repOrderRepository);
 
         setupTestData();
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/hearing/HearingResultedListenerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/hearing/HearingResultedListenerIntegrationTest.java
@@ -17,6 +17,7 @@ import gov.uk.courtdata.model.Session;
 import gov.uk.courtdata.model.hearing.HearingResulted;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -92,20 +93,20 @@ public class HearingResultedListenerIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        identifierRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-        xlatResultRepository.deleteAll();
-        xlatOffenceRepository.deleteAll();
-        wqCoreRepository.deleteAll();
-        offenceRepository.deleteAll();
-        resultRepository.deleteAll();
-        wqResultRepository.deleteAll();
-        wqHearingRepository.deleteAll();
-        queueMessageLogRepository.deleteAll();
-        wqCaseRepository.deleteAll();
-        wqSessionRepository.deleteAll();
-        wqDefendantRepository.deleteAll();
-        wqOffenceRepository.deleteAll();
+        RepositoryUtil.clearUp(identifierRepository,
+                wqLinkRegisterRepository,
+                xlatResultRepository,
+                xlatOffenceRepository,
+                wqCoreRepository,
+                offenceRepository,
+                resultRepository,
+                wqResultRepository,
+                wqHearingRepository,
+                queueMessageLogRepository,
+                wqCaseRepository,
+                wqSessionRepository,
+                wqDefendantRepository,
+                wqOffenceRepository);
 
         setupTestData();
         queueMessageLogTestHelper = new QueueMessageLogTestHelper(queueMessageLogRepository);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/laastatus/service/LaaStatusUpdateControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/laastatus/service/LaaStatusUpdateControllerIntegrationTest.java
@@ -15,6 +15,7 @@ import gov.uk.courtdata.model.laastatus.*;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
+import gov.uk.courtdata.util.RepositoryUtil;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -94,21 +95,21 @@ public class LaaStatusUpdateControllerIntegrationTest extends MockMvcIntegration
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
         setupCdaWebServer();
-        financialAssessmentRepository.deleteAll();
-        wqCoreRepository.deleteAll();
-        queueMessageLogRepository.deleteAll();
-        identifierRepository.deleteAll();
-        caseRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-        solicitorRepository.deleteAll();
-        defendantRepository.deleteAll();
-        sessionRepository.deleteAll();
-        offenceRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        repOrderRepository.deleteAll();
-        solicitorMAATDataRepository.deleteAll();
-        defendantMAATDataRepository.deleteAll();
-        repOrderCPDataRepository.deleteAll();
+        RepositoryUtil.clearUp(financialAssessmentRepository,
+                wqCoreRepository,
+                queueMessageLogRepository,
+                identifierRepository,
+                caseRepository,
+                wqLinkRegisterRepository,
+                solicitorRepository,
+                defendantRepository,
+                sessionRepository,
+                offenceRepository,
+                passportAssessmentRepository,
+                repOrderRepository,
+                solicitorMAATDataRepository,
+                defendantMAATDataRepository,
+                repOrderCPDataRepository);
         queueMessageLogTestHelper = new QueueMessageLogTestHelper(queueMessageLogRepository);
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/controller/LinkControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/controller/LinkControllerIntegrationTest.java
@@ -10,6 +10,7 @@ import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.link.controller.LinkController;
 import gov.uk.courtdata.model.CaseDetailsValidate;
 import gov.uk.courtdata.repository.*;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,11 +72,11 @@ public class LinkControllerIntegrationTest {
     @BeforeEach
     public void setUp() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
-        financialAssessmentRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        repOrderRepository.deleteAll();
-        repOrderCPDataRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
+        RepositoryUtil.clearUp(financialAssessmentRepository,
+                passportAssessmentRepository,
+                repOrderRepository,
+                repOrderCPDataRepository,
+                wqLinkRegisterRepository);
     }
 
     @Test
@@ -178,9 +179,11 @@ public class LinkControllerIntegrationTest {
 
     @AfterEach
     public void clearUp() {
-        repOrderRepository.deleteAll();
-        repOrderCPDataRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
+        RepositoryUtil.clearUp(financialAssessmentRepository,
+                passportAssessmentRepository,
+                repOrderRepository,
+                repOrderCPDataRepository,
+                wqLinkRegisterRepository);
     }
 
     public RepOrderCPDataEntity createRepOrderCPDataEntity(final Integer maatId, final String caseUrn) {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/impl/SaveAndLinkImplIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/impl/SaveAndLinkImplIntegrationTest.java
@@ -15,6 +15,7 @@ import gov.uk.courtdata.model.id.AsnSeqTxnCaseId;
 import gov.uk.courtdata.model.id.CaseTxnId;
 import gov.uk.courtdata.model.id.ProceedingMaatId;
 import gov.uk.courtdata.repository.*;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,19 +67,19 @@ public class SaveAndLinkImplIntegrationTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        financialAssessmentRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        wqCoreRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-        caseRepository.deleteAll();
-        solicitorRepository.deleteAll();
-        proceedingRepository.deleteAll();
-        defendantRepository.deleteAll();
-        sessionRepository.deleteAll();
-        offenceRepository.deleteAll();
-        resultRepository.deleteAll();
-        repOrderDataRepository.deleteAll();
-        repOrderRepository.deleteAll();
+        RepositoryUtil.clearUp(financialAssessmentRepository,
+                passportAssessmentRepository,
+                wqCoreRepository,
+                wqLinkRegisterRepository,
+                caseRepository,
+                solicitorRepository,
+                proceedingRepository,
+                defendantRepository,
+                sessionRepository,
+                offenceRepository,
+                resultRepository,
+                repOrderDataRepository,
+                repOrderRepository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkCpJobStatusServiceIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkCpJobStatusServiceIntegrationTest.java
@@ -10,12 +10,11 @@ import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.link.service.CreateLinkCpJobStatusListener;
 import gov.uk.courtdata.repository.WqCoreRepository;
 import gov.uk.courtdata.repository.WqLinkRegisterRepository;
-
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -37,9 +36,7 @@ public class CreateLinkCpJobStatusServiceIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        wqCoreRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-
+        RepositoryUtil.clearUp(wqCoreRepository, wqLinkRegisterRepository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkListenerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkListenerIntegrationTest.java
@@ -13,6 +13,7 @@ import gov.uk.courtdata.link.service.CreateLinkListener;
 import gov.uk.courtdata.model.CaseDetails;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,15 +64,15 @@ public class CreateLinkListenerIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        financialAssessmentRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        repOrderRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-        repOrderDataRepository.deleteAll();
-        solicitorMAATDataRepository.deleteAll();
-        defendantMAATDataRepository.deleteAll();
-        courtHouseCodesRepository.deleteAll();
-        queueMessageLogRepository.deleteAll();
+        RepositoryUtil.clearUp(financialAssessmentRepository,
+                passportAssessmentRepository,
+                repOrderRepository,
+                wqLinkRegisterRepository,
+                repOrderDataRepository,
+                solicitorMAATDataRepository,
+                defendantMAATDataRepository,
+                courtHouseCodesRepository,
+                queueMessageLogRepository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/offence/OffenceControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/offence/OffenceControllerIntegrationTest.java
@@ -6,6 +6,7 @@ import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.repository.OffenceRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -43,7 +44,7 @@ public class OffenceControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @AfterAll
     static void cleanUp(@Autowired OffenceRepository offenceRepository) {
-        offenceRepository.deleteAll();
+        RepositoryUtil.clearUp(offenceRepository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/prosecution_concluded/ProsecutionConcludedAndHearingIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/prosecution_concluded/ProsecutionConcludedAndHearingIntegrationTest.java
@@ -16,6 +16,7 @@ import gov.uk.courtdata.repository.WQHearingRepository;
 import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
+import gov.uk.courtdata.util.RepositoryUtil;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -30,8 +31,10 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
-import java.util.*;
-
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -70,10 +73,10 @@ public class ProsecutionConcludedAndHearingIntegrationTest extends MockMvcIntegr
 
     @BeforeEach
     public void setUp() throws Exception {
-        wqHearingRepository.deleteAll();
-        queueMessageLogRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-        prosecutionConcludedRepository.deleteAll();
+        RepositoryUtil.clearUp(wqHearingRepository,
+                queueMessageLogRepository,
+                wqLinkRegisterRepository,
+                prosecutionConcludedRepository);
         loadData();
         setupCdaWebServer();
         queueMessageLogTestHelper = new QueueMessageLogTestHelper(queueMessageLogRepository);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/prosecution_concluded/ProsecutionConcludedIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/prosecution_concluded/ProsecutionConcludedIntegrationTest.java
@@ -17,6 +17,7 @@ import gov.uk.courtdata.prosecutionconcluded.service.HearingsService;
 import gov.uk.courtdata.prosecutionconcluded.service.ProsecutionConcludedListener;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -100,19 +101,19 @@ public class ProsecutionConcludedIntegrationTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        financialAssessmentRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        wqHearingRepository.deleteAll();
-        offenceRepository.deleteAll();
-        queueMessageLogRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-        xlatResultRepository.deleteAll();
-        resultRepository.deleteAll();
-        repOrderRepository.deleteAll();
-        crownCourtCodeRepository.deleteAll();
-        updateOutcomesRepository.deleteAll();
-        reservationsRepository.deleteAll();
-        prosecutionConcludedRepository.deleteAll();
+        RepositoryUtil.clearUp(financialAssessmentRepository,
+                passportAssessmentRepository,
+                wqHearingRepository,
+                offenceRepository,
+                queueMessageLogRepository,
+                wqLinkRegisterRepository,
+                xlatResultRepository,
+                resultRepository,
+                repOrderRepository,
+                crownCourtCodeRepository,
+                updateOutcomesRepository,
+                reservationsRepository,
+                prosecutionConcludedRepository);
         loadData();
         queueMessageLogTestHelper = new QueueMessageLogTestHelper(queueMessageLogRepository);
         doNothing().when(crownCourtProcessingRepository).invokeUpdateAppealSentenceOrderDate(any(Integer.class), anyString(), any(LocalDate.class), any(LocalDate.class));

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/CCOutcomeControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/CCOutcomeControllerIntegrationTest.java
@@ -10,6 +10,7 @@ import gov.uk.courtdata.model.RepOrderCCOutcome;
 import gov.uk.courtdata.repository.CrownCourtProcessingRepository;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -58,7 +59,7 @@ public class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
     @AfterEach
     void clearUp() {
         existingRepOrder = null;
-        courtProcessingRepository.deleteAll();
+        RepositoryUtil.clearUp(courtProcessingRepository, repOrderRepository);
     }
 
     @Test
@@ -98,7 +99,6 @@ public class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenAValidData_whenUpdateIsInvoked_thenShouldUpdatedCCOutCome() throws Exception {
-        courtProcessingRepository.deleteAll();
         RepOrderCCOutComeEntity savedOutcome = courtProcessingRepository.saveAndFlush(TestEntityDataBuilder.getRepOrderCCOutcomeEntity(1, TestModelDataBuilder.REP_ID));
         runSuccessScenario(MockMvcRequestBuilders.put(endpointUrl).contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestModelDataBuilder.getUpdateRepOrderCCOutcome(savedOutcome.getId()))));

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderCapitalIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderCapitalIntegrationTest.java
@@ -7,6 +7,7 @@ import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.repository.RepOrderCapitalRepository;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,11 +54,9 @@ public class RepOrderCapitalIntegrationTest extends MockMvcIntegrationTest {
 
     @AfterEach
     void clearUp() {
-        repOrderRepository.deleteAll();
-        capitalRepository.deleteAll();
+        RepositoryUtil.clearUp(repOrderRepository, capitalRepository);
     }
-
-
+    
     @Test
     void givenAInvalidRepId_whenGetCapitalAssetCountIsInvoked_thenErrorReturn() throws Exception {
         runBadRequestErrorScenario("MAAT ID is required.", head(ENDPOINT_URL + "/reporder/" + INVALID_REP_ID));

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import gov.uk.courtdata.model.assessment.UpdateAppDateCompleted;
 import gov.uk.courtdata.reporder.mapper.RepOrderMapper;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -93,11 +94,11 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
                  @Autowired RepOrderMvoRepository repOrderMvoRepository,
                  @Autowired RepOrderMvoRegRepository repOrderMvoRegRepository) {
 
-        financialAssessmentRepository.deleteAll();
-        passportAssessmentRepository.deleteAll();
-        repOrderMvoRegRepository.deleteAll();
-        repOrderMvoRepository.deleteAll();
-        repOrderRepository.deleteAll();
+        RepositoryUtil.clearUp(financialAssessmentRepository,
+                passportAssessmentRepository,
+                repOrderMvoRegRepository,
+                repOrderMvoRepository,
+                repOrderRepository);
     }
 
     private RepOrderDTO getUpdatedRepOrderDTO() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/impl/UnLinkImplIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/impl/UnLinkImplIntegrationTest.java
@@ -15,6 +15,7 @@ import gov.uk.courtdata.repository.UnlinkReasonRepository;
 import gov.uk.courtdata.repository.WqCoreRepository;
 import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import gov.uk.courtdata.unlink.impl.UnLinkImpl;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,9 +49,9 @@ public class UnLinkImplIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        wqCoreRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-        unlinkReasonRepository.deleteAll();
+        RepositoryUtil.clearUp(wqCoreRepository,
+                wqLinkRegisterRepository,
+                unlinkReasonRepository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
@@ -4,21 +4,17 @@ import com.google.gson.Gson;
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
-import gov.uk.courtdata.dto.CourtDataDTO;
-import gov.uk.courtdata.entity.CourtHouseCodesEntity;
+import gov.uk.courtdata.courtdataadapter.client.CourtDataAdapterClient;
 import gov.uk.courtdata.entity.RepOrderCPDataEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
-import gov.uk.courtdata.exception.MAATCourtDataException;
-import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.integration.MockServicesConfig;
-import gov.uk.courtdata.courtdataadapter.client.CourtDataAdapterClient;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.model.UnlinkModel;
 import gov.uk.courtdata.repository.*;
 import gov.uk.courtdata.unlink.service.UnlinkListener;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
-import org.junit.Assert;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,14 +65,14 @@ public class UnlinkListenerTest {
 
     @BeforeEach
     public void setUp() {
-        passportAssessmentRepository.deleteAll();
-        financialAssessmentRepository.deleteAll();
-        wqCoreRepository.deleteAll();
-        wqLinkRegisterRepository.deleteAll();
-        unlinkReasonRepository.deleteAll();
-        repOrderRepository.deleteAll();
-        repOrderCPDataRepository.deleteAll();
-        queueMessageLogRepository.deleteAll();
+        RepositoryUtil.clearUp(passportAssessmentRepository,
+                financialAssessmentRepository,
+                wqCoreRepository,
+                wqLinkRegisterRepository,
+                unlinkReasonRepository,
+                repOrderRepository,
+                repOrderCPDataRepository,
+                queueMessageLogRepository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqhearing/WQHearingControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqhearing/WQHearingControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import gov.uk.courtdata.entity.WQHearingEntity;
 import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.repository.WQHearingRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class WQHearingControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @BeforeAll
     static void setUp(@Autowired WQHearingRepository wqHearingRepository) {
-        wqHearingRepository.deleteAll();
+        RepositoryUtil.clearUp(wqHearingRepository);
         wqHearingRepository.save(TestEntityDataBuilder.getWQHearingEntity(8064716));
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqlinkregister/WQLinkRegisterControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqlinkregister/WQLinkRegisterControllerIntegrationTest.java
@@ -6,6 +6,7 @@ import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ public class WQLinkRegisterControllerIntegrationTest extends MockMvcIntegrationT
 
     @BeforeEach
     void setUp(@Autowired WqLinkRegisterRepository wqLinkRegisterRepository) {
-        wqLinkRegisterRepository.deleteAll();
+        RepositoryUtil.clearUp(wqLinkRegisterRepository);
         wqLinkRegisterRepository.save(TestEntityDataBuilder.getWQLinkRegisterEntity(8064716));
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqoffence/WQOffenceControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqoffence/WQOffenceControllerIntegrationTest.java
@@ -5,6 +5,7 @@ import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.repository.WQOffenceRepository;
 import gov.uk.courtdata.util.MockMvcIntegrationTest;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -38,7 +39,7 @@ public class WQOffenceControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @AfterAll
     static void cleanUp(@Autowired WQOffenceRepository wqOffenceRepository) {
-        wqOffenceRepository.deleteAll();
+        RepositoryUtil.clearUp(wqOffenceRepository);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/job/QueueMessageMaintenanceSchedulerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/job/QueueMessageMaintenanceSchedulerTest.java
@@ -4,6 +4,7 @@ import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.entity.QueueMessageLogEntity;
 import gov.uk.courtdata.integration.MockServicesConfig;
 import gov.uk.courtdata.repository.QueueMessageLogRepository;
+import gov.uk.courtdata.util.RepositoryUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ public class QueueMessageMaintenanceSchedulerTest {
 
     @BeforeEach
     public void setUp() {
-        getQueueMessageLogRepository().deleteAll();
+        RepositoryUtil.clearUp(getQueueMessageLogRepository());
     }
 
     @Test
@@ -105,7 +106,7 @@ public class QueueMessageMaintenanceSchedulerTest {
 
     @AfterEach
     public void tearDown() {
-        getQueueMessageLogRepository().deleteAll();
+        RepositoryUtil.clearUp(getQueueMessageLogRepository());
     }
 
     private QueueMessageLogRepository getQueueMessageLogRepository() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/util/RepositoryUtil.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/util/RepositoryUtil.java
@@ -1,0 +1,25 @@
+package gov.uk.courtdata.util;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+@UtilityClass
+public class RepositoryUtil {
+
+    private static final Consumer<JpaRepository<?, ?>> DELETE_ALL_AND_FLUSH = repository -> {
+        repository.deleteAll();
+        repository.flush();
+    };
+
+    /**
+     * The responsibility of this method is to delete all and flush all entities within all the supplied repositories.
+     *
+     * @param repositories The repositories to be cleared
+     */
+    public void clearUp(JpaRepository<?, ?>... repositories) {
+        Arrays.stream(repositories).forEach(DELETE_ALL_AND_FLUSH);
+    }
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/util/RepositoryUtil.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/util/RepositoryUtil.java
@@ -9,7 +9,7 @@ import java.util.function.Consumer;
 @UtilityClass
 public class RepositoryUtil {
 
-    private static final Consumer<JpaRepository<?, ?>> DELETE_ALL_AND_FLUSH = repository -> {
+    private final Consumer<JpaRepository<?, ?>> DELETE_ALL_AND_FLUSH = repository -> {
         repository.deleteAll();
         repository.flush();
     };


### PR DESCRIPTION
## What

[[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)](https://dsdmoj.atlassian.net/browse/LASB-1982)

Describe what you did and why.

As illustrated by https://github.com/ministryofjustice/laa-maat-court-data-api/pull/739 there is a need to provide a standard and reusable way to correctly tear down/delete contents of all repositories in integration tests. This will reduce duplicate and boiler plate code and help ensure that all repositories are in a clean state following any integration test run.

Changes include:

- Add new Utility class and method `gov.uk.courtdata.util.RepositoryUtil.clearUp`
- Replace duplicated `deleteAll()` and `flush()` calls in tests with a single call to `RepositoryUtil.clearUp()`

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
