### PR TITLE
LASB-2419:Update config to one line as required by Cloud Formation

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -740,9 +740,7 @@ Resources:
       AccessLogSettings:
        DestinationArn: !GetAtt ApiGatewayCloudwatchLogGroup.Arn
        Format: >-
-        {"requestId":"$context.requestId","extendedRequestId":"$context.extendedRequestId","ip":"$context.identity.sourceIp",
-         "cognitoIdentityId":"$context.identity.cognitoIdentityId","cognitoIdentityPoolId":"$context.identity.cognitoIdentityPoolId",
-         "requestTime":"$context.requestTime","routeKey":"$context.routeKey","status":"$context.status"}
+        {"requestId":"$context.requestId","extendedRequestId":"$context.extendedRequestId","ip":"$context.identity.sourceIp","cognitoIdentityId":"$context.identity.cognitoIdentityId","cognitoIdentityPoolId":"$context.identity.cognitoIdentityPoolId","requestTime":"$context.requestTime","routeKey":"$context.routeKey","status":"$context.status"}
   ApiExternalDomainName:
     Type: 'AWS::ApiGatewayV2::DomainName'
     Properties:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/LASB/boards/454?selectedIssue=LASB-2419)

Updated gateway logging config to be on one line as this failed in cloud formation

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
