### PR TITLE
LCAM-1012: Removed the manual sonar scan from build.sh 

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,11 +6,6 @@ echo Building the ear file and Docker image with gradle...
 pushd maat-court-data-api
 chmod +x ./gradlew
 ./gradlew build
-./gradlew sonar \
-  -Dsonar.projectKey=ministryofjustice_laa-maat-court-data-api \
-  -Dsonar.host.url=https://sonarcloud.io \
-  -Dsonar.organization=ministryofjustice
-
 docker build -t maat-cda .
 docker tag maat-cda "${IMAGE_URI}"
 popd


### PR DESCRIPTION

## What

[LCAM-1012](https://dsdmoj.atlassian.net/browse/LCAM-1012)

Describe what you did and why.
- Removed the manual sonar scan from build.sh as it is done automatically on merge

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[LCAM-1012]: https://dsdmoj.atlassian.net/browse/LCAM-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ