### PR TITLE
[LASB-2681] CRUD functionality on the eforms_decision_history table

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryController.java
@@ -22,7 +22,7 @@ public class EformsDecisionHistoryController {
         return eformsDecisionHistoryService.getAllEformsDecisionHistory(usn);
     }
 
-    @GetMapping(value = "/{usn}/new")
+    @GetMapping(value = "/{usn}/latest-record")
     @StandardApiResponseCodes
     public EformsDecisionHistory getLatestEformsDecisionHistoryRecord(@PathVariable Integer usn) {
         return eformsDecisionHistoryService.getNewEformsDecisionHistoryRecord(usn);

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryController.java
@@ -1,0 +1,59 @@
+package gov.uk.courtdata.eform.controller;
+
+import gov.uk.courtdata.eform.repository.entity.EformsDecisionHistory;
+import gov.uk.courtdata.eform.service.EformsDecisionHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/eform/decision-history")
+public class EformsDecisionHistoryController {
+
+    private final EformsDecisionHistoryService eformsDecisionHistoryService;
+
+    @GetMapping(value = "/{usn}")
+    @StandardApiResponseCodes
+    public List<EformsDecisionHistory> getAllEformsDecisionHistory(@PathVariable Integer usn) {
+        return eformsDecisionHistoryService.getAllEformsDecisionHistory(usn);
+    }
+
+    @GetMapping(value = "/{usn}/new")
+    @StandardApiResponseCodes
+    public EformsDecisionHistory getLatestEformsDecisionHistoryRecord(@PathVariable Integer usn) {
+        return eformsDecisionHistoryService.getNewEformsDecisionHistoryRecord(usn);
+    }
+
+    @GetMapping(value = "/{usn}/previous-wrote-to-result")
+    @StandardApiResponseCodes
+    public EformsDecisionHistory getPreviousEformsDecisionHistoryRecordWroteToResult(@PathVariable Integer usn) {
+        return eformsDecisionHistoryService.getPreviousEformsDecisionHistoryRecordWroteToResult(usn);
+    }
+
+   @PostMapping
+    @StandardApiResponseCodes
+    public ResponseEntity<Void> createEformsDecisionHistory(@RequestBody EformsDecisionHistory eformsDecisionHistory) {
+        eformsDecisionHistoryService.createEformsDecisionHistory(eformsDecisionHistory);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping(value = "/{usn}")
+    @StandardApiResponseCodes
+    public ResponseEntity<Void> deleteEformsDecisionHistory(@PathVariable Integer usn) {
+        eformsDecisionHistoryService.deleteEformsDecisionHistory(usn);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping(value = "/{usn}")
+    @StandardApiResponseCodes
+    public ResponseEntity<Void> updateEformsDecisionHistoryFields(@PathVariable Integer usn,
+                                                                  @RequestBody Map<String, Object> updateFields) {
+        eformsDecisionHistoryService.updateEformsDecisionHistoryFields(usn, updateFields);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -51,8 +50,8 @@ public class EformsDecisionHistoryController {
     @PatchMapping(value = "/{usn}")
     @StandardApiResponseCodes
     public ResponseEntity<Void> updateEformsDecisionHistoryFields(@PathVariable Integer usn,
-                                                                  @RequestBody Map<String, Object> updateFields) {
-        eformsDecisionHistoryService.updateEformsDecisionHistoryFields(usn, updateFields);
+                                                                  @RequestBody EformsDecisionHistory eformsDecisionHistory) {
+        eformsDecisionHistoryService.updateEformsDecisionHistoryFields(usn, eformsDecisionHistory);
         return ResponseEntity.ok().build();
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/EformsDecisionHistoryRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/EformsDecisionHistoryRepository.java
@@ -1,0 +1,15 @@
+package gov.uk.courtdata.eform.repository;
+
+import gov.uk.courtdata.eform.repository.entity.EformsDecisionHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface EformsDecisionHistoryRepository extends JpaRepository<EformsDecisionHistory, Integer> {
+    List<EformsDecisionHistory> findAllByUsn(Integer usn);
+    void deleteAllByUsn(Integer usn);
+    EformsDecisionHistory findTopByUsnOrderByIdDesc(Integer usn);
+    EformsDecisionHistory findFirstByUsnAndWroteToResultsOrderByIdDesc(Integer usn, String wroteResult);
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsDecisionHistory.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsDecisionHistory.java
@@ -23,12 +23,12 @@ public class EformsDecisionHistory {
     @SequenceGenerator(name = "eforms_decision_history_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eforms_decision_history_seq")
     private Integer id;
-    @Column(name = "USN")
+    @Column(name = "USN", nullable = false)
     private Integer usn;
-    @Column(name = "REP_ID")
+    @Column(name = "REP_ID", nullable = false)
     private Integer repId;
     @CreationTimestamp
-    @Column(name = "DATE_RESULT_CREATED")
+    @Column(name = "DATE_RESULT_CREATED", nullable = false)
     private LocalDateTime dateResultCreated;
     @Column(name = "CASE_ID")
     private String caseId;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsDecisionHistory.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsDecisionHistory.java
@@ -1,10 +1,8 @@
 package gov.uk.courtdata.eform.repository.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -15,12 +13,15 @@ import java.time.LocalDateTime;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "EFORMS_DECISION_HISTORY", schema = "TOGDATA")
 public class EformsDecisionHistory {
 
     @Id
     @Column(name = "ID")
+    @SequenceGenerator(name = "eforms_decision_history_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eforms_decision_history_seq")
     private Integer id;
     @Column(name = "USN")
     private Integer usn;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsDecisionHistory.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsDecisionHistory.java
@@ -1,0 +1,76 @@
+package gov.uk.courtdata.eform.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "EFORMS_DECISION_HISTORY", schema = "TOGDATA")
+public class EformsDecisionHistory {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+    @Column(name = "USN")
+    private Integer usn;
+    @Column(name = "REP_ID")
+    private Integer repId;
+    @CreationTimestamp
+    @Column(name = "DATE_RESULT_CREATED")
+    private LocalDateTime dateResultCreated;
+    @Column(name = "CASE_ID")
+    private String caseId;
+    @Column(name = "DATE_APP_CREATED")
+    private LocalDate dateAppCreated;
+    @Column(name = "IOJ_RESULT")
+    private String iojResult;
+    @Column(name = "IOJ_ASSESSOR_NAME")
+    private String iojAssessorName;
+    @Column(name = "IOJ_REASON")
+    private String iojReason;
+    @Column(name = "MEANS_RESULT")
+    private String meansResult;
+    @Column(name = "MEANS_ASSESSOR_NAME")
+    private String meansAssessorName;
+    @Column(name = "DATE_MEANS_CREATED")
+    private LocalDate dateMeansCreated;
+    @Column(name = "FUNDING_DECISION")
+    private String fundingDecision;
+    @Column(name = "PASSPORT_RESULT")
+    private String passportResult;
+    @Column(name = "PASSPORT_ASSESSOR_NAME")
+    private String passportAssessorName;
+    @Column(name = "DATE_PASSPORT_CREATED")
+    private LocalDate datePassportCreated;
+    @Column(name = "DWP_RESULT")
+    private String dwpResult;
+    @Column(name = "IOJ_APPEAL_RESULT")
+    private String iojAppealResult;
+    @Column(name = "HARDSHIP_RESULT")
+    private String hardshipResult;
+    @Column(name = "CASE_TYPE")
+    private String caseType;
+    @Column(name = "REP_DECISION")
+    private String repDecision;
+    @Column(name = "CC_REP_DECISION")
+    private String ccRepDecision;
+    @Column(name = "ASSESSMENT_ID")
+    private Integer assessmentId;
+    @Column(name = "ASSESSMENT_TYPE")
+    private String assessmentType;
+    @Column(name = "WROTE_TO_RESULTS")
+    private String wroteToResults;
+    @Column(name = "MAGS_OUTCOME")
+    private String magsOutcome;
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/service/EformsDecisionHistoryService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/service/EformsDecisionHistoryService.java
@@ -16,12 +16,15 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class EformsDecisionHistoryService {
 
+    private static final String WROTE_TO_RESULT = "Y";
+
     private final EformsDecisionHistoryRepository eformsDecisionHistoryRepository;
 
     @Transactional
     public List<EformsDecisionHistory> getAllEformsDecisionHistory(Integer usn) {
         return eformsDecisionHistoryRepository.findAllByUsn(usn);
     }
+
     @Transactional
     public EformsDecisionHistory getNewEformsDecisionHistoryRecord(Integer usn) {
         return eformsDecisionHistoryRepository.findTopByUsnOrderByIdDesc(usn);
@@ -29,18 +32,21 @@ public class EformsDecisionHistoryService {
 
     @Transactional
     public EformsDecisionHistory getPreviousEformsDecisionHistoryRecordWroteToResult(Integer usn) {
-        return eformsDecisionHistoryRepository.findFirstByUsnAndWroteToResultsOrderByIdDesc(usn, "Y");
+        return eformsDecisionHistoryRepository.findFirstByUsnAndWroteToResultsOrderByIdDesc(usn, WROTE_TO_RESULT);
     }
 
-   public void createEformsDecisionHistory(EformsDecisionHistory eformsDecisionHistory) {
-        eformsDecisionHistoryRepository.save(eformsDecisionHistory);
+    @Transactional
+    public void createEformsDecisionHistory(EformsDecisionHistory eformsDecisionHistory) {
+        eformsDecisionHistoryRepository.saveAndFlush(eformsDecisionHistory);
     }
 
+    @Transactional
     public void deleteEformsDecisionHistory(Integer usn) {
         eformsDecisionHistoryRepository.deleteAllByUsn(usn);
     }
 
-   public void updateEformsDecisionHistoryFields(Integer usn, Map<String, Object> updateFields) {
+    @Transactional
+    public void updateEformsDecisionHistoryFields(Integer usn, Map<String, Object> updateFields) {
 
         Optional<EformsDecisionHistory> latestEformsDecisionHistory = Optional.ofNullable(eformsDecisionHistoryRepository.findTopByUsnOrderByIdDesc(usn));
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/service/EformsDecisionHistoryService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/service/EformsDecisionHistoryService.java
@@ -1,36 +1,40 @@
 package gov.uk.courtdata.eform.service;
 
+import gov.uk.courtdata.eform.exception.UsnException;
 import gov.uk.courtdata.eform.repository.EformsDecisionHistoryRepository;
 import gov.uk.courtdata.eform.repository.entity.EformsDecisionHistory;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EformsDecisionHistoryService {
 
     private static final String WROTE_TO_RESULT = "Y";
+    private static final String USN_NOT_FOUND = "The USN [%d] not found in Eforms Decision History table";
 
     private final EformsDecisionHistoryRepository eformsDecisionHistoryRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<EformsDecisionHistory> getAllEformsDecisionHistory(Integer usn) {
         return eformsDecisionHistoryRepository.findAllByUsn(usn);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public EformsDecisionHistory getNewEformsDecisionHistoryRecord(Integer usn) {
         return eformsDecisionHistoryRepository.findTopByUsnOrderByIdDesc(usn);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public EformsDecisionHistory getPreviousEformsDecisionHistoryRecordWroteToResult(Integer usn) {
         return eformsDecisionHistoryRepository.findFirstByUsnAndWroteToResultsOrderByIdDesc(usn, WROTE_TO_RESULT);
     }
@@ -46,17 +50,21 @@ public class EformsDecisionHistoryService {
     }
 
     @Transactional
-    public void updateEformsDecisionHistoryFields(Integer usn, Map<String, Object> updateFields) {
+    public void updateEformsDecisionHistoryFields(Integer usn, EformsDecisionHistory eformsDecisionHistory) {
 
         Optional<EformsDecisionHistory> latestEformsDecisionHistory = Optional.ofNullable(eformsDecisionHistoryRepository.findTopByUsnOrderByIdDesc(usn));
 
         if (latestEformsDecisionHistory.isPresent()) {
-            updateFields.forEach((key, value) -> {
-                Field field = ReflectionUtils.findField(EformsDecisionHistory.class, key);
-                field.setAccessible(true);
-                ReflectionUtils.setField(field, latestEformsDecisionHistory.get(), value);
-            });
+            for (Field declaredField : EformsDecisionHistory.class.getDeclaredFields()) {
+                ReflectionUtils.makeAccessible(declaredField);
+                Object fieldValue = ReflectionUtils.getField(declaredField, eformsDecisionHistory);
+                if (fieldValue != null) {
+                    ReflectionUtils.setField(declaredField, latestEformsDecisionHistory.get(), fieldValue);
+                }
+            }
             eformsDecisionHistoryRepository.save(latestEformsDecisionHistory.get());
+        } else {
+            throw new UsnException(HttpStatus.NOT_FOUND, String.format(USN_NOT_FOUND, usn));
         }
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/service/EformsDecisionHistoryService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/service/EformsDecisionHistoryService.java
@@ -1,0 +1,56 @@
+package gov.uk.courtdata.eform.service;
+
+import gov.uk.courtdata.eform.repository.EformsDecisionHistoryRepository;
+import gov.uk.courtdata.eform.repository.entity.EformsDecisionHistory;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EformsDecisionHistoryService {
+
+    private final EformsDecisionHistoryRepository eformsDecisionHistoryRepository;
+
+    @Transactional
+    public List<EformsDecisionHistory> getAllEformsDecisionHistory(Integer usn) {
+        return eformsDecisionHistoryRepository.findAllByUsn(usn);
+    }
+    @Transactional
+    public EformsDecisionHistory getNewEformsDecisionHistoryRecord(Integer usn) {
+        return eformsDecisionHistoryRepository.findTopByUsnOrderByIdDesc(usn);
+    }
+
+    @Transactional
+    public EformsDecisionHistory getPreviousEformsDecisionHistoryRecordWroteToResult(Integer usn) {
+        return eformsDecisionHistoryRepository.findFirstByUsnAndWroteToResultsOrderByIdDesc(usn, "Y");
+    }
+
+   public void createEformsDecisionHistory(EformsDecisionHistory eformsDecisionHistory) {
+        eformsDecisionHistoryRepository.save(eformsDecisionHistory);
+    }
+
+    public void deleteEformsDecisionHistory(Integer usn) {
+        eformsDecisionHistoryRepository.deleteAllByUsn(usn);
+    }
+
+   public void updateEformsDecisionHistoryFields(Integer usn, Map<String, Object> updateFields) {
+
+        Optional<EformsDecisionHistory> latestEformsDecisionHistory = Optional.ofNullable(eformsDecisionHistoryRepository.findTopByUsnOrderByIdDesc(usn));
+
+        if (latestEformsDecisionHistory.isPresent()) {
+            updateFields.forEach((key, value) -> {
+                Field field = ReflectionUtils.findField(EformsDecisionHistory.class, key);
+                field.setAccessible(true);
+                ReflectionUtils.setField(field, latestEformsDecisionHistory.get(), value);
+            });
+            eformsDecisionHistoryRepository.save(latestEformsDecisionHistory.get());
+        }
+    }
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryControllerTest.java
@@ -1,0 +1,80 @@
+package gov.uk.courtdata.eform.controller;
+
+
+import gov.uk.courtdata.eform.repository.entity.EformsDecisionHistory;
+import gov.uk.courtdata.eform.service.EformsDecisionHistoryService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(EformsDecisionHistoryController.class)
+public class EformsDecisionHistoryControllerTest {
+
+    private static final String ENDPOINT_FORMAT = "/api/eform/decision-history";
+    private static final int USN = 123;
+
+    @MockBean
+    private EformsDecisionHistoryService eformsDecisionHistoryService;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void shouldSuccessfullyGetEformApplication() throws Exception {
+        EformsDecisionHistory eformsDecisionHistory = EformsDecisionHistory.builder().id(1).usn(USN).repId(45635).fundingDecision("Granted").iojResult("Pass").build();
+        List<EformsDecisionHistory> eformsDecisionHistoryList = List.of(eformsDecisionHistory);
+        when(eformsDecisionHistoryService.getAllEformsDecisionHistory(USN))
+                .thenReturn(eformsDecisionHistoryList);
+
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_FORMAT+ "/" +123)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json("["+responseEformsDecisionHistory()+"]"));
+        verify(eformsDecisionHistoryService, times(1)).getAllEformsDecisionHistory(USN);
+    }
+
+    private String responseEformsDecisionHistory(){
+        return "{\n" +
+                "  \"id\": 1,\n" +
+                "  \"usn\": 123,\n" +
+                "  \"repId\": 45635,\n" +
+                "  \"dateResultCreated\": null,\n" +
+                "  \"caseId\": null,\n" +
+                "  \"dateAppCreated\": null,\n" +
+                "  \"iojResult\": \"Pass\",\n" +
+                "  \"iojAssessorName\": null,\n" +
+                "  \"iojReason\": null,\n" +
+                "  \"meansResult\": null,\n" +
+                "  \"meansAssessorName\": null,\n" +
+                "  \"dateMeansCreated\": null,\n" +
+                "  \"fundingDecision\": \"Granted\",\n" +
+                "  \"passportResult\": null,\n" +
+                "  \"passportAssessorName\": null,\n" +
+                "  \"datePassportCreated\": null,\n" +
+                "  \"dwpResult\": null,\n" +
+                "  \"iojAppealResult\": null,\n" +
+                "  \"hardshipResult\": null,\n" +
+                "  \"caseType\": null,\n" +
+                "  \"repDecision\": null,\n" +
+                "  \"ccRepDecision\": null,\n" +
+                "  \"assessmentId\": null,\n" +
+                "  \"assessmentType\": null,\n" +
+                "  \"wroteToResults\": null,\n" +
+                "  \"magsOutcome\": null\n" +
+                "}";
+    }
+
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryControllerTest.java
@@ -39,7 +39,7 @@ public class EformsDecisionHistoryControllerTest {
         when(eformsDecisionHistoryService.getNewEformsDecisionHistoryRecord(12345))
                 .thenReturn(eformsDecisionHistory);
 
-        mvc.perform(MockMvcRequestBuilders.get(BASE_ENDPOINT_FORMAT+ "/" +12345+"/new")
+        mvc.perform(MockMvcRequestBuilders.get(BASE_ENDPOINT_FORMAT+ "/" +12345+"/latest-record")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.usn").value(String.valueOf(12345)))

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryControllerTest.java
@@ -1,6 +1,5 @@
 package gov.uk.courtdata.eform.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.uk.courtdata.eform.repository.entity.EformsDecisionHistory;
 import gov.uk.courtdata.eform.service.EformsDecisionHistoryService;
 import org.junit.jupiter.api.Test;
@@ -13,9 +12,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -83,13 +80,12 @@ public class EformsDecisionHistoryControllerTest {
 
     @Test
     void shouldSuccessfullyUpdateEformDecisionHistory() throws Exception {
-        EformsDecisionHistory eformsDecisionHistory = EformsDecisionHistory.builder().id(3).usn(12345).repId(45635).fundingDecision("Granted").iojResult("Pass").build();
+        EformsDecisionHistory eformsDecisionHistory = EformsDecisionHistory.builder().wroteToResults("Y").build();
         String requestJson = "{\"wroteToResults\":\"Y\"}";
-        Map<String,Object> updateFields = new ObjectMapper().readValue(requestJson, HashMap.class);
         mvc.perform(MockMvcRequestBuilders.patch(BASE_ENDPOINT_FORMAT+ "/" +12345).content(requestJson)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
-        verify(eformsDecisionHistoryService, times(1)).updateEformsDecisionHistoryFields(12345, updateFields);
+        verify(eformsDecisionHistoryService, times(1)).updateEformsDecisionHistoryFields(12345, eformsDecisionHistory);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformsDecisionHistoryServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformsDecisionHistoryServiceTest.java
@@ -1,0 +1,77 @@
+package gov.uk.courtdata.eform.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.uk.courtdata.eform.repository.EformsDecisionHistoryRepository;
+import gov.uk.courtdata.eform.repository.entity.EformsDecisionHistory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EformsDecisionHistoryServiceTest {
+
+    @InjectMocks
+    private EformsDecisionHistoryService eformsDecisionHistoryService;
+    @Mock
+    private EformsDecisionHistoryRepository eformsDecisionHistoryRepository;
+
+    @Test
+    void shouldRetrieveEformDecisionHistoryForGivenUSN() {
+        EformsDecisionHistory eformsDecisionHistory = EformsDecisionHistory.builder().id(1).usn(123).build();
+        List<EformsDecisionHistory> eformsDecisionHistoryList = List.of(eformsDecisionHistory);
+        when(eformsDecisionHistoryRepository.findAllByUsn(anyInt())).thenReturn(eformsDecisionHistoryList);
+        eformsDecisionHistoryService.getAllEformsDecisionHistory(anyInt());
+        verify(eformsDecisionHistoryRepository).findAllByUsn(anyInt());
+    }
+
+    @Test
+    void shouldRetrieveLatestEformDecisionHistoryForGivenUSN() {
+        EformsDecisionHistory eformsDecisionHistory = EformsDecisionHistory.builder().id(1).usn(123).build();
+        when(eformsDecisionHistoryRepository.findTopByUsnOrderByIdDesc(anyInt())).thenReturn(eformsDecisionHistory);
+        eformsDecisionHistoryService.getNewEformsDecisionHistoryRecord(anyInt());
+        verify(eformsDecisionHistoryRepository).findTopByUsnOrderByIdDesc(anyInt());
+    }
+
+    @Test
+    void shouldRetrievePreviousEformsDecisionHistoryRecordWroteToResultForGivenUSN() {
+        EformsDecisionHistory eformsDecisionHistory = EformsDecisionHistory.builder().id(1).usn(123).wroteToResults("Y").build();
+        when(eformsDecisionHistoryRepository.findFirstByUsnAndWroteToResultsOrderByIdDesc(123, "Y")).thenReturn(eformsDecisionHistory);
+        eformsDecisionHistoryService.getPreviousEformsDecisionHistoryRecordWroteToResult(123);
+        verify(eformsDecisionHistoryRepository).findFirstByUsnAndWroteToResultsOrderByIdDesc(123, "Y");
+    }
+
+    @Test
+    void shouldCreateEformsDecisionHistoryRecordForGivenUSN() {
+        EformsDecisionHistory eformsDecisionHistory = EformsDecisionHistory.builder().id(1).usn(123).build();
+        eformsDecisionHistoryService.createEformsDecisionHistory(eformsDecisionHistory);
+        verify(eformsDecisionHistoryRepository).saveAndFlush(eformsDecisionHistory);
+    }
+
+    @Test
+    void shouldDeleteEformsDecisionHistoryRecordForGivenUSN() {
+        eformsDecisionHistoryService.deleteEformsDecisionHistory(anyInt());
+        verify(eformsDecisionHistoryRepository).deleteAllByUsn(anyInt());
+    }
+
+    @Test
+    void shouldUpdateEformsDecisionHistoryRecordForGivenUSN() throws JsonProcessingException {
+        EformsDecisionHistory eformsDecisionHistory = EformsDecisionHistory.builder().id(1).usn(123).build();
+        String requestJson = "{\"wroteToResults\":\"Y\"}";
+        Map<String, Object> updateFields = new ObjectMapper().readValue(requestJson, HashMap.class);
+        when(eformsDecisionHistoryRepository.findTopByUsnOrderByIdDesc(anyInt())).thenReturn(eformsDecisionHistory);
+        eformsDecisionHistoryService.updateEformsDecisionHistoryFields(anyInt(), updateFields);
+        verify(eformsDecisionHistoryRepository).findTopByUsnOrderByIdDesc(anyInt());
+        verify(eformsDecisionHistoryRepository).save(eformsDecisionHistory);
+    }
+}


### PR DESCRIPTION
## What

[LASB-2681](https://dsdmoj.atlassian.net/browse/LASB-2681)

Adding endpoints to allow CRUD functionality on the eforms_decision_history table

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[LASB-2681]: https://dsdmoj.atlassian.net/browse/LASB-2681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ