### PR TITLE
[LASB-2680] CRUD functionality on the eforms_history table

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/controller/EformsHistoryController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/controller/EformsHistoryController.java
@@ -1,0 +1,43 @@
+package gov.uk.courtdata.eform.controller;
+
+import gov.uk.courtdata.eform.repository.entity.EformsHistory;
+import gov.uk.courtdata.eform.service.EformsHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/eform/history")
+public class EformsHistoryController {
+
+    private final EformsHistoryService eformsHistoryService;
+
+    @GetMapping(value = "/{usn}")
+    @StandardApiResponseCodes
+    public List<EformsHistory> getAllEformsDecisionHistory(@PathVariable Integer usn) {
+        return eformsHistoryService.getAllEformsHistory(usn);
+    }
+
+    @GetMapping(value = "/{usn}/latest-record")
+    @StandardApiResponseCodes
+    public EformsHistory getLatestEformsHistoryRecord(@PathVariable Integer usn) {
+        return eformsHistoryService.getLatestEformsHistoryRecord(usn);
+    }
+
+    @PostMapping
+    @StandardApiResponseCodes
+    public ResponseEntity<Void> createEformsHistory(@RequestBody EformsHistory eformsHistory) {
+        eformsHistoryService.createEformsHistory(eformsHistory);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping(value = "/{usn}")
+    @StandardApiResponseCodes
+    public ResponseEntity<Void> deleteEformsHistory(@PathVariable Integer usn) {
+        eformsHistoryService.deleteEformsHistory(usn);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/EformsHistoryRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/EformsHistoryRepository.java
@@ -1,0 +1,16 @@
+package gov.uk.courtdata.eform.repository;
+
+import gov.uk.courtdata.eform.repository.entity.EformsHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface EformsHistoryRepository extends JpaRepository<EformsHistory, Integer> {
+
+    List<EformsHistory> findAllByUsn(Integer usn);
+    EformsHistory findTopByUsnOrderByIdDesc(Integer usn);
+    void deleteAllByUsn(Integer usn);
+
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsHistory.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsHistory.java
@@ -1,0 +1,37 @@
+package gov.uk.courtdata.eform.repository.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "EFORMS_HISTORY", schema = "TOGDATA")
+public class EformsHistory {
+    @Id
+    @Column(name = "ID")
+    @SequenceGenerator(name = "eforms_history_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eforms_history_seq")
+    private Integer id;
+    @Column(name = "USN", nullable = false)
+    private Integer usn;
+    @Column(name = "REP_ID")
+    private Integer repId;
+    @Column(name = "ACTION")
+    private String action;
+    @Column(name = "KEY_ID")
+    private Integer keyId;
+    @CreationTimestamp
+    @Column(name = "DATE_CREATED", nullable = false)
+    private LocalDateTime dateCreated;
+    @Column(name = "USER_CREATED", nullable = false)
+    private String userCreated;
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsHistory.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/repository/entity/EformsHistory.java
@@ -32,6 +32,6 @@ public class EformsHistory {
     @CreationTimestamp
     @Column(name = "DATE_CREATED", nullable = false)
     private LocalDateTime dateCreated;
-    @Column(name = "USER_CREATED", nullable = false)
+    @Column(name = "USER_CREATED")
     private String userCreated;
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/service/EformsHistoryService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/eform/service/EformsHistoryService.java
@@ -1,0 +1,35 @@
+package gov.uk.courtdata.eform.service;
+
+import gov.uk.courtdata.eform.repository.EformsHistoryRepository;
+import gov.uk.courtdata.eform.repository.entity.EformsHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EformsHistoryService {
+
+   private final EformsHistoryRepository eformsHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<EformsHistory> getAllEformsHistory(Integer usn) {
+        return eformsHistoryRepository.findAllByUsn(usn);
+    }
+    @Transactional(readOnly = true)
+    public EformsHistory getLatestEformsHistoryRecord(Integer usn) {
+        return eformsHistoryRepository.findTopByUsnOrderByIdDesc(usn);
+    }
+
+    @Transactional
+    public void createEformsHistory(EformsHistory eformsHistory) {
+        eformsHistoryRepository.saveAndFlush(eformsHistory);
+    }
+
+    @Transactional
+    public void deleteEformsHistory(Integer usn) {
+        eformsHistoryRepository.deleteAllByUsn(usn);
+    }
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsHistoryControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsHistoryControllerTest.java
@@ -1,0 +1,95 @@
+package gov.uk.courtdata.eform.controller;
+
+import gov.uk.courtdata.eform.repository.entity.EformsHistory;
+import gov.uk.courtdata.eform.service.EformsHistoryService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(EformsHistoryController.class)
+public class EformsHistoryControllerTest {
+
+    private static final String BASE_ENDPOINT_FORMAT = "/api/eform/history";
+
+    @MockBean
+    private EformsHistoryService eformsHistoryService;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void shouldSuccessfullyGetNewEformHistoryRecordForGivenUSN() throws Exception {
+        EformsHistory eformsHistory = EformsHistory.builder().id(1).usn(12345).action("Get").build();
+
+        when(eformsHistoryService.getLatestEformsHistoryRecord(12345))
+                .thenReturn(eformsHistory);
+
+        mvc.perform(MockMvcRequestBuilders.get(BASE_ENDPOINT_FORMAT+ "/" +12345+"/latest-record")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.usn").value(String.valueOf(12345)))
+                .andExpect(jsonPath("$.action").value(String.valueOf("Get")));
+
+        verify(eformsHistoryService, times(1)).getLatestEformsHistoryRecord(12345);
+    }
+
+    @Test
+    void shouldSuccessfullyDeleteEformHistoryForGivenUSN() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.delete(BASE_ENDPOINT_FORMAT+ "/" +12345)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(eformsHistoryService, times(1)).deleteEformsHistory(12345);
+    }
+
+     @Test
+    void shouldSuccessfullyCreateEformDecisionHistory() throws Exception {
+         EformsHistory eformsHistory = EformsHistory.builder().id(2).usn(123).action("Get").userCreated("test").build();
+        mvc.perform(MockMvcRequestBuilders.post(BASE_ENDPOINT_FORMAT).content(eformsHistory())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+        verify(eformsHistoryService, times(1)).createEformsHistory(eformsHistory);
+    }
+
+
+    @Test
+    void shouldSuccessfullyGetAllEformHistoryForGivenUSN() throws Exception {
+        EformsHistory eformsHistory = EformsHistory.builder().id(2).usn(123).action("Get").userCreated("test").build();
+        List<EformsHistory> eformsHistoryList = List.of(eformsHistory);
+        when(eformsHistoryService.getAllEformsHistory(123))
+                .thenReturn(eformsHistoryList);
+
+        mvc.perform(MockMvcRequestBuilders.get(BASE_ENDPOINT_FORMAT+ "/" +123)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json("["+eformsHistory()+"]"));
+        verify(eformsHistoryService, times(1)).getAllEformsHistory(123);
+    }
+
+    private String eformsHistory(){
+        return "{\n" +
+                "  \"id\": 2,\n" +
+                "  \"usn\": 123,\n" +
+                "  \"repId\": null,\n" +
+                "  \"action\": \"Get\",\n" +
+                "  \"keyId\": null,\n" +
+                "  \"dateCreated\": null,\n" +
+                "  \"userCreated\": \"test\"\n" +
+                "}";
+    }
+
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformsHistoryServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformsHistoryServiceTest.java
@@ -1,0 +1,54 @@
+package gov.uk.courtdata.eform.service;
+
+import gov.uk.courtdata.eform.repository.EformsHistoryRepository;
+import gov.uk.courtdata.eform.repository.entity.EformsHistory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class EformsHistoryServiceTest {
+
+    @InjectMocks
+    private EformsHistoryService eformsHistoryService;
+    @Mock
+    private EformsHistoryRepository eformsHistoryRepository;
+
+    @Test
+    void shouldRetrieveEformDecisionHistoryForGivenUSN() {
+        EformsHistory eformsHistory = EformsHistory.builder().id(1).usn(123).action("Get").userCreated("test").build();
+        List<EformsHistory> eformsHistoryList = List.of(eformsHistory);
+        when(eformsHistoryRepository.findAllByUsn(anyInt())).thenReturn(eformsHistoryList);
+        eformsHistoryService.getAllEformsHistory(anyInt());
+        verify(eformsHistoryRepository, times(1)).findAllByUsn(anyInt());
+    }
+
+    @Test
+    void shouldRetrieveLatestEformDecisionHistoryForGivenUSN() {
+        EformsHistory eformsHistory = EformsHistory.builder().id(1).usn(123).action("Get").userCreated("test").build();
+        when(eformsHistoryRepository.findTopByUsnOrderByIdDesc(anyInt())).thenReturn(eformsHistory);
+        eformsHistoryService.getLatestEformsHistoryRecord(anyInt());
+        verify(eformsHistoryRepository, times(1)).findTopByUsnOrderByIdDesc(anyInt());
+    }
+
+    @Test
+    void shouldCreateEformsDecisionHistoryRecordForGivenUSN() {
+        EformsHistory eformsHistory = EformsHistory.builder().id(1).usn(123).action("Get").userCreated("test").build();
+        eformsHistoryService.createEformsHistory(eformsHistory);
+        verify(eformsHistoryRepository, times(1)).saveAndFlush(eformsHistory);
+    }
+
+    @Test
+    void shouldDeleteEformsDecisionHistoryRecordForGivenUSN() {
+        eformsHistoryService.deleteEformsHistory(anyInt());
+        verify(eformsHistoryRepository, times(1)).deleteAllByUsn(anyInt());
+    }
+
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformsHistoryServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformsHistoryServiceTest.java
@@ -33,9 +33,9 @@ public class EformsHistoryServiceTest {
     @Test
     void shouldRetrieveLatestEformDecisionHistoryForGivenUSN() {
         EformsHistory eformsHistory = EformsHistory.builder().id(1).usn(123).action("Get").userCreated("test").build();
-        when(eformsHistoryRepository.findTopByUsnOrderByIdDesc(anyInt())).thenReturn(eformsHistory);
-        eformsHistoryService.getLatestEformsHistoryRecord(anyInt());
-        verify(eformsHistoryRepository, times(1)).findTopByUsnOrderByIdDesc(anyInt());
+        when(eformsHistoryRepository.findTopByUsnOrderByIdDesc(123)).thenReturn(eformsHistory);
+        eformsHistoryService.getLatestEformsHistoryRecord(123);
+        verify(eformsHistoryRepository, times(1)).findTopByUsnOrderByIdDesc(123);
     }
 
     @Test


### PR DESCRIPTION
## What

[LASB-2680](https://dsdmoj.atlassian.net/browse/LASB-2680)

CRUD functionality on the eforms_history table

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[LASB-2680]: https://dsdmoj.atlassian.net/browse/LASB-2680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ