### PR TITLE
LASB-1718 - DART_QUERY schema permissions

### DIFF
--- a/maat-court-data-api/src/main/resources/db/changelog/changes/lasb_1718_grant_dart_read_permissions.sql
+++ b/maat-court-data-api/src/main/resources/db/changelog/changes/lasb_1718_grant_dart_read_permissions.sql
@@ -1,0 +1,22 @@
+-- We haven't included it here as we don't want a password being committed, but you need to create
+-- the user before running the script below.
+
+GRANT CREATE SESSION to DART_QUERY;
+commit;
+
+BEGIN
+    -- Add TOGDATA permissions
+    FOR t IN (SELECT table_name FROM dba_tables WHERE owner = 'TOGDATA') LOOP
+        EXECUTE IMMEDIATE 'GRANT SELECT ON TOGDATA.' || t.table_name || ' TO DART_QUERY';
+    END LOOP;
+
+    -- Add MLA permissions
+    FOR t IN (SELECT table_name FROM dba_tables WHERE owner = 'MLA') LOOP
+        EXECUTE IMMEDIATE 'GRANT SELECT ON MLA.' || t.table_name || ' TO DART_QUERY';
+    END LOOP;
+END;
+
+
+
+
+

--- a/maat-court-data-api/src/main/resources/db/changelog/changes/lasb_1718_grant_dart_read_permissions_rollback.sql
+++ b/maat-court-data-api/src/main/resources/db/changelog/changes/lasb_1718_grant_dart_read_permissions_rollback.sql
@@ -1,0 +1,14 @@
+REVOKE CREATE SESSION FROM DART_QUERY;
+commit;
+
+BEGIN
+    -- Remove TOGDATA permissions
+    FOR t IN (SELECT table_name FROM DBA_TAB_PRIVS WHERE GRANTEE = 'DART_QUERY' AND owner = 'TOGDATA') LOOP
+        EXECUTE IMMEDIATE 'REVOKE SELECT ON TOGDATA.' || t.table_name || ' FROM DART_QUERY';
+    END LOOP;
+
+    -- Remove MLA permissions
+    FOR t IN (SELECT table_name FROM DBA_TAB_PRIVS WHERE GRANTEE = 'DART_QUERY' AND owner = 'MLA') LOOP
+        EXECUTE IMMEDIATE 'REVOKE SELECT ON MLA.' || t.table_name || ' FROM DART_QUERY';
+    END LOOP;
+END;


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1718)

Added permissions for the DART_QUERY user to the database changelog as a record of the commands that have now been run on production.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
