### PR TITLE
LASB-2810: Add missing parameter store permission

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -473,6 +473,7 @@ Resources:
               Resource:
                 - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/maat-cd-api/*'
                 - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/APP_MAATDB_DBPASSWORD_MLA1'
+                - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/APP_MAATDB_DBPASSWORD_TOGDATA'
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-2810)

- [x] Added permissions for the ECS task execution role to access the required togdata credentials from the AWS parameter store. This is related to LCAM-1025 but is blocking the deployment of the LASB-2810 changes.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
