### PR TITLE
LCAM-1207

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/applicant/entity/ApplicantHistoryEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/applicant/entity/ApplicantHistoryEntity.java
@@ -116,11 +116,12 @@ public class ApplicantHistoryEntity {
     @Column(name = "PHONE_WORK")
     private String phoneWork;
 
+    @Builder.Default
     @ToString.Exclude
     @Fetch(FetchMode.JOIN)
     @JsonManagedReference
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "APHI_ID", nullable = false)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<ApplicantHistoryDisability> applicantHistoryDisabilities = new LinkedHashSet<>();
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/ApplicantConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/ApplicantConvertor.java
@@ -85,7 +85,7 @@ public class ApplicantConvertor extends Convertor
 		{
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 
-			getDTO().setTimestamp(					getOracleType().getTimeStamp());
+			getDTO().setTimestamp(					convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 			getDTO().setId(							convertorHelper.toSysGenLong( 	getOracleType().getApplId() ));
 			getDTO().setApplicantHistoryId(			convertorHelper.toLong( 	getOracleType().getAphiId() ));
 			getDTO().setDob(						convertorHelper.toDate(		getOracleType().getDob() ));
@@ -188,7 +188,7 @@ public class ApplicantConvertor extends Convertor
 			setDTO( dto );	// if the dto class type is not right for this conversion an exception is thrown
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 			
-	        getOracleType().setTimeStamp(          	getDTO().getTimestamp());	
+	        getOracleType().setTimeStamp(          	convertorHelper.toTimestamp(getDTO().getTimestamp()));
 			getOracleType().setApplId( 				convertorHelper.toSysGenLong( 	getDTO().getId() ) );
 			getOracleType().setAphiId( 				convertorHelper.toLong( 	getDTO().getApplicantHistoryId() ) );
 			getOracleType().setDob(					convertorHelper.toDate(		getDTO().getDob() ));

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/ApplicantConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/ApplicantConvertor.java
@@ -86,7 +86,7 @@ public class ApplicantConvertor extends Convertor
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 
 			getDTO().setTimestamp(					convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
-			getDTO().setId(							convertorHelper.toSysGenLong( 	getOracleType().getApplId() ));
+			getDTO().setId(							convertorHelper.toLong( 	getOracleType().getApplId() ));
 			getDTO().setApplicantHistoryId(			convertorHelper.toLong( 	getOracleType().getAphiId() ));
 			getDTO().setDob(						convertorHelper.toDate(		getOracleType().getDob() ));
 			getDTO().setEmail(						convertorHelper.toString(	getOracleType().getEmail() ));
@@ -189,7 +189,7 @@ public class ApplicantConvertor extends Convertor
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 			
 	        getOracleType().setTimeStamp(          	convertorHelper.toTimestamp(getDTO().getTimestamp()));
-			getOracleType().setApplId( 				convertorHelper.toSysGenLong( 	getDTO().getId() ) );
+			getOracleType().setApplId( 				convertorHelper.toLong( 	getDTO().getId() ) );
 			getOracleType().setAphiId( 				convertorHelper.toLong( 	getDTO().getApplicantHistoryId() ) );
 			getOracleType().setDob(					convertorHelper.toDate(		getDTO().getDob() ));
 			getOracleType().setEmail(				convertorHelper.toString(	getDTO().getEmail() ));

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/ApplicationConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/ApplicationConvertor.java
@@ -86,7 +86,7 @@ public class ApplicationConvertor extends Convertor
 		try
 		{
 			ConvertorHelper convertorHelper = new ConvertorHelper();
-			getDTO().setTimestamp(				getOracleType().getTimeStamp() );
+			getDTO().setTimestamp(				convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 			
 			getDTO().setRepId(					convertorHelper.toLong( 	getOracleType().getRepId() ));
 			getDTO().setAreaId(					convertorHelper.toLong( 	getOracleType().getAreaId() ));
@@ -320,7 +320,7 @@ public class ApplicationConvertor extends Convertor
 			setType( null );	// force new type to be instantiated 
 			setDTO( dto );	
 			ConvertorHelper convertorHelper 			= new ConvertorHelper();
-			getOracleType().setTimeStamp(				getDTO().getTimestamp() );
+			getOracleType().setTimeStamp(				convertorHelper.toTimestamp(getDTO().getTimestamp()));
 			
 			getOracleType().setRepId( 					convertorHelper.toLong( 	getDTO().getRepId() ) );
 			getOracleType().setAreaId(					convertorHelper.toLong( 	getDTO().getAreaId() ));

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/AssessmentDetailConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/AssessmentDetailConvertor.java
@@ -60,7 +60,7 @@ public class AssessmentDetailConvertor extends Convertor {
 			getDTO().setDescription(		convertorHelper.toString(getOracleType().getDescription()));
 			getDTO().setDetailCode(			convertorHelper.toString(getOracleType().getDetailCode()));
 			
-			getDTO().setTimestamp(			getOracleType().getTimeStamp());
+			getDTO().setTimestamp(			convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 			
 			FrequencyType applicantfreqType = getOracleType().getApplicantFreqObject();
 			FrequencyConvertor frequencyConverter = new FrequencyConvertor();
@@ -91,7 +91,7 @@ public class AssessmentDetailConvertor extends Convertor {
 	        getOracleType().setDescription(        convertorHelper.toString(getDTO().getDescription()));	                       
 	        getOracleType().setDetailCode(         convertorHelper.toString(getDTO().getDetailCode()));	                       
 	        getOracleType().setPartnerAmount(      convertorHelper.toDouble(getDTO().getPartnerAmount()));
-	        getOracleType().setTimeStamp(          getDTO().getTimestamp());	
+	        getOracleType().setTimeStamp(          convertorHelper.toTimestamp(getDTO().getTimestamp()));
 	        
 			FrequencyConvertor frequencyConverter = new FrequencyConvertor();
 			if(getDTO().getApplicantFrequency() != null)

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/CapitalEquityConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/CapitalEquityConvertor.java
@@ -83,15 +83,15 @@ public class CapitalEquityConvertor extends Convertor
 		{
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 			
-			getDTO().setAvailable(					convertorHelper.toBoolean(	getOracleType().getAvailable()));
-			getDTO().setNoCapitalDeclared(			convertorHelper.toBoolean( 	getOracleType().getNoCapitalDeclared()    	));
-			getDTO().setSuffientVeriToCoverCase( 	convertorHelper.toBoolean( 	getOracleType().getSufficientVeriToCoverCase() 	));
-			getDTO().setVerifiedEquityToCoverCase( 	convertorHelper.toBoolean( 	getOracleType().getVerifiedEquityToCoverCase()   	));
-			getDTO().setSuffientDeclToCoverCase( 	convertorHelper.toBoolean( 	getOracleType().getSufficientDeclToCoverCase() 	));
-			getDTO().setDeclaredEquityToCoverCase( 	convertorHelper.toBoolean( 	getOracleType().getDeclaredEquityToCoverCase()   	));
-			getDTO().setTotalCapital(				convertorHelper.toSysGenCurrency(	getOracleType().getTotalCapital() 			));
-			getDTO().setTotalEquity(				convertorHelper.toCurrency(	getOracleType().getTotalEquity() 			));
-			getDTO().setTotalCapitalAndEquity(		convertorHelper.toCurrency(	getOracleType().getTotalCapitalAndEquity()	));
+			getDTO().setAvailable(					convertorHelper.toBoolean(getOracleType().getAvailable()));
+			getDTO().setNoCapitalDeclared(			convertorHelper.toBoolean( getOracleType().getNoCapitalDeclared()));
+			getDTO().setSuffientVeriToCoverCase( 	convertorHelper.toBoolean( getOracleType().getSufficientVeriToCoverCase()));
+			getDTO().setVerifiedEquityToCoverCase( 	convertorHelper.toBoolean( getOracleType().getVerifiedEquityToCoverCase()));
+			getDTO().setSuffientDeclToCoverCase( 	convertorHelper.toBoolean( getOracleType().getSufficientDeclToCoverCase()));
+			getDTO().setDeclaredEquityToCoverCase( 	convertorHelper.toBoolean( getOracleType().getDeclaredEquityToCoverCase()));
+			getDTO().setTotalCapital(				getOracleType().getTotalCapital());
+			getDTO().setTotalEquity(				getOracleType().getTotalEquity());
+			getDTO().setTotalCapitalAndEquity(		getOracleType().getTotalCapitalAndEquity());
 			
 			
 			/*

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/ContributionsConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/ContributionsConvertor.java
@@ -76,14 +76,14 @@ public class ContributionsConvertor extends Convertor
 		{
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 	
-			getDTO().setId(					convertorHelper.toLong( 	getOracleType().getId()    				));
-			getDTO().setMonthlyContribs(	convertorHelper.toSysGenCurrency( 	getOracleType().getMonthlyContribs()    ));
-			getDTO().setUpfrontContribs(	convertorHelper.toSysGenCurrency( 	getOracleType().getUpfrontContribs()	));
-			getDTO().setEffectiveDate( 		convertorHelper.toSysGenDate( 	getOracleType().getEffectiveDate()  	));
-			getDTO().setCalcDate(			convertorHelper.toSysGenDate(		getOracleType().getCalcDate()			));
-			getDTO().setCapped(				convertorHelper.toSysGenCurrency(	getOracleType().getContributionCap()	));
-			getDTO().setUpliftApplied(		convertorHelper.toBoolean(	getOracleType().getUpliftApplied()		));
-			getDTO().setBasedOn(			convertorHelper.toSysGenString(	getOracleType().getBasedOn()			));
+			getDTO().setId(convertorHelper.toLong(getOracleType().getId()));
+			getDTO().setMonthlyContribs(getOracleType().getMonthlyContribs());
+			getDTO().setUpfrontContribs(getOracleType().getUpfrontContribs());
+			getDTO().setEffectiveDate(convertorHelper.toSysGenDate(getOracleType().getEffectiveDate()));
+			getDTO().setCalcDate(convertorHelper.toSysGenDate(getOracleType().getCalcDate()));
+			getDTO().setCapped(getOracleType().getContributionCap());
+			getDTO().setUpliftApplied(convertorHelper.toBoolean(getOracleType().getUpliftApplied()));
+			getDTO().setBasedOn(convertorHelper.toSysGenString(getOracleType().getBasedOn()));
 		}
 		catch (NullPointerException nex)
 		{
@@ -114,14 +114,14 @@ public class ContributionsConvertor extends Convertor
 			setDTO( dto );
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 
-			getOracleType().setId(					convertorHelper.toLong( 	getDTO().getId()    			));
-			getOracleType().setMonthlyContribs(	    convertorHelper.toSysGenCurrency( 	getDTO().getMonthlyContribs()   ));
-			getOracleType().setUpfrontContribs(	    convertorHelper.toSysGenCurrency( 	getDTO().getUpfrontContribs()	));
-			getOracleType().setEffectiveDate( 		convertorHelper.toSysGenDate( 	getDTO().getEffectiveDate()  	));
-			getOracleType().setCalcDate(			convertorHelper.toSysGenDate(		getDTO().getCalcDate()			));
-			getOracleType().setContributionCap(		convertorHelper.toSysGenCurrency(	getDTO().getCapped()			));
-			getOracleType().setUpliftApplied(		convertorHelper.toBoolean(	getDTO().isUpliftApplied()		));
-			getOracleType().setBasedOn(				convertorHelper.toSysGenString(	getDTO().getBasedOn()			));
+			getOracleType().setId(convertorHelper.toLong(getDTO().getId()));
+			getOracleType().setMonthlyContribs(getDTO().getMonthlyContribs());
+			getOracleType().setUpfrontContribs(getDTO().getUpfrontContribs());
+			getOracleType().setEffectiveDate(convertorHelper.toSysGenDate(getDTO().getEffectiveDate()));
+			getOracleType().setCalcDate(convertorHelper.toSysGenDate(getDTO().getCalcDate()));
+			getOracleType().setContributionCap(getDTO().getCapped());
+			getOracleType().setUpliftApplied(convertorHelper.toBoolean(getDTO().isUpliftApplied()));
+			getOracleType().setBasedOn(convertorHelper.toSysGenString(getDTO().getBasedOn()));
 		}		
 		catch (NullPointerException nex)
 		{

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/CrownCourtSummaryConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/CrownCourtSummaryConvertor.java
@@ -101,22 +101,19 @@ public class CrownCourtSummaryConvertor extends Convertor
 			/*
 			 * convert the multiple outcome collection
 			 */
-			getDTO().setOutcomeDTOs( new ArrayList<OutcomeDTO>() );
+			getDTO().setOutcomeDTOs(new ArrayList<>());
 			
-			if ( getOracleType().getCcOutcomeTab() != null ){
+			if (getOracleType().getCcOutcomeTab() != null) {
 			
 				OutcomeTabtype outcomeTabtype = getOracleType().getCcOutcomeTab();
-				OutcomeType[]	outcomeTypeArray	= outcomeTabtype.getArray();
+				OutcomeType[] outcomeTypeArray = outcomeTabtype.getArray();
 				OutcomeConvertor outcomeConvertor = new  OutcomeConvertor();
-				
-				for ( int i = 0; i < outcomeTypeArray.length; i++ ){
-					
-					outcomeConvertor.setDTOFromType( outcomeTypeArray[i] );
-					getDTO().getOutcomeDTOs().add(outcomeConvertor.getDTO());
-				}				
+
+                for (OutcomeType outcomeType : outcomeTypeArray) {
+                    outcomeConvertor.setDTOFromType(outcomeType);
+                    getDTO().getOutcomeDTOs().add(outcomeConvertor.getDTO());
+                }
 			}
-			
-			
 		}
 		catch (NullPointerException nex)
 		{

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/FinancialAssessmentConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/FinancialAssessmentConvertor.java
@@ -75,7 +75,7 @@ public class FinancialAssessmentConvertor extends Convertor
 		try
 		{
 			ConvertorHelper convertorHelper = new ConvertorHelper();
-			getDTO().setTimestamp(	getOracleType().getTimeStamp() );
+			getDTO().setTimestamp(convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 			
 			getDTO().setId(				convertorHelper.toLong(		getOracleType().getFinAssessmentId()));
 			getDTO().setFullAvailable(	convertorHelper.toBoolean(	getOracleType().getFullAvailable() 	));
@@ -141,7 +141,7 @@ public class FinancialAssessmentConvertor extends Convertor
 			setDTO( dto );
 			
 			ConvertorHelper convertorHelper = new ConvertorHelper();
-			getOracleType().setTimeStamp(		getDTO().getTimestamp() );
+			getOracleType().setTimeStamp(		convertorHelper.toTimestamp(getDTO().getTimestamp()));;
 			
 			getOracleType().setFinAssessmentId(	convertorHelper.toLong(		getDTO().getId()			));
 			getOracleType().setFullAvailable(	convertorHelper.toBoolean(	getDTO().getFullAvailable()	));

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/FullAssessmentConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/FullAssessmentConvertor.java
@@ -84,7 +84,7 @@ public class FullAssessmentConvertor extends Convertor {
 			getDTO().setThreshold(					convertorHelper.toDouble(getOracleType().getThreshold()));
 			getDTO().setResult(						convertorHelper.toString(getOracleType().getResult()));
 			getDTO().setResultReason(				convertorHelper.toString(getOracleType().getResultReason()));
-			getDTO().setTimestamp(					getOracleType().getTimeStamp());
+			getDTO().setTimestamp(					convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 
 			//section summaries
 			getDTO().setSectionSummaries(			new ArrayList<AssessmentSectionSummaryDTO>());

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/HRProgressConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/HRProgressConvertor.java
@@ -67,7 +67,7 @@ public class HRProgressConvertor extends Convertor {
 			getDTO().setDateCompleted(	convertorHelper.toDate(getOracleType().getDateCompleted()));
 			getDTO().setDateRequired(	convertorHelper.toDate(getOracleType().getDateRequired()));			
 			getDTO().setDateRequested(	convertorHelper.toDate(getOracleType().getDateRequested()));			
-			getDTO().setTimestamp(		getOracleType().getTimeStamp());
+			getDTO().setTimestamp(		convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 			
 			HRProgressActionConvertor progressActionConverter = new HRProgressActionConvertor();
 			if(getOracleType().getProgressActionObject() != null)
@@ -109,7 +109,7 @@ public class HRProgressConvertor extends Convertor {
             getOracleType().setDateCompleted(	convertorHelper.toDate(getDTO().getDateCompleted()));	
             getOracleType().setDateRequired(	convertorHelper.toDate(getDTO().getDateRequired()));	
             getOracleType().setDateRequested(	convertorHelper.toDate(getDTO().getDateRequested()));	
-            getOracleType().setTimeStamp(	 	getDTO().getTimestamp());
+            getOracleType().setTimeStamp(	 	convertorHelper.toTimestamp(getDTO().getTimestamp()));
             
             HRProgressActionConvertor  progressActionConverter = new HRProgressActionConvertor();
 			if(getDTO().getProgressAction() != null){				

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/HardshipReviewConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/HardshipReviewConvertor.java
@@ -68,14 +68,14 @@ public class HardshipReviewConvertor extends Convertor {
 		try
 		{
 			ConvertorHelper convertorHelper = new ConvertorHelper();
-			getDTO().setId( 							convertorHelper.toLong(		getOracleType().getId()));
-			getDTO().setCmuId(							convertorHelper.toLong(		getOracleType().getCmuId()));
-			getDTO().setReviewResult( 					convertorHelper.toString(	getOracleType().getReviewResult()));
-			getDTO().setReviewDate( 					convertorHelper.toDate(		getOracleType().getReviewDate()));
-			getDTO().setNotes( 							convertorHelper.toString(	getOracleType().getNotes()));
-			getDTO().setDecisionNotes( 					convertorHelper.toString(	getOracleType().getDecisionNotes()));
-			getDTO().setDisposableIncome( 				convertorHelper.toSysGenCurrency(	getOracleType().getDisposIncome()));
-			getDTO().setDisposableIncomeAfterHardship( 	convertorHelper.toSysGenCurrency(	getOracleType().getDisposIncomeAfterHardship()));
+			getDTO().setId(convertorHelper.toLong(getOracleType().getId()));
+			getDTO().setCmuId(convertorHelper.toLong(getOracleType().getCmuId()));
+			getDTO().setReviewResult(convertorHelper.toString(getOracleType().getReviewResult()));
+			getDTO().setReviewDate(convertorHelper.toDate(getOracleType().getReviewDate()));
+			getDTO().setNotes(convertorHelper.toString(getOracleType().getNotes()));
+			getDTO().setDecisionNotes(convertorHelper.toString(	getOracleType().getDecisionNotes()));
+			getDTO().setDisposableIncome(getOracleType().getDisposIncome());
+			getDTO().setDisposableIncomeAfterHardship(getOracleType().getDisposIncomeAfterHardship());
 			
 			//New Work Reason
 			NewWorkReasonConvertor mwrConvertor	= new NewWorkReasonConvertor();
@@ -152,14 +152,14 @@ public class HardshipReviewConvertor extends Convertor {
 			setType( null );	// force new type to be instantiated 
 			setDTO( dto );	// if the dto class type is not right for this conversion an exception is thrown
 			ConvertorHelper convertorHelper = new ConvertorHelper();            
-			getOracleType().setId(							convertorHelper.toLong(		getDTO().getId())); 
-			getOracleType().setCmuId(						convertorHelper.toLong(		getDTO().getCmuId())); 
-			getOracleType().setReviewResult(				convertorHelper.toString(	getDTO().getReviewResult()));
-			getOracleType().setReviewDate(					convertorHelper.toDate(		getDTO().getReviewDate())); 
-			getOracleType().setNotes(						convertorHelper.toString(	getDTO().getNotes())); 
-			getOracleType().setDecisionNotes(				convertorHelper.toString(	getDTO().getDecisionNotes())); 
-			getOracleType().setDisposIncome(				convertorHelper.toSysGenCurrency(	getDTO().getDisposableIncome()));
-			getOracleType().setDisposIncomeAfterHardship(	convertorHelper.toSysGenCurrency(	getDTO().getDisposableIncomeAfterHardship()));
+			getOracleType().setId(convertorHelper.toLong(getDTO().getId()));
+			getOracleType().setCmuId(convertorHelper.toLong(getDTO().getCmuId()));
+			getOracleType().setReviewResult(convertorHelper.toString(getDTO().getReviewResult()));
+			getOracleType().setReviewDate(convertorHelper.toDate(getDTO().getReviewDate()));
+			getOracleType().setNotes(convertorHelper.toString(getDTO().getNotes()));
+			getOracleType().setDecisionNotes(convertorHelper.toString(getDTO().getDecisionNotes()));
+			getOracleType().setDisposIncome(getDTO().getDisposableIncome());
+			getOracleType().setDisposIncomeAfterHardship(getDTO().getDisposableIncomeAfterHardship());
 			
 			//New Work Reason
 			NewWorkReasonConvertor mwrConvertor	= new NewWorkReasonConvertor();

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/InitialAssessmentConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/InitialAssessmentConvertor.java
@@ -83,7 +83,7 @@ public class InitialAssessmentConvertor extends Convertor
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 			
 			getDTO().setCriteriaId(						convertorHelper.toLong(		getOracleType().getCriteriaId() ));
-			getDTO().setTimestamp(						getOracleType().getTimeStamp() );
+			getDTO().setTimestamp(						convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 			getDTO().setAssessmentDate                (	convertorHelper.toDate( 	getOracleType().getAssessmentDate() ));
 			getDTO().setOtherBenefitNote              (	convertorHelper.toString( 	getOracleType().getOtherBenefitNote() ));
 			getDTO().setOtherIncomeNote               (	convertorHelper.toString( 	getOracleType().getOtherIncomeNote() ));

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/IojAppealConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/IojAppealConvertor.java
@@ -63,7 +63,7 @@ public class IojAppealConvertor extends Convertor {
 	    try
 	    {
 			ConvertorHelper convertorHelper = new ConvertorHelper();
-			getDTO().setTimestamp(						getOracleType().getTimeStamp() );
+			getDTO().setTimestamp(						convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 
 			getDTO().setIojId(					convertorHelper.toLong( 	getOracleType().getId() ));
 			getDTO().setCmuId(					convertorHelper.toLong( 	getOracleType().getCmuId() ));
@@ -117,7 +117,7 @@ public class IojAppealConvertor extends Convertor {
 			setDTO(dto);	
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 			
-			getOracleType().setTimeStamp(				getDTO().getTimestamp() );
+			getOracleType().setTimeStamp(				convertorHelper.toTimestamp(getDTO().getTimestamp()));
 
 			getOracleType().setId(						convertorHelper.toLong( 	getDTO().getIojId() ));
 			getOracleType().setCmuId(					convertorHelper.toLong( 	getDTO().getCmuId() ));

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/PassportedConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/PassportedConvertor.java
@@ -1,5 +1,9 @@
 package gov.uk.courtdata.dao.convertor;
 
+
+import java.sql.SQLException;
+
+
 import gov.uk.courtdata.dao.convertor.helper.ConvertorHelper;
 import gov.uk.courtdata.dao.oracle.PassportAssessmentType;
 import gov.uk.courtdata.dto.application.JobSeekerDTO;
@@ -8,230 +12,222 @@ import gov.uk.courtdata.dto.application.PassportedDTO;
 import gov.uk.courtdata.validator.MAATApplicationException;
 import gov.uk.courtdata.validator.MAATSystemException;
 
-import java.sql.SQLException;
 
 /**
  * @author TOWO-N
- *
  */
-public class PassportedConvertor  extends Convertor {
+public class PassportedConvertor extends Convertor {
 
-	/**
-	 * Returns the instance of the DTO cast to the appropriate class
-	 * @see Convertor#getDTO()
-	 */
-	@Override
-	public PassportedDTO getDTO(){
-		return (PassportedDTO)this.getDto();
-	}
-	
-	/**
-	 * sets the local instance of the dto
-	 * @see Convertor#setDTO(Object)
-	 */
-	@Override
-	public void setDTO(Object dto) throws MAATApplicationException	{
-		if (dto instanceof PassportedDTO)
-			this.setDto(dto);
-		else
-			throw new MAATApplicationException(" Invalid DTO type for conversion got " + dto.getClass().getName() + " wanted " + PassportedDTO.class.getName());
-	}
-	
-	@Override
-	public PassportAssessmentType getOracleType() throws MAATApplicationException, MAATSystemException{
+    /**
+     * Returns the instance of the DTO cast to the appropriate class
+     *
+     * @see Convertor#getDTO()
+     */
+    @Override
+    public PassportedDTO getDTO() {
+        return (PassportedDTO) this.getDto();
+    }
 
-		if ( getDbType() == null ){
-			setType( new PassportAssessmentType() );
-		}
-		
-		if ( getDbType() instanceof PassportAssessmentType ){
-			return (PassportAssessmentType)getDbType();
-		}else{
-			return null;
-		}
-	}	
+    /**
+     * sets the local instance of the dto
+     *
+     * @see Convertor#setDTO(java.lang.Object)
+     */
+    @Override
+    public void setDTO(Object dto) throws MAATApplicationException {
+        if (dto instanceof PassportedDTO) {
+            this.setDto(dto);
+        } else {
+            throw new MAATApplicationException(" Invalid DTO type for conversion got " + dto.getClass()
+                    .getName() + " wanted " + PassportedDTO.class.getName());
+        }
+    }
 
-	/**
-	 * This method take the oracleType class passed as a parameter and
-	 * converts the embedded oracle java classes to native java. 
-	 */
-	public void setDTOFromType(Object oracleType ) throws MAATApplicationException, MAATSystemException{
+    @Override
+    public PassportAssessmentType getOracleType() throws MAATApplicationException, MAATSystemException {
 
-		this.setType(oracleType);
-		this.setDto( new PassportedDTO() );	// create the new DTO
-		
-		try{
-			ConvertorHelper convertorHelper 			= new ConvertorHelper();
-			getDTO().setTimestamp(						getOracleType().getTimeStamp() );
+        if (getDbType() == null) {
+            setType(new PassportAssessmentType());
+        }
 
-			getDTO().setPassportedId(					convertorHelper.toLong(		getOracleType().getId()));
-			getDTO().setUsn(							convertorHelper.toLong(		getOracleType().getUsn()));	
-			getDTO().setCmuId(							convertorHelper.toLong(		getOracleType().getCmuId() ));			
-			getDTO().setBenefitClaimedByPartner(		convertorHelper.toBoolean(	getOracleType().getPartnerBenefitClaimed()));
-			getDTO().setBenefitGaurenteedStatePension(	convertorHelper.toBoolean(	getOracleType().getStatePensionCredit()));
-			getDTO().setBenefitIncomeSupport(			convertorHelper.toBoolean(	getOracleType().getIncomeSupport()));
-			getDTO().setBenefitEmploymentSupport(		convertorHelper.toBoolean(	getOracleType().getEsa()));
-			getDTO().setDate(							convertorHelper.toDate(		getOracleType().getAssDate()));
-			getDTO().setNotes(							convertorHelper.toString(	getOracleType().getPassportNote()));			
-			getDTO().setResult(							convertorHelper.toString(	getOracleType().getResult()));
-			getDTO().setDwpResult(						convertorHelper.toString(	getOracleType().getDwpResult()));			
-			getDTO().setUnder18HeardYouthCourt(			convertorHelper.toBoolean(	getOracleType().getUnder18HeardYouthCourt()));
-			getDTO().setUnder18HeardMagsCourt(			convertorHelper.toBoolean(	getOracleType().getUnder18HeardMagsCourt()));
-			getDTO().setUnder18FullEducation(			convertorHelper.toBoolean(	getOracleType().getUnder18FullEducation()));
-			getDTO().setUnder16(						convertorHelper.toBoolean(	getOracleType().getUnder16()));
-			getDTO().setBetween1617(					convertorHelper.toBoolean(	getOracleType().getBetween1617()));
+        if (getDbType() instanceof PassportAssessmentType passportAssessmentType) {
+            return passportAssessmentType;
+        } else {
+            return null;  // temp fix, could cause null pointer exception
+        }
+    }
 
-			JobSeekerDTO jobSeeker = new JobSeekerDTO();
-			jobSeeker.setIsJobSeeker(					convertorHelper.toBoolean(	getOracleType().getJobSeekers()));
-			jobSeeker.setLastSignedOn(					convertorHelper.toDate(		getOracleType().getLastSignOnDate()));
-			getDTO().setBenefitJobSeeker(jobSeeker);
-			
-			PartnerDTO partner = new PartnerDTO();
-			partner.setDateOfBirth(						convertorHelper.toDate(		getOracleType().getPartnerDob()));
-			partner.setFirstName(						convertorHelper.toString(	getOracleType().getPartnerFirstName()));
-			partner.setNationaInsuranceNumber(			convertorHelper.toString(	getOracleType().getPartnerNiNo()));
-			partner.setSurname(							convertorHelper.toString(	getOracleType().getPartnerSurname()));
-			getDTO().setPartnerDetails(partner);
+    /**
+     * This method take the oracleType class passed as a parameter and
+     * converts the embedded oracle java classes to native java.
+     */
+    public void setDTOFromType(Object oracleType) throws MAATApplicationException, MAATSystemException {
 
-			IncomeEvidenceSummaryConvertor ieConvertor = new IncomeEvidenceSummaryConvertor();
-			if ( getOracleType().getIncomeEvidenceSummaryObject() != null )
-			{
-				ieConvertor.setDTOFromType(  getOracleType().getIncomeEvidenceSummaryObject() );
-			}
-			getDTO().setPassportSummaryEvidenceDTO( ieConvertor.getDTO() );
+        this.setType(oracleType);
+        this.setDto(new PassportedDTO());    // create the new DTO
 
-			
-			
-			
-			if ( getOracleType().getStatusObject() != null )
-			{
-				AssessmentStatusConvertor convertor	= new AssessmentStatusConvertor();
-				convertor.setDTOFromType( getOracleType().getStatusObject() );
-				getDTO().setAssessementStatusDTO( convertor.getDTO() );
-			}					
-			
-			if ( getOracleType().getConfirmationObject() != null )
-			{
-				PassportConfirmationConvertor convertor	= new PassportConfirmationConvertor();
-				convertor.setDTOFromType( getOracleType().getConfirmationObject() );
-				getDTO().setPassportConfirmationDTO( convertor.getDTO() );
-			}
-			
-			if ( getOracleType().getNewWorkReasonObject() != null )
-			{
-				NewWorkReasonConvertor convertor	= new NewWorkReasonConvertor();
-				convertor.setDTOFromType( getOracleType().getNewWorkReasonObject() );
-				getDTO().setNewWorkReason( convertor.getDTO() );
-			}
-			
-			if ( getOracleType().getReviewTypeObject() != null )
-			{
-				ReviewTypeConvertor    convertor    =  new ReviewTypeConvertor();
-				convertor.setDTOFromType( getOracleType().getReviewTypeObject() );
-				getDTO().setReviewType( convertor.getDTO() );
-			}
-			
-			getDTO().setWhoDwpChecked(convertorHelper.toString(	getOracleType().getWhoDwpChecked()));
+        try {
+            ConvertorHelper convertorHelper = new ConvertorHelper();
+            getDTO().setTimestamp(convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 
-		}
-		catch (NullPointerException nex)
-		{
-			throw new MAATApplicationException( "PassportedConverter - the embedded dto is null");
-		
-		}
-		catch (SQLException ex)
-		{
-			throw new MAATSystemException( ex );
-		}				
-	}
-	
-	/**
-	 * This method will convert the native java object attributes to populate
-	 * the oracle java types of the embedded type class.
-	 * @return
-	 */
-	public void setTypeFromDTO(Object dto) throws MAATApplicationException, MAATSystemException{
-		/*
-		 * update the oracle type object converting all of the dto attributes to oracleType attributes
-		 */
-		try{	
-			setType( null );	// force new type to be instantiated 
-			setDTO(dto);	
-			ConvertorHelper convertorHelper			= new ConvertorHelper();
-			getOracleType().setTimeStamp(			getDTO().getTimestamp() );
-			
-			getOracleType().setId( 								convertorHelper.toLong( 	getDTO().getPassportedId() ) );
-			getOracleType().setUsn(								convertorHelper.toLong( 	getDTO().getUsn() ) );
-			getOracleType().setCmuId( 							convertorHelper.toLong( 	getDTO().getCmuId() ) );
-			getOracleType().setPartnerBenefitClaimed(			convertorHelper.toBoolean(	getDTO().getBenefitClaimedByPartner()));
-			getOracleType().setStatePensionCredit(				convertorHelper.toBoolean(	getDTO().getBenefitGaurenteedStatePension()));
-			getOracleType().setIncomeSupport(					convertorHelper.toBoolean(	getDTO().getBenefitIncomeSupport()));
-			getOracleType().setEsa(								convertorHelper.toBoolean(	getDTO().getBenefitEmploymentSupport()));
-			getOracleType().setAssDate(							convertorHelper.toDate(		getDTO().getDate()));
-			getOracleType().setPassportNote(					convertorHelper.toString(	getDTO().getNotes()));			
-			getOracleType().setResult(							convertorHelper.toString(	getDTO().getResult()));
-			getOracleType().setDwpResult(						convertorHelper.toString(	getDTO().getDwpResult()));			
-			getOracleType().setUnder18HeardYouthCourt(			convertorHelper.toBoolean(	getDTO().getUnder18HeardYouthCourt()));
-			getOracleType().setUnder18HeardMagsCourt(			convertorHelper.toBoolean(	getDTO().getUnder18HeardMagsCourt()));
-			getOracleType().setUnder18FullEducation(			convertorHelper.toBoolean(	getDTO().getUnder18FullEducation()));
-			getOracleType().setUnder16(						    convertorHelper.toBoolean(	getDTO().getUnder16()));
-			getOracleType().setBetween1617(					    convertorHelper.toBoolean(	getDTO().getBetween1617()));			
-			getOracleType().setJobSeekers(						convertorHelper.toBoolean(  getDTO().getBenefitJobSeeker().getIsJobSeeker() ));
-			getOracleType().setLastSignOnDate(					convertorHelper.toDate(     getDTO().getBenefitJobSeeker().getLastSignedOn() ) );
-			getOracleType().setPartnerDob(						convertorHelper.toDate( 	getDTO().getPartnerDetails().getDateOfBirth() ));
-			getOracleType().setPartnerFirstName(				convertorHelper.toString(   getDTO().getPartnerDetails().getFirstName() ));
-			getOracleType().setPartnerSurname(					convertorHelper.toString(   getDTO().getPartnerDetails().getSurname()));
-			getOracleType().setPartnerNiNo(						convertorHelper.toString(   getDTO().getPartnerDetails().getNationaInsuranceNumber()));
-			
-			IncomeEvidenceSummaryConvertor ieConvertor = new IncomeEvidenceSummaryConvertor();
-			if ( getDTO().getPassportSummaryEvidenceDTO() != null )
-			{
-				ieConvertor.setTypeFromDTO( getDTO().getPassportSummaryEvidenceDTO() );
-			}
-			getOracleType().setIncomeEvidenceSummaryObject( ieConvertor.getOracleType());
-			
-			
-			
+            getDTO().setPassportedId(convertorHelper.toLong(getOracleType().getId()));
+            getDTO().setUsn(convertorHelper.toLong(getOracleType().getUsn()));
+            getDTO().setCmuId(convertorHelper.toLong(getOracleType().getCmuId()));
+            getDTO().setBenefitClaimedByPartner(convertorHelper.toBoolean(getOracleType().getPartnerBenefitClaimed()));
+            getDTO().setBenefitGaurenteedStatePension(
+                    convertorHelper.toBoolean(getOracleType().getStatePensionCredit()));
+            getDTO().setBenefitIncomeSupport(convertorHelper.toBoolean(getOracleType().getIncomeSupport()));
+            getDTO().setBenefitUniversalCredit(convertorHelper.toBoolean(getOracleType().getUniversalCredit()));
+            getDTO().setBenefitEmploymentSupport(convertorHelper.toBoolean(getOracleType().getEsa()));
+            getDTO().setDate(convertorHelper.toDate(getOracleType().getAssDate()));
+            getDTO().setNotes(convertorHelper.toString(getOracleType().getPassportNote()));
+            getDTO().setResult(convertorHelper.toString(getOracleType().getResult()));
+            getDTO().setDwpResult(convertorHelper.toString(getOracleType().getDwpResult()));
+            getDTO().setUnder18HeardYouthCourt(convertorHelper.toBoolean(getOracleType().getUnder18HeardYouthCourt()));
+            getDTO().setUnder18HeardMagsCourt(convertorHelper.toBoolean(getOracleType().getUnder18HeardMagsCourt()));
+            getDTO().setUnder18FullEducation(convertorHelper.toBoolean(getOracleType().getUnder18FullEducation()));
+            getDTO().setUnder16(convertorHelper.toBoolean(getOracleType().getUnder16()));
+            getDTO().setBetween1617(convertorHelper.toBoolean(getOracleType().getBetween1617()));
 
-			AssessmentStatusConvertor assConvertor	= new AssessmentStatusConvertor();
-			if ( getDTO().getAssessementStatusDTO() != null )
-			{
-				assConvertor.setTypeFromDTO( getDTO().getAssessementStatusDTO() );
-			}
-			getOracleType().setStatusObject( assConvertor.getOracleType() );
+            JobSeekerDTO jobSeeker = new JobSeekerDTO();
+            jobSeeker.setIsJobSeeker(convertorHelper.toBoolean(getOracleType().getJobSeekers()));
+            jobSeeker.setLastSignedOn(convertorHelper.toDate(getOracleType().getLastSignOnDate()));
+            getDTO().setBenefitJobSeeker(jobSeeker);
 
-			PassportConfirmationConvertor pcConvertor	= new PassportConfirmationConvertor();
-			if ( getDTO().getPassportConfirmationDTO() != null )
-			{
-				pcConvertor.setTypeFromDTO( getDTO().getPassportConfirmationDTO() );
-			}
-			getOracleType().setConfirmationObject( pcConvertor.getOracleType() );
+            PartnerDTO partner = new PartnerDTO();
+            partner.setDateOfBirth(convertorHelper.toDate(getOracleType().getPartnerDob()));
+            partner.setFirstName(convertorHelper.toString(getOracleType().getPartnerFirstName()));
+            partner.setNationaInsuranceNumber(convertorHelper.toString(getOracleType().getPartnerNiNo()));
+            partner.setSurname(convertorHelper.toString(getOracleType().getPartnerSurname()));
+            getDTO().setPartnerDetails(partner);
 
-			NewWorkReasonConvertor nwrConvertor	= new NewWorkReasonConvertor();
-			if ( getDTO().getNewWorkReason() != null )
-			{
-				nwrConvertor.setTypeFromDTO( getDTO().getNewWorkReason() );
-			}
-			getOracleType().setNewWorkReasonObject( nwrConvertor.getOracleType() );
-			
-			ReviewTypeConvertor reviewTypeConvertor	= new ReviewTypeConvertor();
-			if ( getDTO().getReviewType() != null )
-			{
-				reviewTypeConvertor.setTypeFromDTO( getDTO().getReviewType() );
-			}
-			getOracleType().setReviewTypeObject( reviewTypeConvertor.getOracleType() );
-			
-			getOracleType().setWhoDwpChecked(convertorHelper.toString(getDTO().getWhoDwpChecked()));
-		}
-		catch (NullPointerException nex)
-		{
-			throw new MAATApplicationException( "PassportedConvertor - the embedded dto is null");
-		}
-		catch (SQLException ex)
-		{
-			throw new MAATSystemException( ex );
-		}				
-	}
-	
+            IncomeEvidenceSummaryConvertor ieConvertor = new IncomeEvidenceSummaryConvertor();
+            if (getOracleType().getIncomeEvidenceSummaryObject() != null) {
+                ieConvertor.setDTOFromType(getOracleType().getIncomeEvidenceSummaryObject());
+            }
+            getDTO().setPassportSummaryEvidenceDTO(ieConvertor.getDTO());
+
+
+            if (getOracleType().getStatusObject() != null) {
+                AssessmentStatusConvertor convertor = new AssessmentStatusConvertor();
+                convertor.setDTOFromType(getOracleType().getStatusObject());
+                getDTO().setAssessementStatusDTO(convertor.getDTO());
+            }
+
+            if (getOracleType().getConfirmationObject() != null) {
+                PassportConfirmationConvertor convertor = new PassportConfirmationConvertor();
+                convertor.setDTOFromType(getOracleType().getConfirmationObject());
+                getDTO().setPassportConfirmationDTO(convertor.getDTO());
+            }
+
+            if (getOracleType().getNewWorkReasonObject() != null) {
+                NewWorkReasonConvertor convertor = new NewWorkReasonConvertor();
+                convertor.setDTOFromType(getOracleType().getNewWorkReasonObject());
+                getDTO().setNewWorkReason(convertor.getDTO());
+            }
+
+            if (getOracleType().getReviewTypeObject() != null) {
+                ReviewTypeConvertor convertor = new ReviewTypeConvertor();
+                convertor.setDTOFromType(getOracleType().getReviewTypeObject());
+                getDTO().setReviewType(convertor.getDTO());
+            }
+
+            getDTO().setWhoDwpChecked(convertorHelper.toString(getOracleType().getWhoDwpChecked()));
+
+        } catch (NullPointerException nex) {
+            /*
+             * This will happen if the dto object has not been set
+             */
+            throw new MAATApplicationException("PassportedConverter - the embedded dto is null");
+
+        } catch (SQLException ex) {
+            throw new MAATSystemException(ex);
+        }
+    }
+
+    /**
+     * This method will convert the native java object attributes to populate
+     * the oracle java types of the embedded type class.
+     *
+     * @return
+     */
+    public void setTypeFromDTO(Object dto) throws MAATApplicationException, MAATSystemException {
+        /*
+         * update the oracle type object converting all of the dto attributes to oracleType attributes
+         */
+        try {
+            setType(null);    // force new type to be instantiated
+            setDTO(dto);
+            ConvertorHelper convertorHelper = new ConvertorHelper();
+            getOracleType().setTimeStamp(convertorHelper.toTimestamp(getDTO().getTimestamp()));
+
+            getOracleType().setId(convertorHelper.toLong(getDTO().getPassportedId()));
+            getOracleType().setUsn(convertorHelper.toLong(getDTO().getUsn()));
+            getOracleType().setCmuId(convertorHelper.toLong(getDTO().getCmuId()));
+            getOracleType().setPartnerBenefitClaimed(convertorHelper.toBoolean(getDTO().getBenefitClaimedByPartner()));
+            getOracleType().setStatePensionCredit(
+                    convertorHelper.toBoolean(getDTO().getBenefitGaurenteedStatePension()));
+            getOracleType().setIncomeSupport(convertorHelper.toBoolean(getDTO().getBenefitIncomeSupport()));
+            getOracleType().setEsa(convertorHelper.toBoolean(getDTO().getBenefitEmploymentSupport()));
+            getOracleType().setUniversalCredit(convertorHelper.toBoolean(getDTO().getBenefitUniversalCredit()));
+            getOracleType().setAssDate(convertorHelper.toDate(getDTO().getDate()));
+            getOracleType().setPassportNote(convertorHelper.toString(getDTO().getNotes()));
+            getOracleType().setResult(convertorHelper.toString(getDTO().getResult()));
+            getOracleType().setDwpResult(convertorHelper.toString(getDTO().getDwpResult()));
+            getOracleType().setUnder18HeardYouthCourt(convertorHelper.toBoolean(getDTO().getUnder18HeardYouthCourt()));
+            getOracleType().setUnder18HeardMagsCourt(convertorHelper.toBoolean(getDTO().getUnder18HeardMagsCourt()));
+            getOracleType().setUnder18FullEducation(convertorHelper.toBoolean(getDTO().getUnder18FullEducation()));
+            getOracleType().setUnder16(convertorHelper.toBoolean(getDTO().getUnder16()));
+            getOracleType().setBetween1617(convertorHelper.toBoolean(getDTO().getBetween1617()));
+            getOracleType().setJobSeekers(convertorHelper.toBoolean(getDTO().getBenefitJobSeeker().getIsJobSeeker()));
+            getOracleType().setLastSignOnDate(convertorHelper.toDate(getDTO().getBenefitJobSeeker().getLastSignedOn()));
+            getOracleType().setPartnerDob(convertorHelper.toDate(getDTO().getPartnerDetails().getDateOfBirth()));
+            getOracleType().setPartnerFirstName(convertorHelper.toString(getDTO().getPartnerDetails().getFirstName()));
+            getOracleType().setPartnerSurname(convertorHelper.toString(getDTO().getPartnerDetails().getSurname()));
+            getOracleType().setPartnerNiNo(
+                    convertorHelper.toString(getDTO().getPartnerDetails().getNationaInsuranceNumber()));
+
+            IncomeEvidenceSummaryConvertor ieConvertor = new IncomeEvidenceSummaryConvertor();
+            if (getDTO().getPassportSummaryEvidenceDTO() != null) {
+                ieConvertor.setTypeFromDTO(getDTO().getPassportSummaryEvidenceDTO());
+            }
+            getOracleType().setIncomeEvidenceSummaryObject(ieConvertor.getOracleType());
+
+
+            AssessmentStatusConvertor assConvertor = new AssessmentStatusConvertor();
+            if (getDTO().getAssessementStatusDTO() != null) {
+                assConvertor.setTypeFromDTO(getDTO().getAssessementStatusDTO());
+            }
+            getOracleType().setStatusObject(assConvertor.getOracleType());
+
+            PassportConfirmationConvertor pcConvertor = new PassportConfirmationConvertor();
+            if (getDTO().getPassportConfirmationDTO() != null) {
+                pcConvertor.setTypeFromDTO(getDTO().getPassportConfirmationDTO());
+            }
+            getOracleType().setConfirmationObject(pcConvertor.getOracleType());
+
+            NewWorkReasonConvertor nwrConvertor = new NewWorkReasonConvertor();
+            if (getDTO().getNewWorkReason() != null) {
+                nwrConvertor.setTypeFromDTO(getDTO().getNewWorkReason());
+            }
+            getOracleType().setNewWorkReasonObject(nwrConvertor.getOracleType());
+
+            ReviewTypeConvertor reviewTypeConvertor = new ReviewTypeConvertor();
+            if (getDTO().getReviewType() != null) {
+                reviewTypeConvertor.setTypeFromDTO(getDTO().getReviewType());
+            }
+            getOracleType().setReviewTypeObject(reviewTypeConvertor.getOracleType());
+
+            getOracleType().setWhoDwpChecked(convertorHelper.toString(getDTO().getWhoDwpChecked()));
+        } catch (NullPointerException nex) {
+            /*
+             * This will happen if the dto object has not been set
+             */
+            throw new MAATApplicationException("PassportedConvertor - the embedded dto is null");
+        } catch (SQLException ex) {
+            throw new MAATSystemException(ex);
+        }
+    }
+
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/PropertyConvertor.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/PropertyConvertor.java
@@ -105,7 +105,7 @@ public class PropertyConvertor extends Convertor
 		{
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 
-			getDTO().setTimestamp(					getOracleType().getTimeStamp() );
+			getDTO().setTimestamp(					convertorHelper.toLocalDateTime(getOracleType().getTimeStamp()));
 			getDTO().setId(							convertorHelper.toLong( 	getOracleType().getId() ));
 			getDTO().setBedrooms(					convertorHelper.toString(	getOracleType().getBedrooms() ));
 
@@ -201,7 +201,7 @@ public class PropertyConvertor extends Convertor
             setDTO( dto );	// if the dto class type is not right for this conversion an exception is thrown
 			ConvertorHelper convertorHelper = new ConvertorHelper();
 
-			getOracleType().setTimeStamp(					getDTO().getTimestamp() );
+			getOracleType().setTimeStamp(					convertorHelper.toTimestamp(getDTO().getTimestamp()));
 			getOracleType().setId(							convertorHelper.toLong(		getDTO().getId() ));
 
 			getOracleType().setBedrooms(					convertorHelper.toString(getDTO().getBedrooms()	 ));

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/helper/ConvertorHelper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/convertor/helper/ConvertorHelper.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 
@@ -216,6 +217,14 @@ public class ConvertorHelper {
     public SysGenCurrency toSysGenCurrency(BigDecimal number) {
         return number != null ? new SysGenCurrency(number.toString()) : null;
 
+    }
+
+    public Timestamp toTimestamp(LocalDateTime localDateTime) {
+        return (localDateTime != null) ? Timestamp.valueOf(localDateTime) : null;
+    }
+
+    public LocalDateTime toLocalDateTime(Timestamp timeStamp) {
+        return (timeStamp != null) ? timeStamp.toLocalDateTime() : null;
     }
 
     public Date toDate(Timestamp timeStamp) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/oracle/PassportAssessmentType.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dao/oracle/PassportAssessmentType.java
@@ -17,8 +17,8 @@ public class PassportAssessmentType implements ORAData, ORADataFactory
 
   protected MutableStruct _struct;
 
-  protected static int[] _sqlType =  { 2,2,2002,91,12,12,12,12,91,12,12,12,2002,2002,12,93,12,12,12,12,91,12,12,12,12,2002,2,12,2002 };
-  protected static ORADataFactory[] _factory = new ORADataFactory[29];
+  protected static int[] _sqlType =  { 2,2,2002,91,12,12,12,12,91,12,12,12,2002,2002,12,93,12,12,12,12,91,12,12,12,12,2002,2,12,2002,12 };
+  protected static ORADataFactory[] _factory = new ORADataFactory[30];
   static
   {
     _factory[2] = AssStatusType.getORADataFactory();
@@ -33,10 +33,10 @@ public class PassportAssessmentType implements ORAData, ORADataFactory
   { return _PassportAssessmentTypeFactory; }
   /* constructors */
   protected void _init_struct(boolean init)
-  { if (init) _struct = new MutableStruct(new Object[29], _sqlType, _factory); }
+  { if (init) _struct = new MutableStruct(new Object[30], _sqlType, _factory); }
   public PassportAssessmentType()
   { _init_struct(true); }
-  public PassportAssessmentType(java.math.BigDecimal id, java.math.BigDecimal cmuId, AssStatusType statusObject, java.sql.Timestamp assDate, String partnerBenefitClaimed, String partnerFirstName, String partnerSurname, String partnerNiNo, java.sql.Timestamp partnerDob, String incomeSupport, String jobSeekers, String statePensionCredit, NewWorkReasonType newWorkReasonObject, PassportConfirmationType confirmationObject, String result, java.sql.Timestamp timeStamp, String dwpResult, String passportNote, String under18HeardYouthCourt, String under18HeardMagsCourt, java.sql.Timestamp lastSignOnDate, String esa, String under18FullEducation, String under16, String between1617, IncomeEvidenceSummaryType incomeEvidenceSummaryObject, java.math.BigDecimal usn, String whoDwpChecked, ReviewTypeType reviewTypeObject) throws SQLException
+  public PassportAssessmentType(java.math.BigDecimal id, java.math.BigDecimal cmuId, AssStatusType statusObject, java.sql.Timestamp assDate, String partnerBenefitClaimed, String partnerFirstName, String partnerSurname, String partnerNiNo, java.sql.Timestamp partnerDob, String incomeSupport, String jobSeekers, String statePensionCredit, NewWorkReasonType newWorkReasonObject, PassportConfirmationType confirmationObject, String result, java.sql.Timestamp timeStamp, String dwpResult, String passportNote, String under18HeardYouthCourt, String under18HeardMagsCourt, java.sql.Timestamp lastSignOnDate, String esa, String under18FullEducation, String under16, String between1617, IncomeEvidenceSummaryType incomeEvidenceSummaryObject, java.math.BigDecimal usn, String whoDwpChecked, ReviewTypeType reviewTypeObject, String universalCredit) throws SQLException
   { _init_struct(true);
     setId(id);
     setCmuId(cmuId);
@@ -67,6 +67,7 @@ public class PassportAssessmentType implements ORAData, ORADataFactory
     setUsn(usn);
     setWhoDwpChecked(whoDwpChecked);
     setReviewTypeObject(reviewTypeObject);
+    setUniversalCredit(universalCredit);
   }
 
   /* ORAData interface */
@@ -81,7 +82,7 @@ public class PassportAssessmentType implements ORAData, ORADataFactory
   { return create(null, d, sqlType); }
   protected ORAData create(PassportAssessmentType o, Datum d, int sqlType) throws SQLException
   {
-    if (d == null) return null; 
+    if (d == null) return null;
     if (o == null) o = new PassportAssessmentType();
     o._struct = new MutableStruct((STRUCT) d, _sqlType, _factory);
     return o;
@@ -289,4 +290,9 @@ public class PassportAssessmentType implements ORAData, ORADataFactory
   public void setReviewTypeObject(ReviewTypeType reviewTypeObject) throws SQLException
   { _struct.setAttribute(28, reviewTypeObject); }
 
+  public String getUniversalCredit() throws SQLException
+  { return (String) _struct.getAttribute(29); }
+
+  public void setUniversalCredit(String universalCredit) throws SQLException
+  { _struct.setAttribute(29, universalCredit); }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/AllowedWorkReasonDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/AllowedWorkReasonDTO.java
@@ -3,24 +3,30 @@
  */
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class AllowedWorkReasonDTO extends GenericDTO  {
-
-	private Collection<NewWorkReasonDTO> passportWorkReason;
-	private Collection<NewWorkReasonDTO> meansAssessmentWorkReason;
-	private Collection<NewWorkReasonDTO> magsCourtHardshipWorkReason;
-	private Collection<NewWorkReasonDTO> crownCourtHardshipWorkReason;
-	private Collection<NewWorkReasonDTO> eligibilityWorkReason;
-	private Collection<NewWorkReasonDTO> iojAppealWorkReason;
-
+	@Builder.Default
+	private Collection<NewWorkReasonDTO> iojAppealWorkReason = new ArrayList<>();
+	@Builder.Default
+	private Collection<NewWorkReasonDTO> magsCourtHardshipWorkReason = new ArrayList<>();
+	@Builder.Default
+	private Collection<NewWorkReasonDTO> passportWorkReason = new ArrayList<>();
+	@Builder.Default
+	private Collection<NewWorkReasonDTO> meansAssessmentWorkReason = new ArrayList<>();
+	@Builder.Default
+	private Collection<NewWorkReasonDTO> crownCourtHardshipWorkReason = new ArrayList<>();
+	@Builder.Default
+	private Collection<NewWorkReasonDTO> eligibilityWorkReason = new ArrayList<>();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/AppealDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/AppealDTO.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -9,14 +10,15 @@ import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class AppealDTO extends GenericDTO {
-
     private Boolean available;
     private Date appealReceivedDate;
     private Date appealSentenceOrderDate;
     private Date appealSentOrderDateSet;
-    private AppealTypeDTO appealTypeDTO;
+
+    @Builder.Default
+    private AppealTypeDTO appealTypeDTO = new AppealTypeDTO();
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicantDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicantDTO.java
@@ -1,6 +1,7 @@
 package gov.uk.courtdata.dto.application;
 
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -13,37 +14,44 @@ import java.util.Date;
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-public class ApplicantDTO extends GenericDTO
-{
-	private SysGenLong                          id;
-	private String 								firstName;
-	private String 								otherNames;
-	private String 								surname;
-	private Date 								dob;
-	private String 								NiNumber;
-	private	String								disabled;
-	private Collection<DisabilityDTO>			disabilities;
+public class ApplicantDTO extends GenericDTO {
+    private Long id;
+    private String firstName;
+    private String otherNames;
+    private String surname;
+    private Date dob;
+    private String NiNumber;
+    private String disabled;
+    private Collection<DisabilityDTO> disabilities;
 
-	private DisabilityStatementDTO				disabilityStatementDTO;
+    private String email;
+    private String mobileTelephone;
+    private String workTelephone;
+    private String homeTelephone;
+    private String status;
+    private String gender;
+    private String foreignId;
+    private Boolean useSupplierAddrForPost;
+    private Long applicantHistoryId;
+    private ApplicantPaymentDetailsDTO paymentDetailsDTO;
+    private Date specialInvestigation;
 
-	private EmploymentStatusDTO					employmentStatusDTO;
-	private String 								email;
-	private String 								mobileTelephone;
-	private String 								workTelephone;
-	private String 								homeTelephone;
-	private String								status;
-	private EthnicityDTO						ethnicity;
-	private String 								gender;
-	private AddressDTO 							homeAddressDTO;
-	private AddressDTO 							postalAddressDTO;
-    private Boolean 							noFixedAbode;
-	private Boolean								useHomeAddress;
-	private String								foreignId;	
-	private Boolean								useSupplierAddrForPost;
-	private Long                                applicantHistoryId;
-	private ApplicantPaymentDetailsDTO			paymentDetailsDTO;
-    private Boolean 							hasPartner;
-    private Boolean 							contraryInterest;
-    private Date								specialInvestigation;
-
+    @Builder.Default
+    private DisabilityStatementDTO disabilityStatementDTO = new DisabilityStatementDTO();
+    @Builder.Default
+    private EmploymentStatusDTO employmentStatusDTO = new EmploymentStatusDTO();
+    @Builder.Default
+    private EthnicityDTO ethnicity = new EthnicityDTO();
+    @Builder.Default
+    private AddressDTO homeAddressDTO = new AddressDTO();
+    @Builder.Default
+    private AddressDTO postalAddressDTO = new AddressDTO();
+    @Builder.Default
+    private Boolean noFixedAbode = false;
+    @Builder.Default
+    private Boolean useHomeAddress = false;
+    @Builder.Default
+    private Boolean hasPartner = false;
+    @Builder.Default
+    private Boolean contraryInterest = false;
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicantPaymentDetailsDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicantPaymentDetailsDTO.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -7,14 +8,14 @@ import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class ApplicantPaymentDetailsDTO extends GenericDTO {
-
-    private PaymentMethodDTO paymentMethod;
     private Integer paymentDay;
     private String accountNumber;
     private String sortCode;
     private String accountName;
 
+    @Builder.Default
+    private PaymentMethodDTO paymentMethod = new PaymentMethodDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicationDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicationDTO.java
@@ -1,6 +1,7 @@
 package gov.uk.courtdata.dto.application;
 
 import gov.uk.courtdata.enums.EformEnum;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -33,58 +34,67 @@ public class ApplicationDTO extends GenericDTO {
     private Date decisionDate;
     private Date dateStamp;
     private Date hearingDate;
-    private AreaTransferDetailsDTO areaTransferDTO;
-    private ApplicantDTO applicantDTO;
-    private AssessmentDTO assessmentDTO;
-    private CapitalEquityDTO capitalEquityDTO;
-    private CaseDetailDTO caseDetailsDTO;
-    private CaseManagementUnitDTO caseManagementUnitDTO;
-    private CrownCourtOverviewDTO crownCourtOverviewDTO;
-    private LscTransferDTO lscTransferDTO;
-    private MagsCourtDTO magsCourtDTO;
-    private OutcomeDTO magsOutcomeDTO;
-
-    private OffenceDTO offenceDTO;
-    private PassportedDTO passportedDTO;
-    private RepOrderDecisionDTO repOrderDecision;
-    private RepStatusDTO statusDTO;
-    private SupplierDTO supplierDTO;
-    private ContraryInterestDTO partnerContraryInterestDTO;
-    private AllowedWorkReasonDTO allowedWorkReasonDTO;
-    private DrcSummaryDTO drcSummaryDTO;
-
     private String transactionId;
-
     private Boolean applicantHasPartner;
     private boolean welshCorrepondence;
     private String iojResult;
     private String iojResultNote;
-
     private String solicitorName;
     private String solicitorEmail;
     private String solicitorAdminEmail;
-
-    private Collection<AssessmentSummaryDTO> assessmentSummary;
-    private Collection<ApplicantLinkDTO> applicantLinks;
-
-    private Collection<FdcContributionDTO> fdcContributions;
-
-
     private boolean courtCustody;
-
     private boolean retrial;
-
     private boolean messageDisplayed;
-
     private String alertMessage;
     private Long usn;
-
     private EformEnum applicationType;
 
-    private ArrayList<DigitisedMeansAssessmentDTO> meansAssessments; // MW - 30/03/2017 - To support FIP changes
-
-    private CommonPlatformDataDTO commonPlatformData;
-
-    private BreathingSpaceDTO breathingSpaceDTO;
-
+    @Builder.Default
+    private AreaTransferDetailsDTO areaTransferDTO = new AreaTransferDetailsDTO();
+    @Builder.Default
+    private ApplicantDTO applicantDTO = new ApplicantDTO();
+    @Builder.Default
+    private AssessmentDTO assessmentDTO = new AssessmentDTO();
+    @Builder.Default
+    private CapitalEquityDTO capitalEquityDTO = new CapitalEquityDTO();
+    @Builder.Default
+    private CaseDetailDTO caseDetailsDTO = new CaseDetailDTO();
+    @Builder.Default
+    private CaseManagementUnitDTO caseManagementUnitDTO = new CaseManagementUnitDTO();
+    @Builder.Default
+    private CrownCourtOverviewDTO crownCourtOverviewDTO = new CrownCourtOverviewDTO();
+    @Builder.Default
+    private LscTransferDTO lscTransferDTO = new LscTransferDTO();
+    @Builder.Default
+    private MagsCourtDTO magsCourtDTO = new MagsCourtDTO();
+    @Builder.Default
+    private OutcomeDTO magsOutcomeDTO = new OutcomeDTO();
+    @Builder.Default
+    private OffenceDTO offenceDTO = new OffenceDTO();
+    @Builder.Default
+    private PassportedDTO passportedDTO = new PassportedDTO();
+    @Builder.Default
+    private RepOrderDecisionDTO repOrderDecision = new RepOrderDecisionDTO();
+    @Builder.Default
+    private RepStatusDTO statusDTO = new RepStatusDTO();
+    @Builder.Default
+    private SupplierDTO supplierDTO = new SupplierDTO();
+    @Builder.Default
+    private ContraryInterestDTO partnerContraryInterestDTO = new ContraryInterestDTO();
+    @Builder.Default
+    private AllowedWorkReasonDTO allowedWorkReasonDTO = new AllowedWorkReasonDTO();
+    @Builder.Default
+    private DrcSummaryDTO drcSummaryDTO = new DrcSummaryDTO();
+    @Builder.Default
+    private Collection<AssessmentSummaryDTO> assessmentSummary = new ArrayList<>();
+    @Builder.Default
+    private Collection<ApplicantLinkDTO> applicantLinks = new ArrayList<>();
+    @Builder.Default
+    private Collection<FdcContributionDTO> fdcContributions = new ArrayList<>();
+    @Builder.Default
+    private ArrayList<DigitisedMeansAssessmentDTO> meansAssessments = new ArrayList<>();
+    @Builder.Default
+    private CommonPlatformDataDTO commonPlatformData = new CommonPlatformDataDTO();
+    @Builder.Default
+    private BreathingSpaceDTO breathingSpaceDTO = new BreathingSpaceDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicationDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicationDTO.java
@@ -12,8 +12,8 @@ import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class ApplicationDTO extends GenericDTO {
     private Long repId;
     private Long areaId;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicationHardshipReviewDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicationHardshipReviewDTO.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Date;
 
@@ -24,8 +25,8 @@ public class ApplicationHardshipReviewDTO extends GenericDTO {
     private String decisionNotes;
     private String test;
     private HRSolicitorsCostsDTO solictorsCosts;
-    private SysGenCurrency disposableIncome;
-    private SysGenCurrency disposableIncomeAfterHardship;
+    private BigDecimal disposableIncome;
+    private BigDecimal disposableIncomeAfterHardship;
     private Collection<HRSectionDTO> section;
     private Collection<HRProgressDTO> progress;
     private AssessmentStatusDTO asessmentStatus;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicationHardshipReviewDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ApplicationHardshipReviewDTO.java
@@ -1,11 +1,13 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
@@ -14,21 +16,25 @@ import java.util.Date;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 public class ApplicationHardshipReviewDTO extends GenericDTO {
-
     private Long id;
-    private SupplierDTO supplier;
-    private NewWorkReasonDTO newWorkReason;
     private Long cmuId;
     private String reviewResult;
     private Date reviewDate;
     private String notes;
     private String decisionNotes;
     private String test;
-    private HRSolicitorsCostsDTO solictorsCosts;
     private BigDecimal disposableIncome;
     private BigDecimal disposableIncomeAfterHardship;
-    private Collection<HRSectionDTO> section;
-    private Collection<HRProgressDTO> progress;
-    private AssessmentStatusDTO asessmentStatus;
-
+    @Builder.Default
+    private SupplierDTO supplier = new SupplierDTO();
+    @Builder.Default
+    private NewWorkReasonDTO newWorkReason = new NewWorkReasonDTO();
+    @Builder.Default
+    private HRSolicitorsCostsDTO solictorsCosts = new HRSolicitorsCostsDTO();
+    @Builder.Default
+    private Collection<HRSectionDTO> section = new ArrayList<>();
+    @Builder.Default
+    private Collection<HRProgressDTO> progress = new ArrayList<>();
+    @Builder.Default
+    private AssessmentStatusDTO asessmentStatus = new AssessmentStatusDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/AreaTransferDetailsDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/AreaTransferDetailsDTO.java
@@ -1,9 +1,10 @@
 /**
- * 
+ *
  */
 package gov.uk.courtdata.dto.application;
 
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -13,23 +14,26 @@ import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-public class AreaTransferDetailsDTO extends GenericDTO
-{
+@EqualsAndHashCode(callSuper = true)
+public class AreaTransferDetailsDTO extends GenericDTO {
 
-	private Long						id ;
-	
-	private AreaDTO                     areaFrom ;
-	private AreaDTO                     areaTo ;
-	private CaseManagementUnitDTO       cmuFrom ;
-	private CaseManagementUnitDTO       cmuTo ;
-	private TransferTypeDTO             transferType ;
-	private TransferStatusDTO			transferStatus;
-	
-	private Date                        dateHmcsSent ;
-	private Date                        dateHmcsReceived;
-	private UserDTO                     hmcsSentBy     ;
-	private UserDTO                     hmcsReceivedBy ;
+    private Long id;
+    private Date dateHmcsSent;
+    private Date dateHmcsReceived;
+    private UserDTO hmcsSentBy;
+    private UserDTO hmcsReceivedBy;
 
+    @Builder.Default
+    private AreaDTO areaFrom = new AreaDTO();
+    @Builder.Default
+    private AreaDTO areaTo = new AreaDTO();
+    @Builder.Default
+    private CaseManagementUnitDTO cmuFrom = new CaseManagementUnitDTO();
+    @Builder.Default
+    private CaseManagementUnitDTO cmuTo = new CaseManagementUnitDTO();
+    @Builder.Default
+    private TransferStatusDTO transferStatus = new TransferStatusDTO();
+    @Builder.Default
+    private TransferTypeDTO transferType = new TransferTypeDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/AssessmentDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/AssessmentDTO.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -8,7 +9,8 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 public class AssessmentDTO {
-    private IOJAppealDTO iojAppeal;
-    private FinancialAssessmentDTO financialAssessmentDTO;
-
+    @Builder.Default
+    private IOJAppealDTO iojAppeal = new IOJAppealDTO();
+    @Builder.Default
+    private FinancialAssessmentDTO financialAssessmentDTO = new FinancialAssessmentDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CapitalEquityDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CapitalEquityDTO.java
@@ -3,22 +3,25 @@
  */
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collection;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class CapitalEquityDTO extends GenericDTO {
     public static final String RESIDENTIAL_STATUS_OWNER = "OWNER";
     public static final String RESIDENTIAL_STATUS_NO_FIXED_ABODE = "NOFIXABODE";
 
+    private Long usn;
     private Boolean available;
     private Boolean noCapitalDeclared;
     private Boolean suffientVeriToCoverCase;
@@ -28,12 +31,15 @@ public class CapitalEquityDTO extends GenericDTO {
     private BigDecimal totalCapital;
     private BigDecimal totalEquity;
     private BigDecimal totalCapitalAndEquity;
-    private Collection<EquityDTO> equityObjects;
-    private Collection<CapitalPropertyDTO> capitalProperties;
-    private Collection<CapitalOtherDTO> capitalOther;
-    private CapitalEvidenceSummaryDTO capitalEvidenceSummary;
 
-    private MotorVehicleOwnerDTO motorVehicleOwnerDTO;
-
-    private Long usn;
+    @Builder.Default
+    private Collection<EquityDTO> equityObjects = new ArrayList<>();
+    @Builder.Default
+    private Collection<CapitalPropertyDTO> capitalProperties = new ArrayList<>();
+    @Builder.Default
+    private Collection<CapitalOtherDTO> capitalOther = new ArrayList<>();
+    @Builder.Default
+    private CapitalEvidenceSummaryDTO capitalEvidenceSummary = new CapitalEvidenceSummaryDTO();
+    @Builder.Default
+    private MotorVehicleOwnerDTO motorVehicleOwnerDTO = new MotorVehicleOwnerDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CapitalEquityDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CapitalEquityDTO.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package gov.uk.courtdata.dto.application;
 
@@ -8,32 +8,32 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 
 @Data
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-public class CapitalEquityDTO extends GenericDTO
-{
+public class CapitalEquityDTO extends GenericDTO {
     public static final String RESIDENTIAL_STATUS_OWNER = "OWNER";
     public static final String RESIDENTIAL_STATUS_NO_FIXED_ABODE = "NOFIXABODE";
 
-    private Boolean							available;
-	private Boolean                         noCapitalDeclared;
-    private Boolean                         suffientVeriToCoverCase;
-    private Boolean                         verifiedEquityToCoverCase;
-    private Boolean                         suffientDeclToCoverCase;
-    private Boolean                         declaredEquityToCoverCase;
-    private SysGenCurrency                  totalCapital;
-    private Currency                        totalEquity;
-    private Currency                        totalCapitalAndEquity;
-    private Collection<EquityDTO>           equityObjects;
-    private Collection<CapitalPropertyDTO>  capitalProperties;
-    private Collection<CapitalOtherDTO>     capitalOther;
-    private CapitalEvidenceSummaryDTO       capitalEvidenceSummary;
-  
+    private Boolean available;
+    private Boolean noCapitalDeclared;
+    private Boolean suffientVeriToCoverCase;
+    private Boolean verifiedEquityToCoverCase;
+    private Boolean suffientDeclToCoverCase;
+    private Boolean declaredEquityToCoverCase;
+    private BigDecimal totalCapital;
+    private BigDecimal totalEquity;
+    private BigDecimal totalCapitalAndEquity;
+    private Collection<EquityDTO> equityObjects;
+    private Collection<CapitalPropertyDTO> capitalProperties;
+    private Collection<CapitalOtherDTO> capitalOther;
+    private CapitalEvidenceSummaryDTO capitalEvidenceSummary;
+
     private MotorVehicleOwnerDTO motorVehicleOwnerDTO;
-    
-    private Long 							usn;
+
+    private Long usn;
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CaseManagementUnitDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CaseManagementUnitDTO.java
@@ -9,12 +9,9 @@ import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class CaseManagementUnitDTO extends GenericDTO {
-
-    private static final long serialVersionUID = 2947962979790795526L;
-
     private Long cmuId;
     private Long areaId;
     private Boolean enabled;
@@ -23,5 +20,4 @@ public class CaseManagementUnitDTO extends GenericDTO {
     private String name;
     private String description;
     private Date timeStamp;
-
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ContributionsDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/ContributionsDTO.java
@@ -5,18 +5,19 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigDecimal;
+
 @Data
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 public class ContributionsDTO extends GenericDTO {
     private Long id;
-    private SysGenCurrency monthlyContribs;
-    private SysGenCurrency upfrontContribs;
+    private BigDecimal monthlyContribs;
+    private BigDecimal upfrontContribs;
     private SysGenDate effectiveDate;
     private SysGenDate calcDate;
-    private SysGenCurrency capped;
+    private BigDecimal capped;
     private boolean upliftApplied;
     private SysGenString basedOn;
-
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CorrespondenceDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CorrespondenceDTO.java
@@ -1,17 +1,19 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class CorrespondenceDTO extends GenericDTO {
     private Long id;
     private Long repId;
@@ -19,10 +21,11 @@ public class CorrespondenceDTO extends GenericDTO {
     private Long passportAssessmentId;
     private Date generatedDate;
     private Date lastPrintDate;
-    private CorrespondenceTypeDTO correspondenceType;
     private String templateName;
-    private Date originalEmailDate; // MW - 30/03/2017 - FIP Changes
+    private Date originalEmailDate;
 
-    private Collection<PrintDateDTO> printDateDTOs;
-
+    @Builder.Default
+    private Collection<PrintDateDTO> printDateDTOs = new ArrayList<>();
+    @Builder.Default
+    private CorrespondenceTypeDTO correspondenceType = new CorrespondenceTypeDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CrownCourtOverviewDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CrownCourtOverviewDTO.java
@@ -1,23 +1,32 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class CrownCourtOverviewDTO extends GenericDTO {
     private Boolean available;
-    private CrownCourtSummaryDTO crownCourtSummaryDTO;
-    private ContributionsDTO contribution;
-    private Collection<ContributionSummaryDTO> contributionSummary;
-    private ApplicantPaymentDetailsDTO applicantPaymentDetailsDTO;
-    private Collection<CorrespondenceDTO> correspondence;
-    private AppealDTO appealDTO;
+
+    @Builder.Default
+    private AppealDTO appealDTO = new AppealDTO();
+    @Builder.Default
+    private ContributionsDTO contribution = new ContributionsDTO();
+    @Builder.Default
+    private CrownCourtSummaryDTO crownCourtSummaryDTO = new CrownCourtSummaryDTO();
+    @Builder.Default
+    private Collection<ContributionSummaryDTO> contributionSummary = new ArrayList<>();
+    @Builder.Default
+    private ApplicantPaymentDetailsDTO applicantPaymentDetailsDTO = new ApplicantPaymentDetailsDTO();
+    @Builder.Default
+    private Collection<CorrespondenceDTO> correspondence = new ArrayList<>();
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CrownCourtSummaryDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/CrownCourtSummaryDTO.java
@@ -1,17 +1,19 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class CrownCourtSummaryDTO extends GenericDTO {
     public static final String REP_ORDER_DECISION_GRANTED = "Granted";
     public static final String REP_TYPE_CC_ONLY = "Crown Court Only";
@@ -23,10 +25,14 @@ public class CrownCourtSummaryDTO extends GenericDTO {
     private Date ccWithDrawalDate;
     private SysGenString repOrderDecision;
     private Boolean inPrisoned;
-    private OutcomeDTO ccOutcome;
-    private OutcomeDTO ccAppealOutcome;
     private Boolean benchWarrantyIssued;
-    private EvidenceFeeDTO evidenceProvisionFee;
-    private Collection<OutcomeDTO> outcomeDTOs;
 
+    @Builder.Default
+    private OutcomeDTO ccOutcome = new OutcomeDTO();
+    @Builder.Default
+    private OutcomeDTO ccAppealOutcome = new OutcomeDTO();
+    @Builder.Default
+    private EvidenceFeeDTO evidenceProvisionFee = new EvidenceFeeDTO();
+    @Builder.Default
+    private Collection<OutcomeDTO> outcomeDTOs = new ArrayList<>();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/DrcProcessDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/DrcProcessDTO.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package gov.uk.courtdata.dto.application;
 
@@ -8,23 +8,23 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigDecimal;
 import java.util.Date;
 
 @Data
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-public class DrcProcessDTO extends GenericDTO 
-{
-	private long					id;
-	private String					stage;
-	private String					subStage;
-	private String					status;
-	private String					stageTime;
-	private SysGenCurrency			collected;
-	private String					charges;
-	private String					type;
-	private Date					lastPaymentTime;
+public class DrcProcessDTO extends GenericDTO {
+    private long id;
+    private String stage;
+    private String subStage;
+    private String status;
+    private String stageTime;
+    private BigDecimal collected;
+    private String charges;
+    private String type;
+    private Date lastPaymentTime;
 
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/DrcSummaryDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/DrcSummaryDTO.java
@@ -1,24 +1,24 @@
 /**
- * 
+ *
  */
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Collection;
+import java.util.HashSet;
 
 @Data
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 public class DrcSummaryDTO extends GenericDTO {
+    private long repId;
 
-	private	long								repId;
-	private Collection<DrcConversationDTO>		conversations;
-
-
-
+    @Builder.Default
+    private Collection<DrcConversationDTO> conversations = new HashSet<>();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/FinancialAssessmentDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/FinancialAssessmentDTO.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -7,16 +8,21 @@ import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class FinancialAssessmentDTO extends GenericDTO {
     private Long id;
-    private Long criteriaId;
-    private InitialAssessmentDTO initial;
-    private FullAssessmentDTO full;
-    private HardshipOverviewDTO hardship;
-    private IncomeEvidenceSummaryDTO incomeEvidence;
-    private Boolean fullAvailable;
     private Long usn;
+    private Long criteriaId;
+    @Builder.Default
+    private Boolean fullAvailable = Boolean.FALSE;
+    @Builder.Default
+    private InitialAssessmentDTO initial = new InitialAssessmentDTO();
+    @Builder.Default
+    private FullAssessmentDTO full = new FullAssessmentDTO();
+    @Builder.Default
+    private HardshipOverviewDTO hardship = new HardshipOverviewDTO();
+    @Builder.Default
+    private IncomeEvidenceSummaryDTO incomeEvidence = new IncomeEvidenceSummaryDTO();
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/FullAssessmentDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/FullAssessmentDTO.java
@@ -1,22 +1,23 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class FullAssessmentDTO extends GenericDTO {
     private Long criteriaId;
     private Date assessmentDate;
     private String assessmentNotes;
-    private Collection<AssessmentSectionSummaryDTO> sectionSummaries;
     private Double adjustedLivingAllowance;
     private String otherHousingNote;
     private Double totalAggregatedExpense;
@@ -24,6 +25,9 @@ public class FullAssessmentDTO extends GenericDTO {
     private Double threshold;
     private String result;
     private String resultReason;
-    private AssessmentStatusDTO assessmnentStatusDTO;
+    @Builder.Default
+    private AssessmentStatusDTO assessmnentStatusDTO = new AssessmentStatusDTO();
+    @Builder.Default
+    private Collection<AssessmentSectionSummaryDTO> sectionSummaries = new ArrayList<>();
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/GenericDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/GenericDTO.java
@@ -5,13 +5,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Data
 @SuperBuilder
 @NoArgsConstructor
 public class GenericDTO {
-    private Timestamp timestamp;
+    private LocalDateTime timestamp;
     private Boolean selected;
     @Builder.Default
     private Boolean mDirty = false;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/HardshipOverviewDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/HardshipOverviewDTO.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -7,10 +8,11 @@ import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class HardshipOverviewDTO extends GenericDTO {
-    private ApplicationHardshipReviewDTO magCourtHardship;
-    private ApplicationHardshipReviewDTO crownCourtHardship;
-
+    @Builder.Default
+    private ApplicationHardshipReviewDTO magCourtHardship = new ApplicationHardshipReviewDTO();
+    @Builder.Default
+    private ApplicationHardshipReviewDTO crownCourtHardship = new ApplicationHardshipReviewDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/IOJAppealDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/IOJAppealDTO.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -9,8 +10,8 @@ import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class IOJAppealDTO extends GenericDTO {
     private Long iojId;
     private Long cmuId;
@@ -20,8 +21,11 @@ public class IOJAppealDTO extends GenericDTO {
     private String appealDecisionResult;
     private String notes;
 
-    private IOJDecisionReasonDTO appealReason;
-    private AssessmentStatusDTO assessmentStatusDTO;
-    private NewWorkReasonDTO newWorkReasonDTO;
+    @Builder.Default
+    private IOJDecisionReasonDTO appealReason = new IOJDecisionReasonDTO();
+    @Builder.Default
+    private AssessmentStatusDTO assessmentStatusDTO = new AssessmentStatusDTO();
+    @Builder.Default
+    private NewWorkReasonDTO newWorkReasonDTO = new NewWorkReasonDTO();
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/IncomeEvidenceSummaryDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/IncomeEvidenceSummaryDTO.java
@@ -1,20 +1,20 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class IncomeEvidenceSummaryDTO extends GenericDTO {
-    private static final long serialVersionUID = 1L;
-
     private Date evidenceDueDate;
     private Date evidenceReceivedDate;
     private Date upliftAppliedDate;
@@ -22,11 +22,15 @@ public class IncomeEvidenceSummaryDTO extends GenericDTO {
     private Date firstReminderDate;
     private Date secondReminderDate;
     private String incomeEvidenceNotes;
-    private Collection<EvidenceDTO> applicantIncomeEvidenceList;
-    private Collection<EvidenceDTO> partnerIncomeEvidenceList;
-    private Collection<ExtraEvidenceDTO> extraEvidenceList;
-    private Boolean enabled;
     private Boolean upliftsAvailable;
 
+    @Builder.Default
+    private Boolean enabled = false;
+    @Builder.Default
+    private Collection<ExtraEvidenceDTO> extraEvidenceList = new ArrayList<>();
+    @Builder.Default
+    private Collection<EvidenceDTO> applicantIncomeEvidenceList = new ArrayList<>();
+    @Builder.Default
+    private Collection<EvidenceDTO> partnerIncomeEvidenceList = new ArrayList<>();
 }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/MotorVehicleOwnerDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/MotorVehicleOwnerDTO.java
@@ -3,11 +3,13 @@
  */
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 @Data
@@ -15,17 +17,11 @@ import java.util.Collection;
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper=false)
 public class MotorVehicleOwnerDTO extends GenericDTO {
-
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = -6525468902833698008L;
-	
-	
 	private Long 		id;
 	private Long 		repId;
 	private Boolean 	noVehicleDeclared;
 	private Boolean		available;
-	
-	private Collection<VehicleRegistrationMarkDTO>  vehicleRegistrationMarkDTOs;
+
+	@Builder.Default
+	private Collection<VehicleRegistrationMarkDTO>  vehicleRegistrationMarkDTOs = new ArrayList<>();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/OffenceDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/OffenceDTO.java
@@ -7,12 +7,10 @@ import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class OffenceDTO extends GenericDTO {
-
     private String offenceType;
     private String description;
     private Double contributionCap;
-
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/PassportedDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/PassportedDTO.java
@@ -32,6 +32,7 @@ public class PassportedDTO extends GenericDTO {
     private Boolean benefitGaurenteedStatePension;
     private Boolean benefitClaimedByPartner;
     private Boolean benefitEmploymentSupport;
+    private Boolean benefitUniversalCredit;
     private PartnerDTO partnerDetails;
     private String notes;
     private String result;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/PassportedDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/PassportedDTO.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -9,32 +10,21 @@ import java.util.Date;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class PassportedDTO extends GenericDTO {
-    private static final long serialVersionUID = 1L;
-
+    private Long usn;
     private Long passportedId;
     private Long cmuId;
-    private Long usn;
-
     private Date date;
-
-    private AssessmentStatusDTO assessementStatusDTO;
-    private PassportConfirmationDTO passportConfirmationDTO;
-    private NewWorkReasonDTO newWorkReason;
-    private ReviewTypeDTO reviewType;
-
     private String dwpResult;
-
     private Boolean benefitIncomeSupport;
-    private JobSeekerDTO benefitJobSeeker;
     private Boolean benefitGaurenteedStatePension;
     private Boolean benefitClaimedByPartner;
     private Boolean benefitEmploymentSupport;
     private Boolean benefitUniversalCredit;
-    private PartnerDTO partnerDetails;
     private String notes;
+    private String whoDwpChecked;
     private String result;
     private Boolean under18HeardYouthCourt;
     private Boolean under18HeardMagsCourt;
@@ -42,8 +32,18 @@ public class PassportedDTO extends GenericDTO {
     private Boolean under16;
     private Boolean between1617;
 
-    private IncomeEvidenceSummaryDTO passportSummaryEvidenceDTO;
-
-    private String whoDwpChecked;
-
+    @Builder.Default
+    private PartnerDTO partnerDetails = new PartnerDTO();
+    @Builder.Default
+    private JobSeekerDTO benefitJobSeeker = new JobSeekerDTO();
+    @Builder.Default
+    private AssessmentStatusDTO assessementStatusDTO = new AssessmentStatusDTO();
+    @Builder.Default
+    private PassportConfirmationDTO passportConfirmationDTO = new PassportConfirmationDTO();
+    @Builder.Default
+    private NewWorkReasonDTO newWorkReason = new NewWorkReasonDTO();
+    @Builder.Default
+    private ReviewTypeDTO reviewType = new ReviewTypeDTO();
+    @Builder.Default
+    private IncomeEvidenceSummaryDTO passportSummaryEvidenceDTO = new IncomeEvidenceSummaryDTO();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/SupplierDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/application/SupplierDTO.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.dto.application;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -7,11 +8,12 @@ import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class SupplierDTO extends GenericDTO {
-    private String accountNumber;
     private String name;
-    private AddressDTO address;
+    private String accountNumber;
 
+    @Builder.Default
+    private AddressDTO address = new AddressDTO();
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1207)

- Replace custom Currency types with BigDecimals.
  - This mirrors a change in the Orchestration service and simplifies mapping logic.
- Missing universal `benefitUniversalCredit` field added in `PassportedDTO` that was preventing stored procedures from executing correctly due to a mapping issue when converting to the matching Oracle type.
- Fixed incorrect validation message in the `StoredProcedureRepository`
- Replaced `sql.Timestamp` fields with `LocalDateTime` to simplify mapping logic.
- New default values for certain fields in legacy data types to mimic the existing behaviour in MAAT.

**Note:** Dependent on [these](https://github.com/ministryofjustice/laa-maat-orchestration/pull/99) changes to the Orchestration service & [these](https://github.com/ministryofjustice/laa-maat-application/pull/501) changes to MAAT
