### PR TITLE
LASB-3216 Enable Open API/Swagger documentation endpoint in non-prod environments

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -613,7 +613,7 @@ Resources:
       Description: !Sub '${pAppName} API Gateway - HTTP API'
       ProtocolType: HTTP
   ApiIntegration:
-    Type: 'AWS::ApiGatewayV2::Integration'
+    Type: AWS::ApiGatewayV2::Integration
     Properties:
       ApiId: !Ref ApiGateway
       Description: !Sub '${pAppName} Integration Proxy'
@@ -623,8 +623,8 @@ Resources:
       ConnectionType: VPC_LINK
       ConnectionId: !Ref ApiGatewayVpcLink
       PayloadFormatVersion: '1.0'
-  ApiRoute1:
-    Type: 'AWS::ApiGatewayV2::Route'
+  ApiRouteLinkValidate:
+    Type: AWS::ApiGatewayV2::Route
     DependsOn:
       - ApiIntegration
     Properties:
@@ -664,6 +664,14 @@ Resources:
       AuthorizationType: JWT
       AuthorizationScopes: [ !Sub '${pAppName}/${pApiScope1}' ]
       AuthorizerId: !Ref ApiAuthorizerForDces
+      Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
+  ApiRouteSwaggerUI:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: cNonProd
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: 'ANY /open-api/{proxy+}'
+      AuthorizationType: NONE
       Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
   ApiAuthorizer:
     Type: 'AWS::ApiGatewayV2::Authorizer'

--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -665,7 +665,7 @@ Resources:
       AuthorizationScopes: [ !Sub '${pAppName}/${pApiScope1}' ]
       AuthorizerId: !Ref ApiAuthorizerForDces
       Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
-  ApiRouteSwaggerUI:
+  ApiRouteOpenAPI:
     Type: AWS::ApiGatewayV2::Route
     Condition: cNonProd
     Properties:


### PR DESCRIPTION
## Enable Open API/Swagger documentation endpoint in non-prod environments

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3216)

Expose the Open API/Swagger documentation endpoint in all non-prod environments to allow developers and non-Java developers etc. to discover and explore the endpoints available in the MAAT Court Data API.

Changes include:
- Enable unauthenticated access to the endpoint `/open-api/*` in all non-prod environments via a new `AWS::ApiGatewayV2::Route` called `ApiRouteOpenAPI`.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
