### PR TITLE
LASB-3216 Revert renaming of existing routes as it causes an AWS CodePipeline error

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -613,7 +613,7 @@ Resources:
       Description: !Sub '${pAppName} API Gateway - HTTP API'
       ProtocolType: HTTP
   ApiIntegration:
-    Type: AWS::ApiGatewayV2::Integration
+    Type: 'AWS::ApiGatewayV2::Integration'
     Properties:
       ApiId: !Ref ApiGateway
       Description: !Sub '${pAppName} Integration Proxy'
@@ -623,8 +623,8 @@ Resources:
       ConnectionType: VPC_LINK
       ConnectionId: !Ref ApiGatewayVpcLink
       PayloadFormatVersion: '1.0'
-  ApiRouteLinkValidate:
-    Type: AWS::ApiGatewayV2::Route
+  ApiRoute1:
+    Type: 'AWS::ApiGatewayV2::Route'
     DependsOn:
       - ApiIntegration
     Properties:


### PR DESCRIPTION
Revert renaming of existing routes as it causes an AWS CodePipeline Deployment failure:

> Resource handler returned message: Route with key ANY /link/validate already exists for this API (Service: AmazonApiGatewayV2; Status Code: 409)

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3216)

Previous PR: https://github.com/ministryofjustice/laa-maat-court-data-api/pull/951

See below screenshots for details:

![Screenshot 2024-04-18 at 17 25 35](https://github.com/ministryofjustice/laa-maat-court-data-api/assets/129768292/1d62b951-7071-4077-bb84-61f722f8ddf9)

![Screenshot 2024-04-18 at 17 26 01](https://github.com/ministryofjustice/laa-maat-court-data-api/assets/129768292/3bfc6d71-8f69-4702-9bf5-f6f5cea4f871)




## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
