### PR TITLE
LASB-3216 Modify springdoc.api-docs.path to align with springdoc.api-docs.swagger-ui.path

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -673,14 +673,6 @@ Resources:
       RouteKey: 'ANY /open-api/{proxy+}'
       AuthorizationType: NONE
       Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
-  ApiRouteMaatAPIDocs:
-    Type: AWS::ApiGatewayV2::Route
-    Condition: cNonProd
-    Properties:
-      ApiId: !Ref ApiGateway
-      RouteKey: 'ANY /maat-api/{proxy+}'
-      AuthorizationType: NONE
-      Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
   ApiAuthorizer:
     Type: 'AWS::ApiGatewayV2::Authorizer'
     Properties:

--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -673,6 +673,14 @@ Resources:
       RouteKey: 'ANY /open-api/{proxy+}'
       AuthorizationType: NONE
       Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
+  ApiRouteMaatAPIDocs:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: cNonProd
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: 'ANY /maat-api/{proxy+}'
+      AuthorizationType: NONE
+      Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
   ApiAuthorizer:
     Type: 'AWS::ApiGatewayV2::Authorizer'
     Properties:

--- a/maat-court-data-api/src/main/resources/application.yaml
+++ b/maat-court-data-api/src/main/resources/application.yaml
@@ -67,7 +67,7 @@ springdoc:
   packagesToScan: gov.uk.courtdata
   show-actuator: true
   api-docs:
-    path: /maat-api
+    path: /open-api
     enabled: true
 
   swagger-ui:


### PR DESCRIPTION
Modify springdoc.api-docs.path to align with springdoc.api-docs.swagger-ui.path to minimise the number of paths required to be exposed via AWS ApiGatewayV2

Specifically, change `springdoc.api-docs.path` from `/maat-api` to `/open-api`.


## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3216)

See attached for evidence of local testing, note that all paths sit under the parent `/open-api `path.

![Swagger maat-api path](https://github.com/ministryofjustice/laa-maat-court-data-api/assets/129768292/ea31ad94-47e2-4d4c-ba88-c0f50b441012)

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
