### PR TITLE
LASB-3216 Add missing API Route for the base open-api URL

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -673,6 +673,14 @@ Resources:
       RouteKey: 'ANY /open-api/{proxy+}'
       AuthorizationType: NONE
       Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
+  ApiRouteOpenAPIBaseURL:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: cNonProd
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: 'ANY /open-api'
+      AuthorizationType: NONE
+      Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
   ApiAuthorizer:
     Type: 'AWS::ApiGatewayV2::Authorizer'
     Properties:


### PR DESCRIPTION
## What

[LASB-3216](https://dsdmoj.atlassian.net/browse/LASB-3216)

Following testing in Dev [https://maat-cd-api.dev.legalservices.gov.uk/open-api/docs.html](https://maat-cd-api.dev.legalservices.gov.uk/open-api/docs.html) I can see that the base URL `/open-api` is not accessible and is returning a 404 Not Found.

This is because the AWS API Gateway Route does not include the base url `/open-api `only sub-paths e.g. `/open-api/` and `/open-api/docs.html` to resolve this, an additional route has been added for the base Open API URL.

![MAAT Court Data Dev - missing route open-api](https://github.com/ministryofjustice/laa-maat-court-data-api/assets/129768292/e43d8fcc-f265-4fb9-b38d-922346577f8c)

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[LASB-3216]: https://dsdmoj.atlassian.net/browse/LASB-3216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ