### PR TITLE
DCES-333 Changed the URL prefix for DCES test-data services

### DIFF
--- a/maat-court-data-api/src/main/resources/application.yaml
+++ b/maat-court-data-api/src/main/resources/application.yaml
@@ -120,7 +120,7 @@ api-endpoints:
   application-domain: /api/internal/v1/application
   applicant-domain: /api/internal/v1/applicant
   debt-collection-enforcement-domain: /api/internal/v1/debt-collection-enforcement
-  debt-collection-enforcement-domain-test-data: /api/internal/v1/test-data/debt-collection-enforcement
+  debt-collection-enforcement-domain-test-data: /api/internal/v1/debt-collection-enforcement/test-data
 
 feature:
   postMvpEnabled: ${POST_MVP_ENABLED}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/testdata/ConcorContributionsTestDataControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/testdata/ConcorContributionsTestDataControllerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 class ConcorContributionsTestDataControllerTest {
 
-    private static final String ENDPOINT_URL = "/api/internal/v1/test-data/debt-collection-enforcement";
+    private static final String ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/test-data";
     private static final String CONCOR_CONTRIBUTION_STATUS_URL = "/concor-contribution-status";
 
     @Autowired

--- a/maat-court-data-api/src/test/resources/application.yaml
+++ b/maat-court-data-api/src/test/resources/application.yaml
@@ -121,5 +121,5 @@ api-endpoints:
   application-domain: /api/internal/v1/application
   applicant-domain: /api/internal/v1/applicant
   debt-collection-enforcement-domain: /api/internal/v1/debt-collection-enforcement
-  debt-collection-enforcement-domain-test-data: /api/internal/v1/test-data/debt-collection-enforcement
+  debt-collection-enforcement-domain-test-data: /api/internal/v1/debt-collection-enforcement/test-data
   user-domain: /api/internal/v1/users

--- a/maat-court-data-api/src/testSqsIntegration/resources/application.yaml
+++ b/maat-court-data-api/src/testSqsIntegration/resources/application.yaml
@@ -120,7 +120,7 @@ api-endpoints:
   applicant-domain: /api/internal/v1/applicant
   user-domain: /api/internal/v1/users
   debt-collection-enforcement-domain: /api/internal/v1/debt-collection-enforcement
-  debt-collection-enforcement-domain-test-data: /api/internal/v1/test-data/debt-collection-enforcement
+  debt-collection-enforcement-domain-test-data: /api/internal/v1/debt-collection-enforcement/test-data
 
 xray:
   enabled: false


### PR DESCRIPTION
## What

* Changed /api/internal/v1/test-data/debt-collection-enforcement to /api/internal/v1/debt-collection-enforcement/test-data
* This was the existing AWS API Gateway CloudFormation file will cover the test-data services with OAuth
* Without this change, the test-data services always responded 401 Unauthorized in the development env
* Changing the URL (rather than changing the CloudFormation files to add the new prefix) was requested by the Crime Apps team (I spoke with Gangadhar Nitta)

[Test Scenarios for the Contribution Use Cases for the Service](https://dsdmoj.atlassian.net/browse/DCES-333)

Moved URLs around to avoid 401 Unauthorized because the API Gateway did not cover the old URL path.

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
