### PR TITLE
DCES-364

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/testdata/ConcorContributionsTestDataController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/testdata/ConcorContributionsTestDataController.java
@@ -24,10 +24,10 @@ public class ConcorContributionsTestDataController {
 
     @NotFoundApiResponse
     @PutMapping(value = "/concor-contribution-status", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<Long>> updateStatus (@Valid UpdateConcorContributionStatusRequest request){
+    public ResponseEntity<List<Integer>> updateStatus (@Valid @RequestBody UpdateConcorContributionStatusRequest request){
 
-        log.info("request {}", request);
-        List<Long> updatedConcorContributionsIds = concorContributionsService.updateConcorContributionStatus(request);
+        log.info("request: {}", request);
+        List<Integer> updatedConcorContributionsIds = concorContributionsService.updateConcorContributionStatus(request);
         log.info("response for concor-contribution-status {}", updatedConcorContributionsIds);
         return ResponseEntity.ok(updatedConcorContributionsIds);
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -36,12 +36,12 @@ public class ConcorContributionsService {
     private final DebtCollectionService debtCollectionService;
 
     @Transactional
-    public List<Long> updateConcorContributionStatus(UpdateConcorContributionStatusRequest request){
+    public List<Integer> updateConcorContributionStatus(UpdateConcorContributionStatusRequest request){
 
-        List<Long> idsToUpdate = concorRepository.findIdsForUpdate(Pageable.ofSize(request.getRecordCount()));
+        List<Integer> idsToUpdate = concorRepository.findIdsForUpdate(Pageable.ofSize(request.getRecordCount()));
 
         if (!idsToUpdate.isEmpty()) {
-            concorRepository.updateStatusForIds(request.getStatus().name(), idsToUpdate);
+            concorRepository.updateStatusForIds(request.getStatus(), idsToUpdate);
         }
         return idsToUpdate;
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
@@ -18,11 +18,11 @@ public interface ConcorContributionsRepository extends JpaRepository<ConcorContr
     List<ConcorContributionsEntity> findByIdIn(Set<Integer> ids);
 
     @Query("SELECT cc.id FROM ConcorContributionsEntity cc WHERE cc.status = 'SENT' AND cc.fullXml IS NOT NULL AND cc.dateModified IS NOT NULL ORDER BY cc.id DESC")
-    List<Long> findIdsForUpdate(Pageable pageable);
+    List<Integer> findIdsForUpdate(Pageable pageable);
 
     @Modifying
     @Transactional
     @Query("UPDATE ConcorContributionsEntity cc SET cc.status = :newStatus WHERE cc.id IN :ids")
-    int updateStatusForIds(@Param("newStatus") String newStatus, @Param("ids") List<Long> ids);
+    int updateStatusForIds(@Param("newStatus") ConcorContributionStatus newStatus, @Param("ids") List<Integer> ids);
 
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/testdata/ConcorContributionsTestDataControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/testdata/ConcorContributionsTestDataControllerTest.java
@@ -39,7 +39,7 @@ class ConcorContributionsTestDataControllerTest {
         final String requestBody = objectMapper.writeValueAsString(request);
 
         when(concorContributionsService.updateConcorContributionStatus(request))
-                .thenReturn(List.of(111L,222L, 333L));
+                .thenReturn(List.of(111,222, 333));
 
         mvc.perform(MockMvcRequestBuilders.put(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_STATUS_URL))
                         .content(requestBody)

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
@@ -250,10 +250,10 @@ class ConcorContributionsServiceTest {
     @Test
     void testUpdateConcorContributionsStatus(){
 
-        when(concorRepository.findIdsForUpdate(any())).thenReturn(List.of(1111L,2222L));
+        when(concorRepository.findIdsForUpdate(any())).thenReturn(List.of(1111,2222));
         when(concorRepository.updateStatusForIds(any(), any())).thenReturn(2);
 
-        List<Long> response = concorService.updateConcorContributionStatus(UpdateConcorContributionStatusRequest.builder().recordCount(2)
+        List<Integer> response = concorService.updateConcorContributionStatus(UpdateConcorContributionStatusRequest.builder().recordCount(2)
                 .status(ConcorContributionStatus.SENT).build());
 
         verify(concorRepository).findIdsForUpdate(any());
@@ -266,7 +266,7 @@ class ConcorContributionsServiceTest {
 
         when(concorRepository.findIdsForUpdate(any())).thenReturn(List.of());
 
-        List<Long> response = concorService.updateConcorContributionStatus(UpdateConcorContributionStatusRequest.builder().recordCount(1)
+        List<Integer> response = concorService.updateConcorContributionStatus(UpdateConcorContributionStatusRequest.builder().recordCount(1)
                 .status(ConcorContributionStatus.SENT).build());
 
         verify(concorRepository).findIdsForUpdate(any());


### PR DESCRIPTION
Fix problems with the new test endpoint /concor-contribution-status where the request parameters were not being received and some other data types were incompatible with other parts of the code.

## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-364)

Describe what you did and why.

Added the @RequestBody annotation to the request parameter of ConcorContributionsService.updateStatus, changed data types of Contribution Id from Long to Integer and status from String to Enum to make the endpoint work as expected.


## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
