### PR TITLE
DCES-349 Fix bug when inserting new rows into contribution_files table

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
@@ -75,7 +75,9 @@ public class DebtCollectionRepository {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(
                 con -> {
-                    PreparedStatement ps = con.prepareStatement(sqlStatement, Statement.RETURN_GENERATED_KEYS);
+                    // Oracle 19c returns string `ROWID` with `Statement.RETURN_GENERATED_KEYS` flag (not numeric `ID`).
+                    // https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/JDBC-standards-support.html#GUID-11E3AAF8-009C-418E-8263-E41EE49F2EA8
+                    PreparedStatement ps = con.prepareStatement(sqlStatement, new String[] {"ID"});
                     Clob xmlClob = con.createClob();
                     Clob ackClob = con.createClob();
 


### PR DESCRIPTION
## What

[Minor fix in the context of DCES-349](https://dsdmoj.atlassian.net/browse/DCES-349)

The existing endpoint `/create-contribution-file` failed with a casting exception because the alphanumeric Oracle `ROWID` key (returned when using `Statement.RETURN_GENERATED_KEYS` flag for the JDBC statement) could not be converted into a `java.lang.Number`.

I'm aware there's a larger task to refactor the DCES endpoints into a more REST-ful structure, but this is a point micro-fix independent of that task.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
