### PR TITLE
DCES-349 set other concor_contribution fields correctly when update status (and clarify names of the two update-status methods)

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
@@ -75,7 +75,7 @@ public class ConcorContributionsRestController {
     public ResponseEntity<List<Integer>> updateStatus (@Valid @RequestBody UpdateConcorContributionStatusRequest request){
 
         log.info("request: {}", request);
-        List<Integer> updatedConcorContributionsIds = concorContributionsService.updateConcorContributionStatus(request);
+        List<Integer> updatedConcorContributionsIds = concorContributionsService.updateConcorContributionStatusAndResetContribFile(request);
         log.info("response for concor-contribution-status {}", updatedConcorContributionsIds);
         return ResponseEntity.ok(updatedConcorContributionsIds);
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
@@ -22,7 +22,7 @@ public interface ConcorContributionsRepository extends JpaRepository<ConcorContr
 
     @Modifying
     @Transactional
-    @Query("UPDATE ConcorContributionsEntity cc SET cc.status = :newStatus WHERE cc.id IN :ids")
-    int updateStatusForIds(@Param("newStatus") ConcorContributionStatus newStatus, @Param("ids") List<Integer> ids);
+    @Query("UPDATE ConcorContributionsEntity cc SET cc.status = :newStatus, cc.contribFileId = NULL WHERE cc.id IN :ids")
+    int updateStatusAndResetContribFileForIds(@Param("newStatus") ConcorContributionStatus newStatus, @Param("ids") List<Integer> ids);
 
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
@@ -186,7 +186,7 @@ class ConcorContributionsRestControllerTest {
         final ObjectMapper objectMapper = new ObjectMapper();
         final String requestBody = objectMapper.writeValueAsString(request);
 
-        when(concorContributionsService.updateConcorContributionStatus(request))
+        when(concorContributionsService.updateConcorContributionStatusAndResetContribFile(request))
                 .thenReturn(List.of(111,222, 333));
 
         mvc.perform(MockMvcRequestBuilders.put(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_STATUS_URL))
@@ -206,7 +206,7 @@ class ConcorContributionsRestControllerTest {
         final ObjectMapper objectMapper = new ObjectMapper();
         final String requestBody = objectMapper.writeValueAsString(request);
 
-        when(concorContributionsService.updateConcorContributionStatus(request)).thenReturn(List.of());
+        when(concorContributionsService.updateConcorContributionStatusAndResetContribFile(request)).thenReturn(List.of());
 
         mvc.perform(MockMvcRequestBuilders.put(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_STATUS_URL))
                         .content(requestBody)

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
@@ -256,13 +256,13 @@ class ConcorContributionsServiceTest {
     void testUpdateConcorContributionsStatus(){
 
         when(concorRepository.findIdsForUpdate(any())).thenReturn(List.of(1111,2222));
-        when(concorRepository.updateStatusForIds(any(), any())).thenReturn(2);
+        when(concorRepository.updateStatusAndResetContribFileForIds(any(), any())).thenReturn(2);
 
-        List<Integer> response = concorService.updateConcorContributionStatus(UpdateConcorContributionStatusRequest.builder().recordCount(2)
+        List<Integer> response = concorService.updateConcorContributionStatusAndResetContribFile(UpdateConcorContributionStatusRequest.builder().recordCount(2)
                 .status(ConcorContributionStatus.SENT).build());
 
         verify(concorRepository).findIdsForUpdate(any());
-        verify(concorRepository).updateStatusForIds(any(), any());
+        verify(concorRepository).updateStatusAndResetContribFileForIds(any(), any());
         assertEquals(2, response.size());
     }
 
@@ -271,11 +271,11 @@ class ConcorContributionsServiceTest {
 
         when(concorRepository.findIdsForUpdate(any())).thenReturn(List.of());
 
-        List<Integer> response = concorService.updateConcorContributionStatus(UpdateConcorContributionStatusRequest.builder().recordCount(1)
+        List<Integer> response = concorService.updateConcorContributionStatusAndResetContribFile(UpdateConcorContributionStatusRequest.builder().recordCount(1)
                 .status(ConcorContributionStatus.SENT).build());
 
         verify(concorRepository).findIdsForUpdate(any());
-        verify(concorRepository,never()).updateStatusForIds(any(), any());
+        verify(concorRepository,never()).updateStatusAndResetContribFileForIds(any(), any());
         assertEquals(0, response.size());
     }
 


### PR DESCRIPTION
## What

Found in the context of developing [DCES_349](https://dsdmoj.atlassian.net/browse/DCES-349)

The updateStatus endpoint that updates a specified count of concor_contribution rows from 'SENT' to a new specified status did not reset the contrib_file_id (which it should do to allow the test to check that the contrib_file_id got set).

> In DCES-349, see validation bullet 'CONTRIB_FILE_ID is populated'. Without this change, then validating this would be pointless.

The service method to set a concor_contribution row to 'SENT' as part of contribution_file creation did not set the userModified to 'DCES' (in fact, it left it unchanged). [TBD, if it should also change the dateModified column.]

> In DCES-349, see validation bullet 'UPDATED_BY = DCES'. Without this change, the user-modified is generally TOGDATA (but could theoretically be anything).

In the course of fixing these two minor issues, I also decided to rename the service method names (and a repository method name) to make their actions more explicit, which is why this PR is more than two lines long.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
