### PR TITLE
Improve consistency of Integration tests with usage of MockMvcIntegrationTest repos

### DIFF
--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/contribution/service/ContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/contribution/service/ContributionsServiceTest.java
@@ -1,5 +1,14 @@
 package gov.uk.courtdata.contribution.service;
 
+import static gov.uk.courtdata.builder.TestEntityDataBuilder.REP_ID;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.contribution.mapper.ContributionsMapper;
@@ -10,19 +19,14 @@ import gov.uk.courtdata.contribution.repository.ContributionsRepository;
 import gov.uk.courtdata.dto.ContributionsDTO;
 import gov.uk.courtdata.entity.ContributionsEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
-
-import static gov.uk.courtdata.builder.TestEntityDataBuilder.REP_ID;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ContributionsServiceTest {
@@ -75,7 +79,7 @@ class ContributionsServiceTest {
         when(repository.findById(anyInt())).thenReturn(Optional.ofNullable(contributionsEntity));
         when(repository.saveAndFlush(any(ContributionsEntity.class))).thenReturn(contributionsEntity);
         contributionsService.update(UpdateContributions.builder().id(testId).build());
-        assert contributionsEntity != null;
+        assertNotNull(contributionsEntity);
         verify(repository).saveAndFlush(contributionsEntity);
         verify(contributionsMapper).mapEntityToDTO(any(ContributionsEntity.class));
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantControllerIntegrationTest.java
@@ -1,24 +1,24 @@
 package gov.uk.courtdata.integration.applicant;
 
+import static gov.uk.courtdata.builder.TestModelDataBuilder.REP_ID;
+import static gov.uk.courtdata.builder.TestModelDataBuilder.SEND_TO_CCLF;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.applicant.dto.RepOrderApplicantLinksDTO;
 import gov.uk.courtdata.applicant.entity.RepOrderApplicantLinksEntity;
+import gov.uk.courtdata.applicant.repository.ApplicantHistoryRepository;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
-import gov.uk.courtdata.applicant.repository.ApplicantHistoryRepository;
-import gov.uk.courtdata.applicant.repository.RepOrderApplicantLinksRepository;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.RepOrderRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import static gov.uk.courtdata.builder.TestModelDataBuilder.REP_ID;
-import static gov.uk.courtdata.builder.TestModelDataBuilder.SEND_TO_CCLF;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class ApplicantControllerIntegrationTest extends MockMvcIntegrationTest {
@@ -28,20 +28,15 @@ public class ApplicantControllerIntegrationTest extends MockMvcIntegrationTest {
     private static final int ID = 1;
 
     @Autowired
-    private RepOrderApplicantLinksRepository repOrderApplicantLinksRepository;
-
-    @Autowired
-    private RepOrderRepository repOrderRepository;
-
-    @Autowired
     private ApplicantHistoryRepository applicantHistoryRepository;
 
     @Test
     void givenCorrectRepId_whenGetRepOrderApplicantLinksIsInvoked_thenResponseIsReturned() throws Exception {
-        RepOrderEntity repOrderEntity = repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder());
+        RepOrderEntity repOrderEntity = repos.repOrder.save(
+            TestEntityDataBuilder.getPopulatedRepOrder());
         RepOrderApplicantLinksEntity repOrderApplicantLinks = TestEntityDataBuilder.getRepOrderApplicantLinksEntity();
         repOrderApplicantLinks.setRepId(repOrderEntity.getId());
-        repOrderApplicantLinksRepository.saveAndFlush(repOrderApplicantLinks);
+        repos.repOrderApplicantLinks.saveAndFlush(repOrderApplicantLinks);
         mockMvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL + "/rep-order-applicant-links/" + repOrderEntity.getId()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
@@ -55,9 +50,10 @@ public class ApplicantControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenValidRequest_whenUpdateRepOrderApplicantLinksIsInvoked_thenUpdateIsSuccess() throws Exception {
-        repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder(REP_ID));
-        repOrderApplicantLinksRepository.saveAndFlush(TestEntityDataBuilder.getRepOrderApplicantLinksEntity());
-        Integer id = repOrderApplicantLinksRepository.findAll().get(0).getId();
+        repos.repOrder.save(TestEntityDataBuilder.getPopulatedRepOrder(REP_ID));
+        repos.repOrderApplicantLinks.saveAndFlush(
+            TestEntityDataBuilder.getRepOrderApplicantLinksEntity());
+        Integer id = repos.repOrderApplicantLinks.findAll().get(0).getId();
         RepOrderApplicantLinksDTO recordToUpdate = TestModelDataBuilder.getRepOrderApplicantLinksDTO(id);
         mockMvc.perform(MockMvcRequestBuilders.put(ENDPOINT_URL + "/rep-order-applicant-links")
                         .content(objectMapper.writeValueAsString(recordToUpdate))

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantDisabilitiesControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantDisabilitiesControllerIntegrationTest.java
@@ -1,20 +1,18 @@
 package gov.uk.courtdata.integration.applicant;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.applicant.dto.ApplicantDisabilitiesDTO;
-import gov.uk.courtdata.applicant.repository.ApplicantDisabilitiesRepository;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class ApplicantDisabilitiesControllerIntegrationTest extends MockMvcIntegrationTest {
@@ -22,18 +20,10 @@ public class ApplicantDisabilitiesControllerIntegrationTest extends MockMvcInteg
     private static final Integer INVALID_ID = 2345;
     private static final String ENDPOINT_URL = "/api/internal/v1/applicant/applicant-disabilities";
 
-    @Autowired
-    private ApplicantDisabilitiesRepository applicantDisabilitiesRepository;
-
-    @AfterEach
-    public void tearDown() {
-        new RepositoryUtil().clearUp(applicantDisabilitiesRepository);
-    }
-
     @Test
     void givenCorrectId_whenGetApplicantDisabilitiesIsInvoked_thenResponseIsReturned() throws Exception {
         createApplicantDisabilities();
-        Integer id = applicantDisabilitiesRepository.findAll().get(0).getId();
+        Integer id = repos.applicantDisabilities.findAll().get(0).getId();
         mockMvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL + "/" + id))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
@@ -48,7 +38,7 @@ public class ApplicantDisabilitiesControllerIntegrationTest extends MockMvcInteg
     @Test
     void givenValidRequest_whenUpdateApplicantDisabilitiesIsInvoked_thenUpdateIsSuccess() throws Exception {
         createApplicantDisabilities();
-        Integer id = applicantDisabilitiesRepository.findAll().get(0).getId();
+        Integer id = repos.applicantDisabilities.findAll().get(0).getId();
         ApplicantDisabilitiesDTO recordToUpdate = TestModelDataBuilder.getApplicantDisabilitiesDTO(id);
         mockMvc.perform(MockMvcRequestBuilders.put(ENDPOINT_URL)
                         .content(objectMapper.writeValueAsString(recordToUpdate))
@@ -86,14 +76,14 @@ public class ApplicantDisabilitiesControllerIntegrationTest extends MockMvcInteg
     @Test
     void givenValidRequest_whenDeleteApplicantDisabilitiesIsInvoked_thenUpdateIsSuccess() throws Exception {
         createApplicantDisabilities();
-        Integer id = applicantDisabilitiesRepository.findAll().get(0).getId();
+        Integer id = repos.applicantDisabilities.findAll().get(0).getId();
         mockMvc.perform(MockMvcRequestBuilders.delete(ENDPOINT_URL + "/" + id)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 
     private void createApplicantDisabilities() {
-        applicantDisabilitiesRepository.save(TestEntityDataBuilder.getApplicantDisabilitiesEntity());
+        repos.applicantDisabilities.save(TestEntityDataBuilder.getApplicantDisabilitiesEntity());
     }
 
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantDisabilitiesServiceIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantDisabilitiesServiceIntegrationTest.java
@@ -1,46 +1,34 @@
 package gov.uk.courtdata.integration.applicant;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.applicant.dto.ApplicantDisabilitiesDTO;
 import gov.uk.courtdata.applicant.entity.ApplicantDisabilitiesEntity;
-import gov.uk.courtdata.applicant.repository.ApplicantDisabilitiesRepository;
 import gov.uk.courtdata.applicant.service.ApplicantDisabilitiesService;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 @Slf4j
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class ApplicantDisabilitiesServiceIntegrationTest extends MockMvcIntegrationTest {
     private static final Integer INVALID_ID = 2345;
 
     @Autowired
-    private ApplicantDisabilitiesRepository applicantDisabilitiesRepository;
-
-    @Autowired
     private ApplicantDisabilitiesService applicantDisabilitiesService;
-
-    @AfterEach
-    public void tearDown() {
-        new RepositoryUtil().clearUp(applicantDisabilitiesRepository);
-    }
 
     @Test
     void givenValidId_WhenGetApplicantDisabilitiesIsInvoked_thenCorrectResponseIsReturned() {
         createApplicantDisabilities();
-        Integer id = applicantDisabilitiesRepository.findAll().get(0).getId();
+        Integer id = repos.applicantDisabilities.findAll().get(0).getId();
         ApplicantDisabilitiesDTO applicantDisabilitiesDTO = applicantDisabilitiesService.find(id);
         assertThat(applicantDisabilitiesDTO.getDisaDisability()).isNotBlank();
     }
@@ -65,7 +53,7 @@ public class ApplicantDisabilitiesServiceIntegrationTest extends MockMvcIntegrat
     @Test
     void givenAValidInput_whenUpdateApplicantDisabilitiesIsInvoked_thenUpdateIsSuccess() {
         createApplicantDisabilities();
-        Integer id = applicantDisabilitiesRepository.findAll().get(0).getId();
+        Integer id = repos.applicantDisabilities.findAll().get(0).getId();
         ApplicantDisabilitiesDTO recordToUpdate = TestModelDataBuilder.getApplicantDisabilitiesDTO(id);
         ApplicantDisabilitiesDTO applicantDisabilitiesDTO = applicantDisabilitiesService
                 .update(recordToUpdate);
@@ -85,16 +73,16 @@ public class ApplicantDisabilitiesServiceIntegrationTest extends MockMvcIntegrat
     @Test
     void givenAValidInput_whenDeleteApplicantDisabilitiesIsInvoked_thenDeleteIsSuccess() {
         createApplicantDisabilities();
-        Integer id = applicantDisabilitiesRepository.findAll().get(0).getId();
+        Integer id = repos.applicantDisabilities.findAll().get(0).getId();
         applicantDisabilitiesService.delete(id);
-        Optional<ApplicantDisabilitiesEntity> record = applicantDisabilitiesRepository.findById(id);
+        Optional<ApplicantDisabilitiesEntity> record = repos.applicantDisabilities.findById(id);
         assertThatThrownBy(record::get).isInstanceOf(NoSuchElementException.class)
                 .hasMessageContaining("No value present");
 
     }
 
     private void createApplicantDisabilities() {
-        applicantDisabilitiesRepository.save(TestEntityDataBuilder.getApplicantDisabilitiesEntity());
+        repos.applicantDisabilities.save(TestEntityDataBuilder.getApplicantDisabilitiesEntity());
     }
 
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantServiceIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantServiceIntegrationTest.java
@@ -1,42 +1,29 @@
 package gov.uk.courtdata.integration.applicant;
 
+import static gov.uk.courtdata.builder.TestModelDataBuilder.REP_ID;
+import static gov.uk.courtdata.builder.TestModelDataBuilder.SEND_TO_CCLF;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.applicant.dto.ApplicantHistoryDTO;
 import gov.uk.courtdata.applicant.dto.RepOrderApplicantLinksDTO;
 import gov.uk.courtdata.applicant.entity.ApplicantHistoryEntity;
-import gov.uk.courtdata.applicant.repository.ApplicantHistoryRepository;
-import gov.uk.courtdata.applicant.repository.RepOrderApplicantLinksRepository;
 import gov.uk.courtdata.applicant.service.ApplicantHistoryService;
 import gov.uk.courtdata.applicant.service.RepOrderApplicantLinksService;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.RepOrderRepository;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.List;
-
-import static gov.uk.courtdata.builder.TestModelDataBuilder.REP_ID;
-import static gov.uk.courtdata.builder.TestModelDataBuilder.SEND_TO_CCLF;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class ApplicantServiceIntegrationTest extends MockMvcIntegrationTest {
 
     private static final int ID = 1;
-
-    @Autowired
-    private RepOrderApplicantLinksRepository repOrderApplicantLinksRepository;
-
-    @Autowired
-    private RepOrderRepository repOrderRepository;
-
-    @Autowired
-    private ApplicantHistoryRepository applicantHistoryRepository;
 
     @Autowired
     private RepOrderApplicantLinksService repOrderApplicantLinksService;
@@ -46,8 +33,9 @@ public class ApplicantServiceIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenValidRepId_WhenGetRepOrderApplicantLinksIsInvoked_thenCorrectResponseIsReturned() {
-        repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder(REP_ID));
-        repOrderApplicantLinksRepository.saveAndFlush(TestEntityDataBuilder.getRepOrderApplicantLinksEntity());
+        repos.repOrder.save(TestEntityDataBuilder.getPopulatedRepOrder(REP_ID));
+        repos.repOrderApplicantLinks.saveAndFlush(
+            TestEntityDataBuilder.getRepOrderApplicantLinksEntity());
         List<RepOrderApplicantLinksDTO> result = repOrderApplicantLinksService.find(REP_ID);
         assertThat(result.isEmpty()).isFalse();
         assertThat(result.get(0).getId()).isGreaterThan(0);
@@ -64,9 +52,10 @@ public class ApplicantServiceIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenAValidInput_whenUpdateRepOrderApplicantLinksIsInvoked_thenUpdateIsSuccess() {
-        repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder(REP_ID));
-        repOrderApplicantLinksRepository.saveAndFlush(TestEntityDataBuilder.getRepOrderApplicantLinksEntity());
-        Integer id = repOrderApplicantLinksRepository.findAll().get(0).getId();
+        repos.repOrder.save(TestEntityDataBuilder.getPopulatedRepOrder(REP_ID));
+        repos.repOrderApplicantLinks.saveAndFlush(
+            TestEntityDataBuilder.getRepOrderApplicantLinksEntity());
+        Integer id = repos.repOrderApplicantLinks.findAll().get(0).getId();
         RepOrderApplicantLinksDTO recordToUpdate = TestModelDataBuilder.getRepOrderApplicantLinksDTO(id);
         RepOrderApplicantLinksDTO repOrderApplicantLinksDTO = repOrderApplicantLinksService.update(recordToUpdate);
         assertThat(repOrderApplicantLinksDTO.getId()).isEqualTo(id);
@@ -85,8 +74,8 @@ public class ApplicantServiceIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenValidId_whenGetApplicantHistoryIsInvoked_thenCorrectResponseIsReturned() {
         ApplicantHistoryEntity testRecord = TestEntityDataBuilder.getApplicantHistoryEntity("N");
-        applicantHistoryRepository.saveAndFlush(testRecord);
-        Integer id = applicantHistoryRepository.findAll().get(0).getId();
+        repos.applicantHistory.saveAndFlush(testRecord);
+        Integer id = repos.applicantHistory.findAll().get(0).getId();
         ApplicantHistoryDTO result = applicantHistoryService.find(id);
         assertThat(result).isNotNull();
         assertThat(result.getId()).isGreaterThan(0);
@@ -103,8 +92,8 @@ public class ApplicantServiceIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenAValidInput_whenUpdateApplicantHistoryIsInvoked_thenUpdateIsSuccess() {
-        applicantHistoryRepository.saveAndFlush(TestEntityDataBuilder.getApplicantHistoryEntity("N"));
-        Integer id = applicantHistoryRepository.findAll().get(0).getId();
+        repos.applicantHistory.saveAndFlush(TestEntityDataBuilder.getApplicantHistoryEntity("N"));
+        Integer id = repos.applicantHistory.findAll().get(0).getId();
         ApplicantHistoryDTO applicantHistoryDTO = applicantHistoryService.update(TestModelDataBuilder.getApplicantHistoryDTO(id, SEND_TO_CCLF));
         assertThat(applicantHistoryDTO.getId()).isEqualTo(id);
         assertThat(applicantHistoryDTO.getSendToCclf()).isEqualTo(SEND_TO_CCLF);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/PassportAssessmentControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/PassportAssessmentControllerIntegrationTest.java
@@ -1,20 +1,32 @@
 package gov.uk.courtdata.integration.assessment;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.assessment.mapper.PassportAssessmentMapper;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.dto.PassportAssessmentDTO;
-import gov.uk.courtdata.entity.*;
+import gov.uk.courtdata.entity.FinancialAssessmentEntity;
+import gov.uk.courtdata.entity.HardshipReviewEntity;
+import gov.uk.courtdata.entity.NewWorkReasonEntity;
+import gov.uk.courtdata.entity.PassportAssessmentEntity;
+import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.integration.MockNewWorkReasonRepository;
+import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.model.assessment.CreatePassportAssessment;
 import gov.uk.courtdata.model.assessment.UpdatePassportAssessment;
 import gov.uk.courtdata.repository.FinancialAssessmentRepository;
 import gov.uk.courtdata.repository.HardshipReviewRepository;
 import gov.uk.courtdata.repository.PassportAssessmentRepository;
 import gov.uk.courtdata.repository.RepOrderRepository;
-import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -22,14 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class PassportAssessmentControllerIntegrationTest extends MockMvcIntegrationTest {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/authorization/AuthorizationControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/authorization/AuthorizationControllerIntegrationTest.java
@@ -1,21 +1,27 @@
 package gov.uk.courtdata.integration.authorization;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
 import gov.uk.MAATCourtDataApplication;
-import gov.uk.courtdata.entity.*;
-import gov.uk.courtdata.model.authorization.AuthorizationResponse;
-import gov.uk.courtdata.repository.*;
+import gov.uk.courtdata.entity.ReservationsEntity;
+import gov.uk.courtdata.entity.RoleActionEntity;
+import gov.uk.courtdata.entity.RoleWorkReasonEntity;
+import gov.uk.courtdata.entity.UserEntity;
+import gov.uk.courtdata.entity.UserRoleEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
+import gov.uk.courtdata.model.authorization.AuthorizationResponse;
+import gov.uk.courtdata.repository.ReservationsRepository;
+import gov.uk.courtdata.repository.RoleActionsRepository;
+import gov.uk.courtdata.repository.RoleWorkReasonsRepository;
+import gov.uk.courtdata.repository.UserRepository;
+import gov.uk.courtdata.repository.UserRolesRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class AuthorizationControllerIntegrationTest extends MockMvcIntegrationTest {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/correspondence/CorrespondenceStateControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/correspondence/CorrespondenceStateControllerIntegrationTest.java
@@ -1,16 +1,18 @@
 package gov.uk.courtdata.integration.correspondence;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.entity.CorrespondenceStateEntity;
-import gov.uk.courtdata.repository.CorrespondenceStateRepository;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
+import gov.uk.courtdata.repository.CorrespondenceStateRepository;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,10 +22,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ConcorContributionsRestControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ConcorContributionsRestControllerIntegrationTest.java
@@ -1,5 +1,14 @@
 package gov.uk.courtdata.integration.dces;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.dces.service.DebtCollectionRepository;
 import gov.uk.courtdata.entity.ConcorContributionsEntity;
@@ -7,36 +16,30 @@ import gov.uk.courtdata.entity.ContributionFileErrorsEntity;
 import gov.uk.courtdata.entity.ContributionFilesEntity;
 import gov.uk.courtdata.enums.ConcorContributionStatus;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.ConcorContributionsRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class ConcorContributionsRestControllerIntegTest extends MockMvcIntegrationTest {
+class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegrationTest {
 
     private static final String ATOMIC_UPDATE_ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/create-contribution-file";
 
     private static final String ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/concor-contribution-files?status=";
     private static final String DRC_UPDATE_URL = "/api/internal/v1/debt-collection-enforcement/log-contribution-response";
-
-    @Autowired
-    private ConcorContributionsRepository concorRepository;
 
     @SpyBean
     DebtCollectionRepository debtCollectionRepositorySpy;
@@ -145,7 +148,8 @@ class ConcorContributionsRestControllerIntegTest extends MockMvcIntegrationTest 
         assertNull(savedFileEntity.getAckXmlContent());
         assertEquals(expectedFilename, savedFileEntity.getFileName());
         // assert the file id has been set on the contribution
-        Optional<ConcorContributionsEntity> updatedConcor = concorRepository.findById(savedEntityId3);
+        Optional<ConcorContributionsEntity> updatedConcor = repos.concorContributions.findById(
+            savedEntityId3);
         assertTrue(updatedConcor.isPresent());
         ConcorContributionsEntity fdcContributionsEntity = updatedConcor.get();
         assertEquals(savedFileEntity.getFileId(), fdcContributionsEntity.getContribFileId());

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/eform/EFormIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/eform/EFormIntegrationTest.java
@@ -1,21 +1,21 @@
 package gov.uk.courtdata.integration.eform;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import gov.uk.MAATCourtDataApplication;
-import gov.uk.courtdata.eform.repository.EformStagingRepository;
 import gov.uk.courtdata.eform.repository.entity.EformsStagingEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.testutils.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 class EFormIntegrationTest extends MockMvcIntegrationTest {
@@ -31,9 +31,6 @@ class EFormIntegrationTest extends MockMvcIntegrationTest {
     private static final String ALREADY_EXISTS_USN_MESSAGE = String.format("The USN [%d] already exists in the data store.", USN);
     private static final String NONEXISTENT_USN_RETURN = "{\"code\":\"NOT_FOUND\",\"message\":\"" + NONEXISTENT_USN_MESSAGE + "\"}";
     private static final String ALREADY_EXISTS_USN_RETURN = "{\"code\":\"BAD_REQUEST\",\"message\":\"" + ALREADY_EXISTS_USN_MESSAGE + "\"}";
-
-    @Autowired
-    private EformStagingRepository eformStagingRepository;
 
     private String xmlDoc;
     private EformsStagingEntity eformsStagingEntity;
@@ -83,7 +80,7 @@ class EFormIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenExistingUSN_whenPOSTeformCalled_thenErrorReturned() throws Exception {
-        eformStagingRepository.saveAndFlush(eformsStagingEntity);
+        repos.eformStaging.saveAndFlush(eformsStagingEntity);
 
         MockHttpServletRequestBuilder requestBuilder = post(EFORM_USN_PROVIDED_URL)
                 .content(xmlDoc)
@@ -96,7 +93,7 @@ class EFormIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenAUSN_whenGETeformCalled_thenReturnEntryFromDB() throws Exception {
-        eformStagingRepository.saveAndFlush(eformsStagingEntity);
+        repos.eformStaging.saveAndFlush(eformsStagingEntity);
 
         String type = String.format("\"%s\"", TYPE);
         MockHttpServletRequestBuilder requestBuilder = get(EFORM_USN_PROVIDED_URL)
@@ -129,7 +126,7 @@ class EFormIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenAUSN_whenDELETEeformCalled_thenEntryRemovedFromDB() throws Exception {
-        eformStagingRepository.saveAndFlush(eformsStagingEntity);
+        repos.eformStaging.saveAndFlush(eformsStagingEntity);
 
         MockHttpServletRequestBuilder requestBuilder = delete(EFORM_USN_PROVIDED_URL)
                 .contentType(MediaType.APPLICATION_XML);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/job/QueueMessageMaintenanceSchedulerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/job/QueueMessageMaintenanceSchedulerTest.java
@@ -1,24 +1,23 @@
 package gov.uk.courtdata.integration.job;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.entity.QueueMessageLogEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.job.QueueMessageMaintenanceScheduler;
 import gov.uk.courtdata.repository.QueueMessageLogRepository;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 @TestPropertySource(locations = {"classpath:application.yaml"})
@@ -33,11 +32,6 @@ public class QueueMessageMaintenanceSchedulerTest  extends MockMvcIntegrationTes
 
     private static byte[] buildMessage(Integer maatId) {
         return ("{laaTransactionId:\"8720c683-39ef-4168-a8cc-058668a2dcca\",\"maatId\":" + maatId + "}").getBytes();
-    }
-
-    @BeforeEach
-    public void setUp() {
-        new RepositoryUtil().clearUp(getQueueMessageLogRepository());
     }
 
     @Test
@@ -100,11 +94,6 @@ public class QueueMessageMaintenanceSchedulerTest  extends MockMvcIntegrationTes
         assertAll("messageLogEntities",
                 () -> assertNotNull(messageLogEntities),
                 () -> assertTrue(messageLogEntities.isEmpty()));
-    }
-
-    @AfterEach
-    public void tearDown() {
-        new RepositoryUtil().clearUp(getQueueMessageLogRepository());
     }
 
     private QueueMessageLogRepository getQueueMessageLogRepository() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/controller/LinkControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/controller/LinkControllerIntegrationTest.java
@@ -15,15 +15,8 @@ import gov.uk.courtdata.entity.RepOrderCPDataEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
 import gov.uk.courtdata.link.controller.LinkController;
 import gov.uk.courtdata.model.CaseDetailsValidate;
-import gov.uk.courtdata.repository.FinancialAssessmentRepository;
-import gov.uk.courtdata.repository.PassportAssessmentRepository;
-import gov.uk.courtdata.repository.RepOrderCPDataRepository;
-import gov.uk.courtdata.repository.RepOrderRepository;
-import gov.uk.courtdata.repository.WqLinkRegisterRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,30 +42,9 @@ public class LinkControllerIntegrationTest extends MockMvcIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private RepOrderRepository repOrderRepository;
-
-    @Autowired
-    private RepOrderCPDataRepository repOrderCPDataRepository;
-
-    @Autowired
-    private WqLinkRegisterRepository wqLinkRegisterRepository;
-
-    @Autowired
-    private FinancialAssessmentRepository financialAssessmentRepository;
-
-    @Autowired
-    private PassportAssessmentRepository passportAssessmentRepository;
-
-
     @BeforeEach
     public void setUp() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
-        new RepositoryUtil().clearUp(financialAssessmentRepository,
-                passportAssessmentRepository,
-                repOrderRepository,
-                repOrderCPDataRepository,
-                wqLinkRegisterRepository);
     }
 
     @Test
@@ -143,8 +115,9 @@ public class LinkControllerIntegrationTest extends MockMvcIntegrationTest {
     public void testWhenMaatIdIsAlreadyLinked_Returns400ClientError() throws Exception {
 
         createRepOrderEntity();
-        wqLinkRegisterRepository.save(WqLinkRegisterEntity.builder().createdTxId(0).maatId(TEST_MAAT_ID).build());
-        repOrderCPDataRepository.save(createRepOrderCPDataEntity(TEST_MAAT_ID, TEST_CASE_URN));
+        repos.wqLinkRegister.save(
+            WqLinkRegisterEntity.builder().createdTxId(0).maatId(TEST_MAAT_ID).build());
+        repos.repOrderCPData.save(createRepOrderCPDataEntity(TEST_MAAT_ID, TEST_CASE_URN));
 
         final CaseDetailsValidate caseDetailsValidate = getTestCaseDetailsValidate();
 
@@ -162,7 +135,7 @@ public class LinkControllerIntegrationTest extends MockMvcIntegrationTest {
 
         createRepOrderEntity();
 
-        repOrderCPDataRepository.save(createRepOrderCPDataEntity(TEST_MAAT_ID, TEST_CASE_URN));
+        repos.repOrderCPData.save(createRepOrderCPDataEntity(TEST_MAAT_ID, TEST_CASE_URN));
 
         final CaseDetailsValidate caseDetailsValidate = getTestCaseDetailsValidate();
 
@@ -174,15 +147,6 @@ public class LinkControllerIntegrationTest extends MockMvcIntegrationTest {
                 .andExpect(status().is2xxSuccessful());
     }
 
-    @AfterEach
-    public void clearUp() {
-        new RepositoryUtil().clearUp(financialAssessmentRepository,
-                passportAssessmentRepository,
-                repOrderRepository,
-                repOrderCPDataRepository,
-                wqLinkRegisterRepository);
-    }
-
     public RepOrderCPDataEntity createRepOrderCPDataEntity(final Integer maatId, final String caseUrn) {
         return RepOrderCPDataEntity.builder()
                 .repOrderId(maatId)
@@ -192,7 +156,7 @@ public class LinkControllerIntegrationTest extends MockMvcIntegrationTest {
 
 
     public void createRepOrderEntity() {
-        RepOrderEntity repOrder = repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder());
+        RepOrderEntity repOrder = repos.repOrder.save(TestEntityDataBuilder.getPopulatedRepOrder());
         TEST_MAAT_ID = repOrder.getId();
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkCpJobStatusServiceIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/link/service/CreateLinkCpJobStatusServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.integration.link.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.entity.WqCoreEntity;
@@ -8,26 +9,15 @@ import gov.uk.courtdata.enums.WQStatus;
 import gov.uk.courtdata.exception.MAATCourtDataException;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.link.service.CreateLinkCpJobStatusListener;
-import gov.uk.courtdata.repository.WqCoreRepository;
-import gov.uk.courtdata.repository.WqLinkRegisterRepository;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class CreateLinkCpJobStatusServiceIntegrationTest extends MockMvcIntegrationTest {
 
-    @Autowired
-    private WqLinkRegisterRepository wqLinkRegisterRepository;
-    @Autowired
-    private WqCoreRepository wqCoreRepository;
     @Autowired
     private CreateLinkCpJobStatusListener createLinkCpJobStatusListener;
 
@@ -36,16 +26,16 @@ public class CreateLinkCpJobStatusServiceIntegrationTest extends MockMvcIntegrat
 
         //given
         WqLinkRegisterEntity wqLinkRegisterEntity = WqLinkRegisterEntity.builder().maatId(12345678).createdTxId(88999).build();
-        wqLinkRegisterRepository.save(wqLinkRegisterEntity);
+      repos.wqLinkRegister.save(wqLinkRegisterEntity);
 
         WqCoreEntity wqCoreEntity = WqCoreEntity.builder().txId(wqLinkRegisterEntity.getCreatedTxId()).build();
-        wqCoreRepository.save(wqCoreEntity);
+      repos.wqCore.save(wqCoreEntity);
 
         //when
         createLinkCpJobStatusListener.receive(getMessageFromQueue());
 
         //then
-        Optional<WqCoreEntity> optionalWqCoreEntity = wqCoreRepository.findById(88999);
+      Optional<WqCoreEntity> optionalWqCoreEntity = repos.wqCore.findById(88999);
 
         optionalWqCoreEntity.ifPresent(coreEntity -> {
             assertThat(coreEntity.getTxId()).isEqualTo(88999);
@@ -60,10 +50,10 @@ public class CreateLinkCpJobStatusServiceIntegrationTest extends MockMvcIntegrat
 
         //given
         WqLinkRegisterEntity wqLinkRegisterEntity = WqLinkRegisterEntity.builder().maatId(111111).createdTxId(88999).build();
-        wqLinkRegisterRepository.save(wqLinkRegisterEntity);
+      repos.wqLinkRegister.save(wqLinkRegisterEntity);
 
         WqCoreEntity wqCoreEntity = WqCoreEntity.builder().txId(wqLinkRegisterEntity.getCreatedTxId()).build();
-        wqCoreRepository.save(wqCoreEntity);
+      repos.wqCore.save(wqCoreEntity);
 
         Assertions.assertThrows(MAATCourtDataException.class,()->{
             //when
@@ -76,11 +66,12 @@ public class CreateLinkCpJobStatusServiceIntegrationTest extends MockMvcIntegrat
 
     private String getMessageFromQueue() {
 
-        return "{\n" +
-                "  \"maatId\": 12345678,\n" +
-                "  \"jobStatus\": \"SUCCESS\",\n" +
-                "  \"laaTransactionId\": \"6f5b34ea-e038-4f1c-bfe5-d6bf622444f0\"\n" +
-                "}";
-
+      return """
+          {
+            "maatId": 12345678,
+            "jobStatus": "SUCCESS",
+            "laaTransactionId": "6f5b34ea-e038-4f1c-bfe5-d6bf622444f0"
+          }
+          """;
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/offence/OffenceControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/offence/OffenceControllerIntegrationTest.java
@@ -1,27 +1,21 @@
 package gov.uk.courtdata.integration.offence;
 
-import gov.uk.MAATCourtDataApplication;
-import gov.uk.courtdata.builder.TestEntityDataBuilder;
-import gov.uk.courtdata.builder.TestModelDataBuilder;
-import gov.uk.courtdata.repository.OffenceRepository;
-import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpHeaders;
-
-import java.util.List;
-
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
+
+import gov.uk.MAATCourtDataApplication;
+import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.builder.TestModelDataBuilder;
+import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
+import java.util.List;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
@@ -25,7 +25,6 @@ import gov.uk.courtdata.reporder.mapper.RepOrderMapper;
 import gov.uk.courtdata.repository.RepOrderMvoRegRepository;
 import gov.uk.courtdata.repository.RepOrderMvoRepository;
 import gov.uk.courtdata.repository.RepOrderRepository;
-import gov.uk.courtdata.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -56,17 +55,6 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     private static final String VEHICLE_OWNER_INDICATOR_YES = "Y";
     public Integer REP_ORDER_ID_NO_SENTENCE_ORDER_DATE;
     public Integer REP_ID;
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private RepOrderRepository repOrderRepository;
-
-    @Autowired
-    private RepOrderMvoRepository repOrderMvoRepository;
-
-    @Autowired
-    private RepOrderMvoRegRepository repOrderMvoRegRepository;
 
     @Autowired
     private RepOrderMapper mapper;
@@ -97,7 +85,7 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     }
 
     private RepOrderDTO getUpdatedRepOrderDTO() {
-        RepOrderEntity repOrderEntity = repOrderRepository.getReferenceById(REP_ID);
+        RepOrderEntity repOrderEntity = repos.repOrder.getReferenceById(REP_ID);
         RepOrderDTO repOrderDTO = TestModelDataBuilder.getRepOrderDTO(REP_ID);
         repOrderDTO.setDateModified(repOrderEntity.getDateModified());
         repOrderDTO.setSentenceOrderDate(repOrderEntity.getSentenceOrderDate());
@@ -184,7 +172,7 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
                 .content(TestModelDataBuilder.getUpdateAppDateCompletedJson(REP_ID))
                 .contentType(MediaType.APPLICATION_JSON));
 
-        RepOrderEntity repOrderEntity = repOrderRepository.getReferenceById(REP_ID);
+        RepOrderEntity repOrderEntity = repos.repOrder.getReferenceById(REP_ID);
         assertThat(repOrderEntity.getId()).isEqualTo(REP_ID);
         assertThat(repOrderEntity.getAssessmentDateCompleted()).isEqualTo(expectedDate);
     }
@@ -298,7 +286,7 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.delete(BASE_URL + "/" + repOrderEntity.getId()))
                 .andExpect(status().isNoContent());
 
-        boolean exists = repOrderRepository.existsById(repOrderEntity.getId());
+        boolean exists = repos.repOrder.existsById(repOrderEntity.getId());
 
         assertThat(exists).isFalse();
     }
@@ -307,13 +295,13 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     void givenValidRepId_whenFindIOJAssessorDetailsIsCalled_() throws Exception {
         String userName = "grea-k";
         UserEntity userEntity = TestEntityDataBuilder.getUserEntity();
-        userRepository.save(userEntity);
+        repos.user.save(userEntity);
 
         RepOrderEntity repOrder = TestEntityDataBuilder.getPopulatedRepOrder(REP_ID);
         repOrder.setUserCreatedEntity(userEntity);
         repOrder.setUserCreated(userName);
 
-        repOrderRepository.save(repOrder);
+        repos.repOrder.save(repOrder);
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + REP_ID + "/ioj-assessor-details"))
                 .andExpect(status().isOk())

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/controller/UnLinkControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/controller/UnLinkControllerTest.java
@@ -1,5 +1,8 @@
 package gov.uk.courtdata.integration.unlink.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
@@ -8,10 +11,8 @@ import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.model.Unlink;
-import gov.uk.courtdata.repository.RepOrderCPDataRepository;
-import gov.uk.courtdata.repository.RepOrderRepository;
-import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import gov.uk.courtdata.unlink.controller.UnLinkController;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,11 +20,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import java.util.UUID;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 @AutoConfigureMockMvc
@@ -37,15 +33,6 @@ public class UnLinkControllerTest extends MockMvcIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private RepOrderRepository repOrderRepository;
-
-    @Autowired
-    private RepOrderCPDataRepository repOrderCPDataRepository;
-
-    @Autowired
-    private WqLinkRegisterRepository wqLinkRegisterRepository;
-
     @BeforeEach
     public void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(unLinkController).build();
@@ -54,9 +41,11 @@ public class UnLinkControllerTest extends MockMvcIntegrationTest {
     @Test
     public void givenUnlinkModel_whenValidationPassed() throws Exception {
 
-        RepOrderEntity repOrder = repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder());
-        wqLinkRegisterRepository.save(WqLinkRegisterEntity.builder().maatId(repOrder.getId()).createdTxId(1234).build());
-        repOrderCPDataRepository.save(RepOrderCPDataEntity.builder().repOrderId(repOrder.getId()).build());
+        RepOrderEntity repOrder = repos.repOrder.save(TestEntityDataBuilder.getPopulatedRepOrder());
+        repos.wqLinkRegister.save(
+            WqLinkRegisterEntity.builder().maatId(repOrder.getId()).createdTxId(1234).build());
+        repos.repOrderCPData.save(
+            RepOrderCPDataEntity.builder().repOrderId(repOrder.getId()).build());
 
         Unlink unlink = Unlink.builder()
                 .maatId(repOrder.getId())

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/impl/UnLinkImplIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/impl/UnLinkImplIntegrationTest.java
@@ -1,5 +1,11 @@
 package gov.uk.courtdata.integration.unlink.impl;
 
+import static gov.uk.courtdata.constants.CourtDataConstants.SYSTEM_UNLINKED;
+import static gov.uk.courtdata.constants.CourtDataConstants.WQ_SUCCESS_STATUS;
+import static gov.uk.courtdata.constants.CourtDataConstants.WQ_UNLINK_EVENT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.google.gson.Gson;
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
@@ -11,134 +17,119 @@ import gov.uk.courtdata.entity.WqLinkRegisterEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.model.UnlinkModel;
-import gov.uk.courtdata.repository.UnlinkReasonRepository;
-import gov.uk.courtdata.repository.WqCoreRepository;
-import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import gov.uk.courtdata.unlink.impl.UnLinkImpl;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.Optional;
-
-import static gov.uk.courtdata.constants.CourtDataConstants.*;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
-public class UnLinkImplIntegrationTest  extends MockMvcIntegrationTest {
+public class UnLinkImplIntegrationTest extends MockMvcIntegrationTest {
 
-    @Autowired
-    private UnLinkImpl unLinkImpl;
-    @Autowired
-    private WqLinkRegisterRepository wqLinkRegisterRepository;
-    @Autowired
-    private WqCoreRepository wqCoreRepository;
-    @Autowired
-    private UnlinkReasonRepository unlinkReasonRepository;
-    @Autowired
-    private Gson gson;
-    @Autowired
-    private TestModelDataBuilder testModelDataBuilder;
-    @Autowired
-    private TestEntityDataBuilder testEntityDataBuilder;
+  @Autowired
+  private UnLinkImpl unLinkImpl;
 
-    @BeforeEach
-    public void setUp() {
-        new RepositoryUtil().clearUp(wqCoreRepository,
-                wqLinkRegisterRepository,
-                unlinkReasonRepository);
-    }
+  @Autowired
+  private Gson gson;
 
-    @Test
-    public void givenUnlinkLinkModel_whenUnlinkImplIsInvoked_thenCaseIsUnlinked() {
+  @Autowired
+  private TestModelDataBuilder testModelDataBuilder;
 
-        //given
-        Unlink unlink = gson.fromJson(testModelDataBuilder.getUnLinkString(), Unlink.class);
-        UnlinkModel unlinkModel = UnlinkModel.builder().unlink(unlink).build();
-        WqLinkRegisterEntity wqLinkRegisterEntity = testEntityDataBuilder.getWqLinkRegisterEntity();
-        unlinkModel.setWqLinkRegisterEntity(wqLinkRegisterEntity);
-        RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity();
-        unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
-        wqLinkRegisterRepository.save(wqLinkRegisterEntity);
+  @Autowired
+  private TestEntityDataBuilder testEntityDataBuilder;
 
-        //when
-        unLinkImpl.execute(unlinkModel);
+  @Test
+  public void givenUnlinkLinkModel_whenUnlinkImplIsInvoked_thenCaseIsUnlinked() {
 
-        //then
-        assertWQLinkRegister(unlinkModel);
-        assertWQCore(unlinkModel);
-        assertUnLinkReason(unlinkModel);
+    //given
+    Unlink unlink = gson.fromJson(testModelDataBuilder.getUnLinkString(), Unlink.class);
+    UnlinkModel unlinkModel = UnlinkModel.builder().unlink(unlink).build();
+    WqLinkRegisterEntity wqLinkRegisterEntity = testEntityDataBuilder.getWqLinkRegisterEntity();
+    unlinkModel.setWqLinkRegisterEntity(wqLinkRegisterEntity);
+    RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity();
+    unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
+    repos.wqLinkRegister.save(wqLinkRegisterEntity);
 
-    }
+    //when
+    unLinkImpl.execute(unlinkModel);
+
+    //then
+    assertWQLinkRegister(unlinkModel);
+    assertWQCore(unlinkModel);
+    assertUnLinkReason(unlinkModel);
+
+  }
 
 
-    @Test
-    public void givenUnlinkReasonIsOther_whenUnlinked_ThenOtherReasonTextIs(){
+  @Test
+  public void givenUnlinkReasonIsOther_whenUnlinked_ThenOtherReasonTextIs() {
 
-        Unlink unlink = gson.fromJson(testModelDataBuilder.getUnLinkWithOtherReasonString(), Unlink.class);
-        UnlinkModel unlinkModel = UnlinkModel.builder().unlink(unlink).build();
-        WqLinkRegisterEntity wqLinkRegisterEntity = testEntityDataBuilder.getWqLinkRegisterEntity();
-        unlinkModel.setWqLinkRegisterEntity(wqLinkRegisterEntity);
-        RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity();
-        unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
-        wqLinkRegisterRepository.save(wqLinkRegisterEntity);
+    Unlink unlink = gson.fromJson(testModelDataBuilder.getUnLinkWithOtherReasonString(),
+        Unlink.class);
+    UnlinkModel unlinkModel = UnlinkModel.builder().unlink(unlink).build();
+    WqLinkRegisterEntity wqLinkRegisterEntity = testEntityDataBuilder.getWqLinkRegisterEntity();
+    unlinkModel.setWqLinkRegisterEntity(wqLinkRegisterEntity);
+    RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity();
+    unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
+    repos.wqLinkRegister.save(wqLinkRegisterEntity);
+
+    unLinkImpl.execute(unlinkModel);
+
+    assertWQLinkRegister(unlinkModel);
+    assertWQCore(unlinkModel);
+    assertUnLinkOtherReason(unlinkModel);
+
+  }
 
 
-        unLinkImpl.execute(unlinkModel);
+  private void assertWQLinkRegister(UnlinkModel unlinkModel) {
 
-        assertWQLinkRegister(unlinkModel);
-        assertWQCore(unlinkModel);
-        assertUnLinkOtherReason(unlinkModel);
+    Optional<WqLinkRegisterEntity> wqUnLinkRegisterEntity = repos.wqLinkRegister.findById(
+        unlinkModel.getWqLinkRegisterEntity().getCreatedTxId());
+    WqLinkRegisterEntity unLinkRegister = wqUnLinkRegisterEntity.orElse(null);
+    assertNotNull(unLinkRegister);
+    Unlink unlink = unlinkModel.getUnlink();
+    assertThat(unLinkRegister.getMaatId()).isEqualTo(unlink.getMaatId());
+    assertThat(unLinkRegister.getRemovedUserId()).isEqualTo(unlink.getUserId());
+  }
 
-    }
+  private void assertWQCore(UnlinkModel unlinkModel) {
 
+    Optional<WqCoreEntity> wqCoreEntity = repos.wqCore.findById(unlinkModel.getTxId());
+    WqCoreEntity unLinkCore = wqCoreEntity.orElse(null);
+    assertNotNull(unLinkCore);
+    assertThat(unLinkCore.getCaseId()).isEqualTo(unlinkModel.getWqLinkRegisterEntity().getCaseId());
+    assertThat(unLinkCore.getTxId()).isEqualTo(unlinkModel.getTxId());
+    assertThat(unLinkCore.getCreatedUserId()).isEqualTo(unlinkModel.getUnlink().getUserId());
+    assertThat(unLinkCore.getWqType()).isEqualTo(WQ_UNLINK_EVENT);
+    assertThat(unLinkCore.getWqStatus()).isEqualTo(WQ_SUCCESS_STATUS);
 
-    private void assertWQLinkRegister(UnlinkModel unlinkModel) {
+  }
 
-        Optional<WqLinkRegisterEntity> wqUnLinkRegisterEntity = wqLinkRegisterRepository.findById(unlinkModel.getWqLinkRegisterEntity().getCreatedTxId());
-        WqLinkRegisterEntity unLinkRegister = wqUnLinkRegisterEntity.orElse(null);
-        assert unLinkRegister != null;
-        Unlink unlink = unlinkModel.getUnlink();
-        assertThat(unLinkRegister.getMaatId()).isEqualTo(unlink.getMaatId());
-        assertThat(unLinkRegister.getRemovedUserId()).isEqualTo(unlink.getUserId());
-    }
+  private void assertUnLinkReason(UnlinkModel unlinkModel) {
+    Optional<UnlinkEntity> unlinkEntity = repos.unlinkReason.findById(unlinkModel.getTxId());
+    UnlinkEntity unLinkReason = unlinkEntity.orElse(null);
+    assertNotNull(unLinkReason);
 
-    private void assertWQCore(UnlinkModel unlinkModel) {
+    assertThat(unLinkReason.getTxId()).isEqualTo(unlinkModel.getTxId());
+    assertThat(unLinkReason.getCaseId()).isEqualTo(
+        unlinkModel.getWqLinkRegisterEntity().getCaseId());
+    assertThat(unLinkReason.getReasonId()).isEqualTo(unlinkModel.getUnlink().getReasonId());
+    assertThat(unLinkReason.getOtherReason()).isEqualTo(SYSTEM_UNLINKED);
+  }
 
-        Optional<WqCoreEntity> wqCoreEntity = wqCoreRepository.findById(unlinkModel.getTxId());
-        WqCoreEntity unLinkCore = wqCoreEntity.orElse(null);
-        assert unLinkCore != null;
-        assertThat(unLinkCore.getCaseId()).isEqualTo(unlinkModel.getWqLinkRegisterEntity().getCaseId());
-        assertThat(unLinkCore.getTxId()).isEqualTo(unlinkModel.getTxId());
-        assertThat(unLinkCore.getCreatedUserId()).isEqualTo(unlinkModel.getUnlink().getUserId());
-        assertThat(unLinkCore.getWqType()).isEqualTo(WQ_UNLINK_EVENT);
-        assertThat(unLinkCore.getWqStatus()).isEqualTo(WQ_SUCCESS_STATUS);
+  private void assertUnLinkOtherReason(UnlinkModel unlinkModel) {
+    Optional<UnlinkEntity> unlinkEntity = repos.unlinkReason.findById(unlinkModel.getTxId());
+    UnlinkEntity unLinkReason = unlinkEntity.orElse(null);
+    assertNotNull(unLinkReason);
 
-    }
-
-    private void assertUnLinkReason(UnlinkModel unlinkModel) {
-        Optional<UnlinkEntity> unlinkEntity = unlinkReasonRepository.findById(unlinkModel.getTxId());
-        UnlinkEntity unLinkReason = unlinkEntity.orElse(null);
-        assert unLinkReason != null;
-
-        assertThat(unLinkReason.getTxId()).isEqualTo(unlinkModel.getTxId());
-        assertThat(unLinkReason.getCaseId()).isEqualTo(unlinkModel.getWqLinkRegisterEntity().getCaseId());
-        assertThat(unLinkReason.getReasonId()).isEqualTo(unlinkModel.getUnlink().getReasonId());
-        assertThat(unLinkReason.getOtherReason()).isEqualTo(SYSTEM_UNLINKED);
-    }
-
-    private void assertUnLinkOtherReason(UnlinkModel unlinkModel) {
-        Optional<UnlinkEntity> unlinkEntity = unlinkReasonRepository.findById(unlinkModel.getTxId());
-        UnlinkEntity unLinkReason = unlinkEntity.orElse(null);
-        assert unLinkReason != null;
-
-        assertThat(unLinkReason.getTxId()).isEqualTo(unlinkModel.getTxId());
-        assertThat(unLinkReason.getCaseId()).isEqualTo(unlinkModel.getWqLinkRegisterEntity().getCaseId());
-        assertThat(unLinkReason.getReasonId()).isEqualTo(unlinkModel.getUnlink().getReasonId());
-        assertThat(unLinkReason.getOtherReason()).isEqualTo(unlinkModel.getUnlink().getOtherReasonText());
-    }
+    assertThat(unLinkReason.getTxId()).isEqualTo(unlinkModel.getTxId());
+    assertThat(unLinkReason.getCaseId()).isEqualTo(
+        unlinkModel.getWqLinkRegisterEntity().getCaseId());
+    assertThat(unLinkReason.getReasonId()).isEqualTo(unlinkModel.getUnlink().getReasonId());
+    assertThat(unLinkReason.getOtherReason()).isEqualTo(
+        unlinkModel.getUnlink().getOtherReasonText());
+  }
 
 
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
@@ -1,5 +1,8 @@
 package gov.uk.courtdata.integration.unlink.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.google.gson.Gson;
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
@@ -12,20 +15,24 @@ import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.integration.util.RepositoryUtil;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.model.UnlinkModel;
-import gov.uk.courtdata.repository.*;
+import gov.uk.courtdata.repository.FinancialAssessmentRepository;
+import gov.uk.courtdata.repository.PassportAssessmentRepository;
+import gov.uk.courtdata.repository.QueueMessageLogRepository;
+import gov.uk.courtdata.repository.RepOrderCPDataRepository;
+import gov.uk.courtdata.repository.RepOrderRepository;
+import gov.uk.courtdata.repository.UnlinkReasonRepository;
+import gov.uk.courtdata.repository.WqCoreRepository;
+import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import gov.uk.courtdata.unlink.service.UnlinkListener;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.MessageHeaders;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class UnlinkListenerTest extends MockMvcIntegrationTest {
@@ -110,7 +117,7 @@ public class UnlinkListenerTest extends MockMvcIntegrationTest {
 
         List<WqLinkRegisterEntity> wqUnLinkRegisterEntity = wqLinkRegisterRepository.findAll();
         WqLinkRegisterEntity unLinkRegister = wqUnLinkRegisterEntity.get(0);
-        assert unLinkRegister != null;
+        assertNotNull(unLinkRegister);
         Unlink unlink = unlinkModel.getUnlink();
         assertThat(unLinkRegister.getMaatId()).isEqualTo(repId);
         assertThat(unLinkRegister.getRemovedUserId()).isEqualTo(unlink.getUserId());

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/unlink/service/UnlinkListenerTest.java
@@ -12,23 +12,13 @@ import gov.uk.courtdata.entity.RepOrderCPDataEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
 import gov.uk.courtdata.model.Unlink;
 import gov.uk.courtdata.model.UnlinkModel;
-import gov.uk.courtdata.repository.FinancialAssessmentRepository;
-import gov.uk.courtdata.repository.PassportAssessmentRepository;
-import gov.uk.courtdata.repository.QueueMessageLogRepository;
-import gov.uk.courtdata.repository.RepOrderCPDataRepository;
-import gov.uk.courtdata.repository.RepOrderRepository;
-import gov.uk.courtdata.repository.UnlinkReasonRepository;
-import gov.uk.courtdata.repository.WqCoreRepository;
-import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import gov.uk.courtdata.unlink.service.UnlinkListener;
 import gov.uk.courtdata.util.QueueMessageLogTestHelper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,13 +27,6 @@ import org.springframework.messaging.MessageHeaders;
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class UnlinkListenerTest extends MockMvcIntegrationTest {
 
-
-    @Autowired
-    private WqLinkRegisterRepository wqLinkRegisterRepository;
-    @Autowired
-    private WqCoreRepository wqCoreRepository;
-    @Autowired
-    private UnlinkReasonRepository unlinkReasonRepository;
     @Autowired
     private Gson gson;
     @Autowired
@@ -55,36 +38,15 @@ public class UnlinkListenerTest extends MockMvcIntegrationTest {
     @Autowired
     private UnlinkListener unlinkListener;
     @Autowired
-    private RepOrderRepository repOrderRepository;
-    @Autowired
-    private RepOrderCPDataRepository repOrderCPDataRepository;
-    @Autowired
-    private QueueMessageLogRepository queueMessageLogRepository;
-    @Autowired
     private QueueMessageLogTestHelper queueMessageLogTestHelper;
-    @Autowired
-    private FinancialAssessmentRepository financialAssessmentRepository;
-    @Autowired
-    private PassportAssessmentRepository passportAssessmentRepository;
-
-    @BeforeEach
-    public void setUp() {
-        new RepositoryUtil().clearUp(passportAssessmentRepository,
-                financialAssessmentRepository,
-                wqCoreRepository,
-                wqLinkRegisterRepository,
-                unlinkReasonRepository,
-                repOrderRepository,
-                repOrderCPDataRepository,
-                queueMessageLogRepository);
-    }
 
     @Test
     public void givenUnlinkLinkJSONMessage_whenUnlinkListenerIsInvoked_thenCaseIsUnlinked() {
 
         //given
 
-        RepOrderEntity repOrderEntity = repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder());
+        RepOrderEntity repOrderEntity = repos.repOrder.save(
+            TestEntityDataBuilder.getPopulatedRepOrder());
 
         Unlink unlink = gson.fromJson(testModelDataBuilder.getUnLinkString(repOrderEntity.getId()), Unlink.class);
         UnlinkModel unlinkModel = UnlinkModel.builder().unlink(unlink).build();
@@ -92,8 +54,8 @@ public class UnlinkListenerTest extends MockMvcIntegrationTest {
         unlinkModel.setWqLinkRegisterEntity(wqLinkRegisterEntity);
         RepOrderCPDataEntity repOrderCPDataEntity = testEntityDataBuilder.getRepOrderCPDataEntity(repOrderEntity.getId());
         unlinkModel.setRepOrderCPDataEntity(repOrderCPDataEntity);
-        wqLinkRegisterRepository.save(wqLinkRegisterEntity);
-        repOrderCPDataRepository.save(RepOrderCPDataEntity.builder()
+        repos.wqLinkRegister.save(wqLinkRegisterEntity);
+        repos.repOrderCPData.save(RepOrderCPDataEntity.builder()
                 .defendantId("556677")
                 .repOrderId(repOrderEntity.getId())
                 .build());
@@ -115,7 +77,7 @@ public class UnlinkListenerTest extends MockMvcIntegrationTest {
 
     private void assertWQLinkRegister(UnlinkModel unlinkModel, Integer repId) {
 
-        List<WqLinkRegisterEntity> wqUnLinkRegisterEntity = wqLinkRegisterRepository.findAll();
+        List<WqLinkRegisterEntity> wqUnLinkRegisterEntity = repos.wqLinkRegister.findAll();
         WqLinkRegisterEntity unLinkRegister = wqUnLinkRegisterEntity.get(0);
         assertNotNull(unLinkRegister);
         Unlink unlink = unlinkModel.getUnlink();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/users/UserSummaryControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/users/UserSummaryControllerIntegrationTest.java
@@ -1,148 +1,142 @@
 package gov.uk.courtdata.integration.users;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import gov.uk.MAATCourtDataApplication;
-import gov.uk.courtdata.entity.*;
-import gov.uk.courtdata.repository.*;
+import gov.uk.courtdata.entity.ReservationsEntity;
+import gov.uk.courtdata.entity.RoleActionEntity;
+import gov.uk.courtdata.entity.RoleDataItemEntity;
+import gov.uk.courtdata.entity.RoleWorkReasonEntity;
+import gov.uk.courtdata.entity.UserEntity;
+import gov.uk.courtdata.entity.UserRoleEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
-import org.junit.jupiter.api.AfterEach;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest {
 
-    private final String VALID_TEST_USER = "test-user-valid";
-    private final String INVALID_TEST_USER = "test-user-invalid";
-    private final String AUTHORISED_ACTION = "VALID_ACTION";
-    private final String DISABLED_ACTION = "DISABLED_ACTION";
-    private final String VALID_NWORCODE = "VALID_WORK_REASON";
-    private final Integer VALID_RESERVATION_ID = 1234;
-    private final String VALID_SESSION_ID = "valid-session";
-    private final String BASE_URL = "/api/internal/v1/users/";
-    private final String GET_USER_SUMMARY_URL = BASE_URL + "summary/{username}";
-    private final String AUTHORISED_ROLE = "VALID_ROLE";
+  private final String VALID_TEST_USER = "test-user-valid";
+  private final String INVALID_TEST_USER = "test-user-invalid";
+  private final String AUTHORISED_ACTION = "VALID_ACTION";
+  private final String DISABLED_ACTION = "DISABLED_ACTION";
+  private final String VALID_NWORCODE = "VALID_WORK_REASON";
+  private final Integer VALID_RESERVATION_ID = 1234;
+  private final String VALID_SESSION_ID = "valid-session";
+  private final String BASE_URL = "/api/internal/v1/users/";
+  private final String GET_USER_SUMMARY_URL = BASE_URL + "summary/{username}";
+  private final String AUTHORISED_ROLE = "VALID_ROLE";
 
-    @Autowired
-    MockMvc mvc;
-    @Autowired
-    private RoleActionsRepository roleActionsRepository;
-    @Autowired
-    private ReservationsRepository reservationsRepository;
-    @Autowired
-    private RoleWorkReasonsRepository roleWorkReasonsRepository;
-    @Autowired
-    private UserRolesRepository userRolesRepository;
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private RoleDataItemsRepository roleDataItemsRepository;
+  @Autowired
+  MockMvc mvc;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        setupTestData();
-    }
+  @BeforeEach
+  public void setUp() throws Exception {
+    setupTestData();
+  }
 
-    private void setupTestData() {
-        String DISABLED_ROLE = "DISABLED_ROLE";
-        List<UserRoleEntity> userRoleEntities = List.of(
-                UserRoleEntity.builder()
-                        .username(VALID_TEST_USER).roleName(AUTHORISED_ROLE).build(),
-                UserRoleEntity.builder()
-                        .username(VALID_TEST_USER).roleName(DISABLED_ROLE).build()
-        );
+  private void setupTestData() {
+    String DISABLED_ROLE = "DISABLED_ROLE";
+    List<UserRoleEntity> userRoleEntities = List.of(
+        UserRoleEntity.builder()
+            .username(VALID_TEST_USER).roleName(AUTHORISED_ROLE).build(),
+        UserRoleEntity.builder()
+            .username(VALID_TEST_USER).roleName(DISABLED_ROLE).build()
+    );
 
-        userRolesRepository.saveAll(userRoleEntities);
+    repos.userRoles.saveAll(userRoleEntities);
 
-        String ROLE_ACTION_ENABLED = "Y";
-        String ROLE_ACTION_DISABLED = "N";
-        List<RoleActionEntity> roleActionEntities = List.of(
-                RoleActionEntity.builder()
-                        .Id(1).roleName(AUTHORISED_ROLE).action(AUTHORISED_ACTION).enabled(ROLE_ACTION_ENABLED).build(),
-                RoleActionEntity.builder()
-                        .Id(2).roleName(DISABLED_ROLE).action(DISABLED_ACTION).enabled(ROLE_ACTION_DISABLED).build()
-        );
+    String ROLE_ACTION_ENABLED = "Y";
+    String ROLE_ACTION_DISABLED = "N";
+    List<RoleActionEntity> roleActionEntities = List.of(
+        RoleActionEntity.builder()
+            .Id(1).roleName(AUTHORISED_ROLE).action(AUTHORISED_ACTION).enabled(ROLE_ACTION_ENABLED)
+            .build(),
+        RoleActionEntity.builder()
+            .Id(2).roleName(DISABLED_ROLE).action(DISABLED_ACTION).enabled(ROLE_ACTION_DISABLED)
+            .build()
+    );
 
-        roleActionsRepository.saveAll(roleActionEntities);
+    repos.roleActions.saveAll(roleActionEntities);
 
-        roleWorkReasonsRepository
-                .save(RoleWorkReasonEntity.builder()
-                        .id(1)
-                        .roleName(AUTHORISED_ROLE)
-                        .nworCode(VALID_NWORCODE)
-                        .dateCreated(LocalDateTime.now())
-                        .userCreated(VALID_TEST_USER)
-                        .build());
+    repos.roleWorkReasons
+        .save(RoleWorkReasonEntity.builder()
+            .id(1)
+            .roleName(AUTHORISED_ROLE)
+            .nworCode(VALID_NWORCODE)
+            .dateCreated(LocalDateTime.now())
+            .userCreated(VALID_TEST_USER)
+            .build());
 
-        roleDataItemsRepository.save(RoleDataItemEntity.builder()
-                .id(1)
-                .roleName(AUTHORISED_ROLE)
-                .dataItem("DATA_ITEM")
-                .enabled("Y")
-                .insertAllowed("Y")
-                .updateAllowed("Y")
-                .build());
+    repos.roleDataItems.save(RoleDataItemEntity.builder()
+        .id(1)
+        .roleName(AUTHORISED_ROLE)
+        .dataItem("DATA_ITEM")
+        .enabled("Y")
+        .insertAllowed("Y")
+        .updateAllowed("Y")
+        .build());
 
-        LocalDateTime reservationDate = LocalDateTime.now();
-        LocalDateTime expiryDate = reservationDate.plusHours(3);
+    LocalDateTime reservationDate = LocalDateTime.now();
+    LocalDateTime expiryDate = reservationDate.plusHours(3);
 
-        reservationsRepository.save(ReservationsEntity.builder()
-                .recordId(1)
-                .userName(VALID_TEST_USER)
-                .userSession(VALID_SESSION_ID)
-                .recordId(VALID_RESERVATION_ID)
-                .reservationDate(reservationDate)
-                .recordName("REP_ORDER")
-                .expiryDate(expiryDate)
-                .build());
+    repos.reservations.save(ReservationsEntity.builder()
+        .recordId(1)
+        .userName(VALID_TEST_USER)
+        .userSession(VALID_SESSION_ID)
+        .recordId(VALID_RESERVATION_ID)
+        .reservationDate(reservationDate)
+        .recordName("REP_ORDER")
+        .expiryDate(expiryDate)
+        .build());
 
-        userRepository.save(UserEntity.builder()
-                .username(VALID_TEST_USER)
-                .currentSession(VALID_SESSION_ID)
+    repos.user.save(UserEntity.builder()
+        .username(VALID_TEST_USER)
+        .currentSession(VALID_SESSION_ID)
 
-                .build());
-    }
+        .build());
+  }
 
-    @Test
-    public void givenEmptyUsername_whenGetUserSummaryIsInvoked_theCorrectErrorIsThrown() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/summary/")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().is4xxClientError());
-    }
+  @Test
+  public void givenEmptyUsername_whenGetUserSummaryIsInvoked_theCorrectErrorIsThrown()
+      throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/summary/")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().is4xxClientError());
+  }
 
-    @Test
-    public void givenAValidUsername_whenGetUserSummaryIsInvoked_thenCorrectResponseIsReturned() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get(GET_USER_SUMMARY_URL, VALID_TEST_USER))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.roleActions[0]").value(DISABLED_ACTION))
-                .andExpect(jsonPath("$.newWorkReasons[0]").value(VALID_NWORCODE))
-                .andExpect(jsonPath("$.reservationsDTO.recordId").value(VALID_RESERVATION_ID))
-                .andExpect(jsonPath("$.roleDataItem[0].roleName").value(AUTHORISED_ROLE))
-                .andExpect(jsonPath("$.username").value(VALID_TEST_USER));
-    }
+  @Test
+  public void givenAValidUsername_whenGetUserSummaryIsInvoked_thenCorrectResponseIsReturned()
+      throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get(GET_USER_SUMMARY_URL, VALID_TEST_USER))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.roleActions[0]").value(DISABLED_ACTION))
+        .andExpect(jsonPath("$.newWorkReasons[0]").value(VALID_NWORCODE))
+        .andExpect(jsonPath("$.reservationsDTO.recordId").value(VALID_RESERVATION_ID))
+        .andExpect(jsonPath("$.roleDataItem[0].roleName").value(AUTHORISED_ROLE))
+        .andExpect(jsonPath("$.username").value(VALID_TEST_USER));
+  }
 
-    @Test
-    public void givenInValidUsername_whenGetUserSummaryIsInvoked_thenCorrectResponseIsReturned() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get(GET_USER_SUMMARY_URL, INVALID_TEST_USER))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.roleActions").isEmpty())
-                .andExpect(jsonPath("$.newWorkReasons").isEmpty())
-                .andExpect(jsonPath("$.reservationsDTO").doesNotExist())
-                .andExpect(jsonPath("$.username").value(INVALID_TEST_USER));
+  @Test
+  public void givenInValidUsername_whenGetUserSummaryIsInvoked_thenCorrectResponseIsReturned()
+      throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get(GET_USER_SUMMARY_URL, INVALID_TEST_USER))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.roleActions").isEmpty())
+        .andExpect(jsonPath("$.newWorkReasons").isEmpty())
+        .andExpect(jsonPath("$.reservationsDTO").doesNotExist())
+        .andExpect(jsonPath("$.username").value(INVALID_TEST_USER));
 
-    }
+  }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
@@ -1,10 +1,12 @@
 package gov.uk.courtdata.integration.util;
 
+import gov.uk.courtdata.applicant.repository.ApplicantDisabilitiesRepository;
 import gov.uk.courtdata.applicant.repository.ApplicantHistoryRepository;
 import gov.uk.courtdata.applicant.repository.RepOrderApplicantLinksRepository;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.eform.repository.EformStagingRepository;
 import gov.uk.courtdata.entity.UserEntity;
+import gov.uk.courtdata.integration.prosecution_concluded.procedures.UpdateOutcomesRepository;
 import gov.uk.courtdata.repository.AppealTypeRepository;
 import gov.uk.courtdata.repository.CaseRepository;
 import gov.uk.courtdata.repository.ChildWeightHistoryRepository;
@@ -75,6 +77,9 @@ public class Repositories {
 
   @Autowired
   public AppealTypeRepository appealType;
+
+  @Autowired
+  public ApplicantDisabilitiesRepository applicantDisabilities;
 
   @Autowired
   public ApplicantHistoryRepository applicantHistory;
@@ -224,6 +229,9 @@ public class Repositories {
   public UnlinkReasonRepository unlinkReason;
 
   @Autowired
+  public UpdateOutcomesRepository updateOutcomes;
+
+  @Autowired
   public UserRepository user;
 
   @Autowired
@@ -268,6 +276,7 @@ public class Repositories {
   @NotNull
   private JpaRepository[] allRepositories() {
     return new JpaRepository[]{appealType,
+        applicantDisabilities,
         applicantHistory,
         caseRepository,
         childWeightHistory,
@@ -317,6 +326,7 @@ public class Repositories {
         solicitorMAATData,
         solicitor,
         unlinkReason,
+        updateOutcomes,
         user,
         userRoles,
         verdict,

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
@@ -12,8 +12,8 @@ import gov.uk.courtdata.repository.ChildWeightingsRepository;
 import gov.uk.courtdata.repository.ConcorContributionsRepository;
 import gov.uk.courtdata.repository.ContribAppealRulesRepository;
 import gov.uk.courtdata.repository.ContribCalcParametersRepository;
-import gov.uk.courtdata.repository.ContributionFilesRepository;
 import gov.uk.courtdata.repository.ContributionFileErrorsRepository;
+import gov.uk.courtdata.repository.ContributionFilesRepository;
 import gov.uk.courtdata.repository.CorrespondenceRepository;
 import gov.uk.courtdata.repository.CorrespondenceStateRepository;
 import gov.uk.courtdata.repository.CourtHouseCodesRepository;
@@ -46,6 +46,7 @@ import gov.uk.courtdata.repository.RepOrderRepository;
 import gov.uk.courtdata.repository.ReservationsRepository;
 import gov.uk.courtdata.repository.ResultRepository;
 import gov.uk.courtdata.repository.RoleActionsRepository;
+import gov.uk.courtdata.repository.RoleDataItemsRepository;
 import gov.uk.courtdata.repository.RoleWorkReasonsRepository;
 import gov.uk.courtdata.repository.SessionRepository;
 import gov.uk.courtdata.repository.SolicitorMAATDataRepository;
@@ -72,267 +73,271 @@ import org.springframework.stereotype.Component;
 @Component
 public class Repositories {
 
-    @Autowired
-    public AppealTypeRepository appealType;
+  @Autowired
+  public AppealTypeRepository appealType;
 
-    @Autowired
-    private ApplicantHistoryRepository applicantHistory;
+  @Autowired
+  public ApplicantHistoryRepository applicantHistory;
 
-    @Autowired
-    public CaseRepository caseRepository;
+  @Autowired
+  public CaseRepository caseRepository;
 
-    @Autowired
-    public ChildWeightHistoryRepository childWeightHistory;
+  @Autowired
+  public ChildWeightHistoryRepository childWeightHistory;
 
-    @Autowired
-    public ChildWeightingsRepository childWeightings;
+  @Autowired
+  public ChildWeightingsRepository childWeightings;
 
-    @Autowired
-    public ConcorContributionsRepository concorContributions;
+  @Autowired
+  public ConcorContributionsRepository concorContributions;
 
-    @Autowired
-    public ContribAppealRulesRepository contribAppealRules;
+  @Autowired
+  public ContribAppealRulesRepository contribAppealRules;
 
-    @Autowired
-    public ContribCalcParametersRepository contribCalcParameters;
+  @Autowired
+  public ContribCalcParametersRepository contribCalcParameters;
 
-    @Autowired
-    public ContributionFilesRepository contributionFiles;
+  @Autowired
+  public ContributionFilesRepository contributionFiles;
 
-    @Autowired
-    public ContributionFileErrorsRepository contributionFileErrors;
+  @Autowired
+  public ContributionFileErrorsRepository contributionFileErrors;
 
-    @Autowired
-    public CorrespondenceRepository correspondence;
+  @Autowired
+  public CorrespondenceRepository correspondence;
 
-    @Autowired
-    public CorrespondenceStateRepository correspondenceState;
+  @Autowired
+  public CorrespondenceStateRepository correspondenceState;
 
-    @Autowired
-    public CourtHouseCodesRepository courtHouseCodes;
+  @Autowired
+  public CourtHouseCodesRepository courtHouseCodes;
 
-    @Autowired
-    public CrownCourtCodeRepository crownCourtCode;
+  @Autowired
+  public CrownCourtCodeRepository crownCourtCode;
 
-    @Autowired
-    public CrownCourtOutcomeRepository crownCourtOutcome;
+  @Autowired
+  public CrownCourtOutcomeRepository crownCourtOutcome;
 
-    @Autowired
-    public CrownCourtProcessingRepository crownCourtProcessing;
+  @Autowired
+  public CrownCourtProcessingRepository crownCourtProcessing;
 
-    @Autowired
-    public DefendantMAATDataRepository defendantMAATData;
+  @Autowired
+  public DefendantMAATDataRepository defendantMAATData;
 
-    @Autowired
-    public DefendantRepository defendant;
+  @Autowired
+  public DefendantRepository defendant;
 
-    @Autowired
-    private EformStagingRepository eformStaging;
+  @Autowired
+  public EformStagingRepository eformStaging;
 
-    @Autowired
-    public FdcContributionsRepository fdcContributions;
+  @Autowired
+  public FdcContributionsRepository fdcContributions;
 
-    @Autowired
-    public FinancialAssessmentDetailsHistoryRepository financialAssessmentDetailsHistory;
+  @Autowired
+  public FinancialAssessmentDetailsHistoryRepository financialAssessmentDetailsHistory;
 
-    @Autowired
-    public FinancialAssessmentDetailsRepository financialAssessmentDetails;
+  @Autowired
+  public FinancialAssessmentDetailsRepository financialAssessmentDetails;
 
-    @Autowired
-    public FinancialAssessmentRepository financialAssessment;
+  @Autowired
+  public FinancialAssessmentRepository financialAssessment;
 
-    @Autowired
-    public FinancialAssessmentsHistoryRepository financialAssessmentsHistory;
+  @Autowired
+  public FinancialAssessmentsHistoryRepository financialAssessmentsHistory;
 
-    @Autowired
-    public HardshipReviewDetailRepository hardshipReviewDetail;
+  @Autowired
+  public HardshipReviewDetailRepository hardshipReviewDetail;
 
-    @Autowired
-    public HardshipReviewProgressRepository hardshipReviewProgress;
+  @Autowired
+  public HardshipReviewProgressRepository hardshipReviewProgress;
 
-    @Autowired
-    public HardshipReviewRepository hardshipReview;
+  @Autowired
+  public HardshipReviewRepository hardshipReview;
 
-    @Autowired
-    public IdentifierRepository identifier;
+  @Autowired
+  public IdentifierRepository identifier;
 
-    @Autowired
-    public IOJAppealRepository iojAppeal;
+  @Autowired
+  public IOJAppealRepository iojAppeal;
 
-    @Autowired
-    public OffenceRepository offence;
+  @Autowired
+  public OffenceRepository offence;
 
-    @Autowired
-    public PassportAssessmentRepository passportAssessment;
+  @Autowired
+  public PassportAssessmentRepository passportAssessment;
 
-    @Autowired
-    public PleaRepository plea;
+  @Autowired
+  public PleaRepository plea;
 
-    @Autowired
-    public ProceedingRepository proceeding;
+  @Autowired
+  public ProceedingRepository proceeding;
 
-    @Autowired
-    public ProsecutionConcludedRepository prosecutionConcluded;
+  @Autowired
+  public ProsecutionConcludedRepository prosecutionConcluded;
 
-    @Autowired
-    public QueueMessageLogRepository queueMessageLog;
+  @Autowired
+  public QueueMessageLogRepository queueMessageLog;
 
-    @Autowired
-    private RepOrderApplicantLinksRepository repOrderApplicantLinks;
+  @Autowired
+  public RepOrderApplicantLinksRepository repOrderApplicantLinks;
 
-    @Autowired
-    public RepOrderCapitalRepository repOrderCapital;
+  @Autowired
+  public RepOrderCapitalRepository repOrderCapital;
 
-    @Autowired
-    public RepOrderCPDataRepository repOrderCPData;
+  @Autowired
+  public RepOrderCPDataRepository repOrderCPData;
 
-    @Autowired
-    public RepOrderMvoRegRepository repOrderMvoReg;
+  @Autowired
+  public RepOrderMvoRegRepository repOrderMvoReg;
 
-    @Autowired
-    public RepOrderMvoRepository repOrderMvo;
+  @Autowired
+  public RepOrderMvoRepository repOrderMvo;
 
-    @Autowired
-    public RepOrderRepository repOrder;
-
-    @Autowired
-    public ReservationsRepository reservations;
-
-    @Autowired
-    public ResultRepository result;
-
-    @Autowired
-    public RoleActionsRepository roleActions;
-
-    @Autowired
-    public RoleWorkReasonsRepository roleWorkReasons;
-
-    @Autowired
-    public SessionRepository session;
-
-    @Autowired
-    public SolicitorMAATDataRepository solicitorMAATData;
-
-    @Autowired
-    public SolicitorRepository solicitor;
-
-    @Autowired
-    public UnlinkReasonRepository unlinkReason;
-
-    @Autowired
-    public UserRepository user;
-
-    @Autowired
-    public UserRolesRepository userRoles;
-
-    @Autowired
-    public VerdictRepository verdict;
-
-    @Autowired
-    public WQCaseRepository wqCase;
-
-    @Autowired
-    public WqCoreRepository wqCore;
-
-    @Autowired
-    public WQDefendantRepository wqDefendant;
-
-    @Autowired
-    public WQHearingRepository wqHearing;
-
-    @Autowired
-    public WqLinkRegisterRepository wqLinkRegister;
-
-    @Autowired
-    public WQOffenceRepository wqOffence;
-
-    @Autowired
-    public WQResultRepository wqResult;
-
-    @Autowired
-    public WQSessionRepository wqSession;
-
-    @Autowired
-    public XLATOffenceRepository xlatOffence;
-
-    @Autowired
-    public XLATResultRepository xlatResult;
-
-    @Autowired
-    private RepositoryUtil repositoryUtil;
-
-    @NotNull
-    private JpaRepository[] allRepositories() {
-        return new JpaRepository[]{appealType,
-                applicantHistory,
-                caseRepository,
-                childWeightHistory,
-                childWeightings,
-                concorContributions,
-                contribAppealRules,
-                contribCalcParameters,
-                contributionFiles,
-                contributionFileErrors,
-                correspondence,
-                correspondenceState,
-                courtHouseCodes,
-                crownCourtCode,
-                crownCourtOutcome,
-                crownCourtProcessing,
-                defendantMAATData,
-                defendant,
-                eformStaging,
-                fdcContributions,
-                financialAssessmentDetailsHistory,
-                financialAssessmentDetails,
-                financialAssessment,
-                financialAssessmentsHistory,
-                hardshipReviewDetail,
-                hardshipReviewProgress,
-                hardshipReview,
-                identifier,
-                iojAppeal,
-                offence,
-                passportAssessment,
-                plea,
-                proceeding,
-                prosecutionConcluded,
-                queueMessageLog,
-                repOrderApplicantLinks,
-                repOrderCapital,
-                repOrderCPData,
-                repOrderMvoReg,
-                repOrderMvo,
-                repOrder,
-                reservations,
-                result,
-                roleActions,
-                roleWorkReasons,
-                session,
-                solicitorMAATData,
-                solicitor,
-                unlinkReason,
-                user,
-                userRoles,
-                verdict,
-                wqCase,
-                wqCore,
-                wqDefendant,
-                wqHearing,
-                wqLinkRegister,
-                wqOffence,
-                wqResult,
-                wqSession,
-                xlatOffence,
-                xlatResult};
-    }
-
-    public void insertCommonTestData() {
-        user.save(UserEntity.builder().username(TestEntityDataBuilder.TEST_USER).build());
-        user.save(UserEntity.builder().username(TestEntityDataBuilder.USER_CREATED_TEST_S).build());
-    }
-
-    public void clearAll() {
-        repositoryUtil.clearUp(allRepositories());
-    }
+  @Autowired
+  public RepOrderRepository repOrder;
+
+  @Autowired
+  public ReservationsRepository reservations;
+
+  @Autowired
+  public ResultRepository result;
+
+  @Autowired
+  public RoleActionsRepository roleActions;
+
+  @Autowired
+  public RoleDataItemsRepository roleDataItems;
+
+  @Autowired
+  public RoleWorkReasonsRepository roleWorkReasons;
+
+  @Autowired
+  public SessionRepository session;
+
+  @Autowired
+  public SolicitorMAATDataRepository solicitorMAATData;
+
+  @Autowired
+  public SolicitorRepository solicitor;
+
+  @Autowired
+  public UnlinkReasonRepository unlinkReason;
+
+  @Autowired
+  public UserRepository user;
+
+  @Autowired
+  public UserRolesRepository userRoles;
+
+  @Autowired
+  public VerdictRepository verdict;
+
+  @Autowired
+  public WQCaseRepository wqCase;
+
+  @Autowired
+  public WqCoreRepository wqCore;
+
+  @Autowired
+  public WQDefendantRepository wqDefendant;
+
+  @Autowired
+  public WQHearingRepository wqHearing;
+
+  @Autowired
+  public WqLinkRegisterRepository wqLinkRegister;
+
+  @Autowired
+  public WQOffenceRepository wqOffence;
+
+  @Autowired
+  public WQResultRepository wqResult;
+
+  @Autowired
+  public WQSessionRepository wqSession;
+
+  @Autowired
+  public XLATOffenceRepository xlatOffence;
+
+  @Autowired
+  public XLATResultRepository xlatResult;
+
+  @Autowired
+  private RepositoryUtil repositoryUtil;
+
+  @NotNull
+  private JpaRepository[] allRepositories() {
+    return new JpaRepository[]{appealType,
+        applicantHistory,
+        caseRepository,
+        childWeightHistory,
+        childWeightings,
+        concorContributions,
+        contribAppealRules,
+        contribCalcParameters,
+        contributionFiles,
+        contributionFileErrors,
+        correspondence,
+        correspondenceState,
+        courtHouseCodes,
+        crownCourtCode,
+        crownCourtOutcome,
+        crownCourtProcessing,
+        defendantMAATData,
+        defendant,
+        eformStaging,
+        fdcContributions,
+        financialAssessmentDetailsHistory,
+        financialAssessmentDetails,
+        financialAssessment,
+        financialAssessmentsHistory,
+        hardshipReviewDetail,
+        hardshipReviewProgress,
+        hardshipReview,
+        identifier,
+        iojAppeal,
+        offence,
+        passportAssessment,
+        plea,
+        proceeding,
+        prosecutionConcluded,
+        queueMessageLog,
+        repOrderApplicantLinks,
+        repOrderCapital,
+        repOrderCPData,
+        repOrderMvoReg,
+        repOrderMvo,
+        repOrder,
+        reservations,
+        result,
+        roleActions,
+        roleDataItems,
+        roleWorkReasons,
+        session,
+        solicitorMAATData,
+        solicitor,
+        unlinkReason,
+        user,
+        userRoles,
+        verdict,
+        wqCase,
+        wqCore,
+        wqDefendant,
+        wqHearing,
+        wqLinkRegister,
+        wqOffence,
+        wqResult,
+        wqSession,
+        xlatOffence,
+        xlatResult};
+  }
+
+  public void insertCommonTestData() {
+    user.save(UserEntity.builder().username(TestEntityDataBuilder.TEST_USER).build());
+    user.save(UserEntity.builder().username(TestEntityDataBuilder.USER_CREATED_TEST_S).build());
+  }
+
+  public void clearAll() {
+    repositoryUtil.clearUp(allRepositories());
+  }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqhearing/WQHearingControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqhearing/WQHearingControllerIntegrationTest.java
@@ -1,24 +1,19 @@
 package gov.uk.courtdata.integration.wqhearing;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.entity.WQHearingEntity;
-import gov.uk.courtdata.repository.WQHearingRepository;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
+import java.util.List;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqlinkregister/WQLinkRegisterControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqlinkregister/WQLinkRegisterControllerIntegrationTest.java
@@ -1,22 +1,20 @@
 package gov.uk.courtdata.integration.wqlinkregister;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
-import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
+import gov.uk.courtdata.repository.WqLinkRegisterRepository;
+import java.util.List;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqoffence/WQOffenceControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqoffence/WQOffenceControllerIntegrationTest.java
@@ -1,22 +1,17 @@
 package gov.uk.courtdata.integration.wqoffence;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
-import gov.uk.courtdata.repository.WQOffenceRepository;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.integration.util.RepositoryUtil;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})


### PR DESCRIPTION
## Improve consistency of usage of Repositories in Integration tests

Changes include:

- Replace `assert` with `assertEquals` as Java assertions are disabled by default, see [Using Java Assertions](https://www.baeldung.com/java-assert#conclusion).
- Remove local declaration of Repositories in Integration tests and instead re-use Repositories via the `MockMvcIntegrationTest` e.g. `repos.repOrder.save(TestEntityDataBuilder.getRepOrder());`
- Remove redundant calls to `RepositoryUtil().clearUp(` in integration tests, as this is done automatically by extending `MockMvcIntegrationTest`.
- Remove unused imports of `import gov.uk.courtdata.integration.util.RepositoryUtil;`.



## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
