### PR TITLE
Improve consistency of usage of Repositories in Integration tests

### DIFF
--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/applicant/ApplicantControllerIntegrationTest.java
@@ -9,13 +9,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.applicant.dto.RepOrderApplicantLinksDTO;
 import gov.uk.courtdata.applicant.entity.RepOrderApplicantLinksEntity;
-import gov.uk.courtdata.applicant.repository.ApplicantHistoryRepository;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -26,9 +24,6 @@ public class ApplicantControllerIntegrationTest extends MockMvcIntegrationTest {
     private static final Integer INVALID_REP_ID = 234;
     private static final String ENDPOINT_URL = "/api/internal/v1/application/applicant";
     private static final int ID = 1;
-
-    @Autowired
-    private ApplicantHistoryRepository applicantHistoryRepository;
 
     @Test
     void givenCorrectRepId_whenGetRepOrderApplicantLinksIsInvoked_thenResponseIsReturned() throws Exception {
@@ -75,8 +70,8 @@ public class ApplicantControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenCorrectId_whenGetApplicantHistoryIsInvoked_thenResponseIsReturned() throws Exception {
-        applicantHistoryRepository.saveAndFlush(TestEntityDataBuilder.getApplicantHistoryEntity("N"));
-        Integer id = applicantHistoryRepository.findAll().get(0).getId();
+        repos.applicantHistory.saveAndFlush(TestEntityDataBuilder.getApplicantHistoryEntity("N"));
+        Integer id = repos.applicantHistory.findAll().get(0).getId();
         mockMvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL + "/applicant-history/" + id))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
@@ -90,8 +85,8 @@ public class ApplicantControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenValidRequest_whenUpdateApplicantHistoryIsInvoked_thenUpdateIsSuccess() throws Exception {
-        applicantHistoryRepository.saveAndFlush(TestEntityDataBuilder.getApplicantHistoryEntity("N"));
-        Integer id = applicantHistoryRepository.findAll().get(0).getId();
+        repos.applicantHistory.saveAndFlush(TestEntityDataBuilder.getApplicantHistoryEntity("N"));
+        Integer id = repos.applicantHistory.findAll().get(0).getId();
         mockMvc.perform(MockMvcRequestBuilders.put(ENDPOINT_URL + "/applicant-history")
                         .content(objectMapper.writeValueAsString(TestModelDataBuilder.getApplicantHistoryDTO(id, SEND_TO_CCLF)))
                         .contentType(MediaType.APPLICATION_JSON))

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/FinancialAssessmentControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/assessment/FinancialAssessmentControllerIntegrationTest.java
@@ -1,5 +1,12 @@
 package gov.uk.courtdata.integration.assessment;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.assessment.impl.FinancialAssessmentImpl;
 import gov.uk.courtdata.assessment.mapper.FinancialAssessmentMapper;
@@ -15,13 +22,15 @@ import gov.uk.courtdata.entity.NewWorkReasonEntity;
 import gov.uk.courtdata.entity.PassportAssessmentEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.UserEntity;
-import gov.uk.courtdata.integration.MockNewWorkReasonRepository;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.model.NewWorkReason;
 import gov.uk.courtdata.model.assessment.ChildWeightings;
 import gov.uk.courtdata.model.assessment.CreateFinancialAssessment;
 import gov.uk.courtdata.model.assessment.FinancialAssessmentDetails;
 import gov.uk.courtdata.model.assessment.UpdateFinancialAssessment;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,17 +38,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class FinancialAssessmentControllerIntegrationTest extends MockMvcIntegrationTest {
@@ -56,9 +54,6 @@ public class FinancialAssessmentControllerIntegrationTest extends MockMvcIntegra
 
     @Autowired
     private FinancialAssessmentMapper assessmentMapper;
-
-    @Autowired
-    private MockNewWorkReasonRepository newWorkReasonRepository;
 
     private List<FinancialAssessmentEntity> existingAssessmentEntities;
     private RepOrderEntity existingRepOrder;
@@ -82,7 +77,7 @@ public class FinancialAssessmentControllerIntegrationTest extends MockMvcIntegra
         UserEntity userEntity = TestEntityDataBuilder.getUserEntity(TestEntityDataBuilder.TEST_USER);
         repos.user.save(userEntity);
 
-        NewWorkReasonEntity newWorkReasonEntity = newWorkReasonRepository.save(
+        NewWorkReasonEntity newWorkReasonEntity = repos.mockNewWorkReason.save(
                 TestEntityDataBuilder.getFmaNewWorkReasonEntity());
 
         List<FinancialAssessmentEntity> assessmentsToCreate = List.of(

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/authorization/AuthorizationControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/authorization/AuthorizationControllerIntegrationTest.java
@@ -11,16 +11,10 @@ import gov.uk.courtdata.entity.UserEntity;
 import gov.uk.courtdata.entity.UserRoleEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.model.authorization.AuthorizationResponse;
-import gov.uk.courtdata.repository.ReservationsRepository;
-import gov.uk.courtdata.repository.RoleActionsRepository;
-import gov.uk.courtdata.repository.RoleWorkReasonsRepository;
-import gov.uk.courtdata.repository.UserRepository;
-import gov.uk.courtdata.repository.UserRolesRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
@@ -40,17 +34,6 @@ public class AuthorizationControllerIntegrationTest extends MockMvcIntegrationTe
     private final String NEW_WORK_REASON_AUTHORIZED_URL = BASE_URL + "{username}/work-reasons/{nworCode}";
     private final String IS_RESERVED_URL = BASE_URL + "{username}/reservations/{reservationId}/sessions/{sessionId}";
 
-    @Autowired
-    private RoleActionsRepository roleActionsRepository;
-    @Autowired
-    private ReservationsRepository reservationsRepository;
-    @Autowired
-    private RoleWorkReasonsRepository roleWorkReasonsRepository;
-    @Autowired
-    private UserRolesRepository userRolesRepository;
-    @Autowired
-    private UserRepository userRepository;
-
     @BeforeEach
     public void setUp() throws Exception {
         setupTestData();
@@ -66,7 +49,7 @@ public class AuthorizationControllerIntegrationTest extends MockMvcIntegrationTe
                         .username(VALID_TEST_USER).roleName(DISABLED_ROLE).build()
         );
 
-        userRolesRepository.saveAll(userRoleEntities);
+        repos.userRoles.saveAll(userRoleEntities);
 
         String ROLE_ACTION_ENABLED = "Y";
         String ROLE_ACTION_DISABLED = "N";
@@ -77,9 +60,9 @@ public class AuthorizationControllerIntegrationTest extends MockMvcIntegrationTe
                         .Id(2).roleName(DISABLED_ROLE).action(DISABLED_ACTION).enabled(ROLE_ACTION_DISABLED).build()
         );
 
-        roleActionsRepository.saveAll(roleActionEntities);
+        repos.roleActions.saveAll(roleActionEntities);
 
-        roleWorkReasonsRepository
+        repos.roleWorkReasons
                 .save(RoleWorkReasonEntity.builder()
                         .id(1)
                         .roleName(AUTHORISED_ROLE)
@@ -92,7 +75,7 @@ public class AuthorizationControllerIntegrationTest extends MockMvcIntegrationTe
         LocalDateTime reservationDate = LocalDateTime.now();
         LocalDateTime expiryDate = reservationDate.plusHours(3);
 
-        reservationsRepository.save(ReservationsEntity.builder()
+        repos.reservations.save(ReservationsEntity.builder()
                 .recordId(1)
                 .userName(VALID_TEST_USER)
                 .userSession(VALID_SESSION_ID)
@@ -102,7 +85,7 @@ public class AuthorizationControllerIntegrationTest extends MockMvcIntegrationTe
                 .expiryDate(expiryDate)
                 .build());
 
-        userRepository.save(UserEntity.builder()
+        repos.user.save(UserEntity.builder()
                 .username(VALID_TEST_USER)
                 .currentSession(VALID_SESSION_ID)
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/contribution/ContributionsControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/contribution/ContributionsControllerIntegrationTest.java
@@ -14,15 +14,11 @@ import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.contribution.model.CreateContributions;
 import gov.uk.courtdata.contribution.model.UpdateContributions;
-import gov.uk.courtdata.contribution.repository.ContributionsRepository;
 import gov.uk.courtdata.entity.ContributionFilesEntity;
 import gov.uk.courtdata.entity.ContributionsEntity;
 import gov.uk.courtdata.entity.CorrespondenceEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.ContributionFilesRepository;
-import gov.uk.courtdata.repository.CorrespondenceRepository;
-import gov.uk.courtdata.repository.RepOrderRepository;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -46,38 +42,33 @@ class ContributionsControllerIntegrationTest extends MockMvcIntegrationTest {
     public Integer REP_ID = 1234;
     @Autowired
     protected ObjectMapper objectMapper;
-    @Autowired
-    ContributionsRepository contributionsRepository;
-    @Autowired
-    ContributionFilesRepository contributionFilesRepository;
-    @Autowired
-    CorrespondenceRepository correspondenceRepository;
-    @Autowired
-    private RepOrderRepository repOrderRepository;
 
     private ContributionsEntity contributionsEntity;
 
     @BeforeEach
     public void setUp() {
-        RepOrderEntity repOrderEntity = repOrderRepository.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
+        RepOrderEntity repOrderEntity = repos.repOrder.saveAndFlush(
+            TestEntityDataBuilder.getPopulatedRepOrder());
         REP_ID = repOrderEntity.getId();
 
-        ContributionFilesEntity contributionFilesEntity = contributionFilesRepository.saveAndFlush(TestEntityDataBuilder.getContributionFilesEntity());
+        ContributionFilesEntity contributionFilesEntity = repos.contributionFiles.saveAndFlush(
+            TestEntityDataBuilder.getContributionFilesEntity());
         CorrespondenceEntity correspondence = TestEntityDataBuilder.getCorrespondenceEntity(1);
         correspondence.setRepId(REP_ID);
-        CorrespondenceEntity correspondenceEntity = correspondenceRepository.saveAndFlush(correspondence);
+        CorrespondenceEntity correspondenceEntity = repos.correspondence.saveAndFlush(
+            correspondence);
 
         ContributionsEntity contributions = TestEntityDataBuilder.getContributionsEntity();
         contributions.setCorrespondenceId(correspondenceEntity.getId());
         contributions.setContributionFileId(contributionFilesEntity.getFileId());
         contributions.setRepOrder(repOrderEntity);
-        contributionsEntity = contributionsRepository.saveAndFlush(contributions);
+        contributionsEntity = repos.contributions.saveAndFlush(contributions);
 
-
-        RepOrderEntity repOrder = repOrderRepository.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
+        RepOrderEntity repOrder = repos.repOrder.saveAndFlush(
+            TestEntityDataBuilder.getPopulatedRepOrder());
         ContributionsEntity contributionsEntity = TestEntityDataBuilder.getContributionsEntity();
         contributionsEntity.setRepOrder(repOrder);
-        contributionsRepository.saveAndFlush(contributionsEntity);
+        repos.contributions.saveAndFlush(contributionsEntity);
     }
 
     @AfterEach

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/contribution/ContributionsControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/contribution/ContributionsControllerIntegrationTest.java
@@ -1,5 +1,13 @@
 package gov.uk.courtdata.integration.contribution;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
@@ -11,10 +19,6 @@ import gov.uk.courtdata.entity.ContributionsEntity;
 import gov.uk.courtdata.entity.CorrespondenceEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.ContributionFilesRepository;
-import gov.uk.courtdata.repository.CorrespondenceRepository;
-import gov.uk.courtdata.repository.RepOrderRepository;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,10 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
@@ -146,11 +146,11 @@ class ContributionsControllerIntegrationTest extends MockMvcIntegrationTest {
     void givenValidRepId_whenGetContributionsSummaryIsInvoked_thenCorrectResponseIsReturned() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL + "/" + REP_ID
                 + "/summary").contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$[0].id").value(contributionsEntity.getId()))
-                .andExpect(jsonPath("$[0].basedOn").value("Means"))
-                .andExpect(jsonPath("$[0].upliftApplied").value("Y"));
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$[0].id").value(contributionsEntity.getId()))
+            .andExpect(jsonPath("$[0].basedOn").value("Means"))
+            .andExpect(jsonPath("$[0].upliftApplied").value("Y"));
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/contribution/ContributionsServiceIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/contribution/ContributionsServiceIntegrationTest.java
@@ -1,12 +1,14 @@
 package gov.uk.courtdata.integration.contribution;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.contribution.dto.ContributionsSummaryDTO;
 import gov.uk.courtdata.contribution.model.CreateContributions;
 import gov.uk.courtdata.contribution.model.UpdateContributions;
-import gov.uk.courtdata.contribution.repository.ContributionsRepository;
 import gov.uk.courtdata.contribution.service.ContributionsService;
 import gov.uk.courtdata.dto.ContributionsDTO;
 import gov.uk.courtdata.entity.ContributionFilesEntity;
@@ -14,20 +16,13 @@ import gov.uk.courtdata.entity.ContributionsEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.ContributionFilesRepository;
-import gov.uk.courtdata.repository.CorrespondenceRepository;
-import gov.uk.courtdata.repository.RepOrderRepository;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataAccessException;
-
-import java.util.List;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 class ContributionsServiceIntegrationTest extends MockMvcIntegrationTest {
@@ -40,18 +35,6 @@ class ContributionsServiceIntegrationTest extends MockMvcIntegrationTest {
     public Integer REP_ID = 1234;
 
     @Autowired
-    ContributionsRepository contributionsRepository;
-
-    @Autowired
-    ContributionFilesRepository contributionFilesRepository;
-
-    @Autowired
-    CorrespondenceRepository correspondenceRepository;
-
-    @Autowired
-    private RepOrderRepository repOrderRepository;
-
-    @Autowired
     private ContributionsService contributionsService;
 
     private ContributionsEntity contributionsEntity;
@@ -59,7 +42,8 @@ class ContributionsServiceIntegrationTest extends MockMvcIntegrationTest {
     @BeforeEach
     public void setUp() {
 
-        RepOrderEntity repOrderEntity = repOrderRepository.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
+        RepOrderEntity repOrderEntity = repos.repOrder.saveAndFlush(
+            TestEntityDataBuilder.getPopulatedRepOrder());
         REP_ID = repOrderEntity.getId();
 
         ContributionsEntity contributions = TestEntityDataBuilder.getContributionsEntity();
@@ -67,9 +51,9 @@ class ContributionsServiceIntegrationTest extends MockMvcIntegrationTest {
 
         ContributionFilesEntity contributionFilesEntity = TestEntityDataBuilder.getContributionFilesEntity();
         contributionFilesEntity.setFileId(contributions.getContributionFileId());
-        contributionFilesRepository.saveAndFlush(contributionFilesEntity);
+        repos.contributionFiles.saveAndFlush(contributionFilesEntity);
 
-        contributionsEntity = contributionsRepository.saveAndFlush(contributions);
+        contributionsEntity = repos.contributions.saveAndFlush(contributions);
     }
 
     @Test
@@ -130,7 +114,7 @@ class ContributionsServiceIntegrationTest extends MockMvcIntegrationTest {
     void givenValidRepId_whenGetContributionsSummaryIsInvoked_thenCorrectResponseIsReturned() {
         ContributionFilesEntity contributionFilesEntity = TestEntityDataBuilder.getContributionFilesEntity();
         contributionFilesEntity.setFileId(contributionsEntity.getContributionFileId());
-        contributionFilesRepository.saveAndFlush(contributionFilesEntity);
+        repos.contributionFiles.saveAndFlush(contributionFilesEntity);
         List<ContributionsSummaryDTO> contributionsSummary = contributionsService.getContributionsSummary(REP_ID);
         assertThat(contributionsSummary.isEmpty()).isFalse();
         assertThat(contributionsSummary.get(0).getFileName()).isEqualTo(CONTRIBUTION_FILE_NAME);
@@ -145,7 +129,7 @@ class ContributionsServiceIntegrationTest extends MockMvcIntegrationTest {
     }
 
     private Integer getContributionId() {
-        ContributionsEntity contributionsEntity = contributionsRepository.findAll().get(0);
+        ContributionsEntity contributionsEntity = repos.contributions.findAll().get(0);
         Integer contributionId = contributionsEntity.getId();
         return contributionId;
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/correspondence/CorrespondenceStateControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/correspondence/CorrespondenceStateControllerIntegrationTest.java
@@ -10,7 +10,6 @@ import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.entity.CorrespondenceStateEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.CorrespondenceStateRepository;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,13 +33,13 @@ public class CorrespondenceStateControllerIntegrationTest extends MockMvcIntegra
     @Autowired
     protected ObjectMapper objectMapper;
     @Autowired
-    CorrespondenceStateRepository repository;
-    @Autowired
     MockMvc mvc;
 
     @BeforeEach
     public void setUp() {
-        repository.saveAndFlush(TestEntityDataBuilder.getCorrespondenceStateEntity(TestModelDataBuilder.REP_ID, "appealCC"));
+        repos.correspondenceState.saveAndFlush(
+            TestEntityDataBuilder.getCorrespondenceStateEntity(TestModelDataBuilder.REP_ID,
+                "appealCC"));
     }
 
     @Test
@@ -56,7 +55,8 @@ public class CorrespondenceStateControllerIntegrationTest extends MockMvcIntegra
         MvcResult result = runSuccessScenario(MockMvcRequestBuilders.post(ENDPOINT_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestEntityDataBuilder.getCorrespondenceStateEntity(REP_ID, "appealCC"))));
-        Assertions.assertThat(objectMapper.writeValueAsString(repository.findByRepId(REP_ID)))
+        Assertions.assertThat(
+                objectMapper.writeValueAsString(repos.correspondenceState.findByRepId(REP_ID)))
                 .isEqualTo(result.getResponse().getContentAsString());
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderCapitalIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderCapitalIntegrationTest.java
@@ -7,14 +7,11 @@ import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.RepOrderCapitalRepository;
-import gov.uk.courtdata.repository.RepOrderRepository;
 import java.util.List;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 
@@ -27,26 +24,23 @@ public class RepOrderCapitalIntegrationTest extends MockMvcIntegrationTest {
 
     private static final Integer INVALID_REP_ID = -1;
 
-    @Autowired
-    private RepOrderCapitalRepository capitalRepository;
-    @Autowired
-    private RepOrderRepository repOrderRepository;
-
     private Integer REP_ID;
     private Integer MOCK1_REP_ID;
 
     @BeforeEach
     void setUp() {
 
-        RepOrderEntity repOrderEntity = repOrderRepository.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
+        RepOrderEntity repOrderEntity = repos.repOrder.saveAndFlush(
+            TestEntityDataBuilder.getPopulatedRepOrder());
         REP_ID = repOrderEntity.getId();
-        RepOrderEntity repOrder = repOrderRepository.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
+        RepOrderEntity repOrder = repos.repOrder.saveAndFlush(
+            TestEntityDataBuilder.getPopulatedRepOrder());
         MOCK1_REP_ID = repOrder.getId();
 
 
         List repOrderCapitalList = List.of(TestEntityDataBuilder.getRepOrderCapitalEntity(1, REP_ID, "SAVINGS"),
                 TestEntityDataBuilder.getRepOrderCapitalEntity(2, MOCK1_REP_ID, "PROPERTY"));
-        capitalRepository.saveAllAndFlush(repOrderCapitalList);
+        repos.repOrderCapital.saveAllAndFlush(repOrderCapitalList);
 
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
@@ -22,9 +22,6 @@ import gov.uk.courtdata.model.CreateRepOrder;
 import gov.uk.courtdata.model.UpdateRepOrder;
 import gov.uk.courtdata.model.assessment.UpdateAppDateCompleted;
 import gov.uk.courtdata.reporder.mapper.RepOrderMapper;
-import gov.uk.courtdata.repository.RepOrderMvoRegRepository;
-import gov.uk.courtdata.repository.RepOrderMvoRepository;
-import gov.uk.courtdata.repository.RepOrderRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -64,22 +61,20 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
 
 
     @BeforeEach
-    void setUp(@Autowired RepOrderRepository repOrderRepository,
-               @Autowired RepOrderMvoRepository repOrderMvoRepository,
-               @Autowired RepOrderMvoRegRepository repOrderMvoRegRepository) {
-
+    void setUp() {
         RepOrderEntity repOrdTestData = TestEntityDataBuilder.getPopulatedRepOrder();
         repOrdTestData.setSentenceOrderDate(null);
-        RepOrderEntity repOrder = repOrderRepository.save(repOrdTestData);
+      RepOrderEntity repOrder = repos.repOrder.save(repOrdTestData);
         REP_ORDER_ID_NO_SENTENCE_ORDER_DATE = repOrder.getId();
 
-        RepOrderEntity repOrderEntity = repOrderRepository.save(TestEntityDataBuilder.getPopulatedRepOrder());
+      RepOrderEntity repOrderEntity = repos.repOrder.save(
+          TestEntityDataBuilder.getPopulatedRepOrder());
         REP_ID = repOrderEntity.getId();
 
-        repOrderMvoRepository.save(
+      repos.repOrderMvo.save(
                 TestEntityDataBuilder.getRepOrderMvoEntity(TestEntityDataBuilder.MVO_ID, repOrder)
         );
-        repOrderMvoRegRepository.save(
+      repos.repOrderMvoReg.save(
                 TestEntityDataBuilder.getRepOrderMvoRegEntity(TestEntityDataBuilder.REP_ID, repOrder)
         );
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
@@ -4,8 +4,10 @@ import gov.uk.courtdata.applicant.repository.ApplicantDisabilitiesRepository;
 import gov.uk.courtdata.applicant.repository.ApplicantHistoryRepository;
 import gov.uk.courtdata.applicant.repository.RepOrderApplicantLinksRepository;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.contribution.repository.ContributionsRepository;
 import gov.uk.courtdata.eform.repository.EformStagingRepository;
 import gov.uk.courtdata.entity.UserEntity;
+import gov.uk.courtdata.integration.MockNewWorkReasonRepository;
 import gov.uk.courtdata.integration.prosecution_concluded.procedures.UpdateOutcomesRepository;
 import gov.uk.courtdata.repository.AppealTypeRepository;
 import gov.uk.courtdata.repository.CaseRepository;
@@ -109,6 +111,9 @@ public class Repositories {
   public ContributionFileErrorsRepository contributionFileErrors;
 
   @Autowired
+  public ContributionsRepository contributions;
+
+  @Autowired
   public CorrespondenceRepository correspondence;
 
   @Autowired
@@ -164,6 +169,9 @@ public class Repositories {
 
   @Autowired
   public IOJAppealRepository iojAppeal;
+
+  @Autowired
+  public MockNewWorkReasonRepository mockNewWorkReason;
 
   @Autowired
   public OffenceRepository offence;
@@ -286,6 +294,7 @@ public class Repositories {
         contribCalcParameters,
         contributionFiles,
         contributionFileErrors,
+        contributions,
         correspondence,
         correspondenceState,
         courtHouseCodes,
@@ -305,6 +314,7 @@ public class Repositories {
         hardshipReview,
         identifier,
         iojAppeal,
+        mockNewWorkReason,
         offence,
         passportAssessment,
         plea,

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqlinkregister/WQLinkRegisterControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/wqlinkregister/WQLinkRegisterControllerIntegrationTest.java
@@ -7,13 +7,11 @@ import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import gov.uk.courtdata.repository.WqLinkRegisterRepository;
 import java.util.List;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @ExtendWith(SoftAssertionsExtension.class)
@@ -23,12 +21,9 @@ public class WQLinkRegisterControllerIntegrationTest extends MockMvcIntegrationT
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/wq-link-register";
     private static final Integer INVALID_REP_ID = 12312334;
 
-    @Autowired
-    private WqLinkRegisterRepository wqLinkRegisterRepository;
-
     @BeforeEach
-    void setUp(@Autowired WqLinkRegisterRepository wqLinkRegisterRepository) {
-        wqLinkRegisterRepository.save(TestEntityDataBuilder.getWQLinkRegisterEntity(8064716));
+    void setUp() {
+        repos.wqLinkRegister.save(TestEntityDataBuilder.getWQLinkRegisterEntity(8064716));
     }
 
     @Test


### PR DESCRIPTION
## What

Final PR to replace usages of `@Autowired` repositories in Integration tests with usages of the `Repositories` class accessable via `MockMvcIntegrationTest`.

e.g.
```
@Autowired
private RepOrderRepository repOrderRepository;
```
becomes
`repos.repOrder`

Continuation of: https://github.com/ministryofjustice/laa-maat-court-data-api/pull/990

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
