### PR TITLE
DCES-379 Change contribution_file services to return Integer (not Boolean)

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -53,9 +52,9 @@ public class ConcorContributionsRestController {
     @StandardApiResponse
     @PostMapping(value = "/create-contribution-file", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Creating a contribution file and updating the status to Sent in the concor contribution")
-    public ResponseEntity<Boolean> updateContributionFileStatus(@RequestBody @NotEmpty final CreateContributionFileRequest request) {
+    public ResponseEntity<Integer> updateContributionFileStatus(@RequestBody final CreateContributionFileRequest request) {
         log.info("Update concor contribution file references with request {}", request);
-        boolean response = concorContributionsService.createContributionAndUpdateConcorStatus(request);
+        var response = concorContributionsService.createContributionAndUpdateConcorStatus(request);
         return ResponseEntity.ok(response);
     }
 
@@ -63,9 +62,9 @@ public class ConcorContributionsRestController {
     @StandardApiResponse
     @PostMapping(value = "/log-contribution-response", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Logs that a contribution was processed by the Debt Recovery Company. Creates an error entry if one has been returned.")
-    public ResponseEntity<Boolean> logContributionProcessed(@RequestBody final LogContributionProcessedRequest request) {
+    public ResponseEntity<Integer> logContributionProcessed(@RequestBody final LogContributionProcessedRequest request) {
         log.info("Update contribution file sent value, and log any errors with request {}", request);
-        boolean response = concorContributionsService.logContributionProcessed(request);
+        var response = concorContributionsService.logContributionProcessed(request);
         return ResponseEntity.ok(response);
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/FdcContributionsController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/FdcContributionsController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -59,9 +58,9 @@ public class FdcContributionsController {
     @StandardApiResponse
     @PostMapping(value = "/create-fdc-file", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Creating a fdc file and updating the status to Sent in the fdc table")
-    public ResponseEntity<Boolean> updateContributionFileStatus(@RequestBody @NotEmpty final CreateFdcFileRequest request) {
+    public ResponseEntity<Integer> updateContributionFileStatus(@RequestBody final CreateFdcFileRequest request) {
         log.info("Update concor contribution file references with request {}", request);
-        boolean response = fdcContributionsService.createContributionFileAndUpdateFdcStatus(request);
+        var response = fdcContributionsService.createContributionFileAndUpdateFdcStatus(request);
         return ResponseEntity.ok(response);
     }
 
@@ -69,9 +68,9 @@ public class FdcContributionsController {
     @StandardApiResponse
     @PostMapping(value = "/log-fdc-response", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Logs that a final defence cost was processed by the Debt Recovery Company. Creates an error entry if one has been returned.")
-    public ResponseEntity<Boolean> logFdcProcessed(@RequestBody final LogFdcProcessedRequest request) {
+    public ResponseEntity<Integer> logFdcProcessed(@RequestBody final LogFdcProcessedRequest request) {
         log.info("Update contribution file sent value, and log any errors with request {}", request);
-        boolean response = fdcContributionsService.logFdcProcessed(request);
+        var response = fdcContributionsService.logFdcProcessed(request);
         return ResponseEntity.ok(response);
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
@@ -93,7 +93,7 @@ class ConcorContributionsRestControllerTest {
                 .xmlContent("XMLFileContent")
                 .concorContributionIds(Set.of())
                 .build();
-        when(concorContributionsService.createContributionAndUpdateConcorStatus(createContributionFileRequest)).thenReturn(true);
+        when(concorContributionsService.createContributionAndUpdateConcorStatus(createContributionFileRequest)).thenReturn(1111);
 
         final ObjectMapper objectMapper = new ObjectMapper();
         final String requestBody = objectMapper.writeValueAsString(createContributionFileRequest);
@@ -102,7 +102,7 @@ class ConcorContributionsRestControllerTest {
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").value("true"));
+                .andExpect(jsonPath("$").value("1111"));
     }
 
     @Test
@@ -154,12 +154,12 @@ class ConcorContributionsRestControllerTest {
                 .errorText(errorText)
                 .build();
         when(concorContributionsService.logContributionProcessed(request))
-                .thenReturn(true);
+                .thenReturn(1111);
         mvc.perform(MockMvcRequestBuilders.post(String.format(ENDPOINT_URL + DRC_UPDATE_URL))
                 .content(createDrcUpdateJson(id, errorText))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").value("true"));
+                .andExpect(jsonPath("$").value("1111"));
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ConcorContributionsRestControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ConcorContributionsRestControllerIntegrationTest.java
@@ -214,7 +214,7 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
 
-                .andExpect(status().isOk())
+                .andExpect(status().is4xxClientError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check no values in errors
         assertEquals(0, repos.contributionFileErrors.count());

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/FdcContributionsIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/FdcContributionsIntegrationTest.java
@@ -244,7 +244,7 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
 
-                .andExpect(status().isOk())
+                .andExpect(status().is4xxClientError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check no values in errors
         assertEquals(0, repos.contributionFileErrors.count());


### PR DESCRIPTION
## What

[DCES-379](https://dsdmoj.atlassian.net/browse/DCES-379) Change contribution_file services to return Integer (not Boolean)

- Clear up confusion of having both HTTP status error code and a Boolean response body which is only sent with HTTP status 200
- Return the contribution_file ID as it is useful information, right now primarily for testing, but maybe for other things in future and use HTTP status codes to report errors
- Update tests to reflect new return type

Needed to be able to write some of the tests like DCES-354 and DCES-357, etc.
See also ministryofjustice/laa-dces-drc-integration#46, this should be merged before that.
(Branch name was a typo -should say `379`).

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

[DCES-354]: https://dsdmoj.atlassian.net/browse/DCES-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DCES-379]: https://dsdmoj.atlassian.net/browse/DCES-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ