### PR TITLE
DCES-335 Add endpoints to get contribution_file and contribution_file_error entities by ID

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ContributionFileController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ContributionFileController.java
@@ -1,10 +1,20 @@
 package gov.uk.courtdata.dces.controller;
 
+import gov.uk.courtdata.annotation.NotFoundApiResponse;
+import gov.uk.courtdata.annotation.StandardApiResponse;
 import gov.uk.courtdata.dces.response.ContributionFileErrorResponse;
 import gov.uk.courtdata.dces.response.ContributionFileResponse;
 import gov.uk.courtdata.dces.service.ContributionFileService;
+import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,25 +24,42 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
+@Tag(name = "Debt Collection Enforcement", description = "Rest API for Debt Collection Enforcement Service")
 @RequestMapping("${api-endpoints.debt-collection-enforcement-domain}/contribution-file")
 @Slf4j
 @RequiredArgsConstructor
 public class ContributionFileController {
     private final ContributionFileService contributionFileService;
 
+    @Operation(description = "Retrieve a single contribution file by its unique ID")
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ContributionFileResponse.class)))
+    @StandardApiResponse
+    @NotFoundApiResponse
     @GetMapping("/{contributionFileId}")
     public ResponseEntity<ContributionFileResponse> getContributionFile(@PathVariable int contributionFileId) {
-        return ResponseEntity.of(contributionFileService.getContributionFile(contributionFileId));
+        return ResponseEntity.ok(contributionFileService.getContributionFile(contributionFileId).orElseThrow(
+                () -> new RequestedObjectNotFoundException("Contribution file not found"))); // to get ErrorDTO
     }
 
+    @Operation(description = "Retrieve the collection of contribution file errors by contribution file ID")
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+            array = @ArraySchema(schema = @Schema(implementation = ContributionFileErrorResponse.class))))
+    @StandardApiResponse
     @GetMapping("/{contributionFileId}/error")
     public ResponseEntity<List<ContributionFileErrorResponse>> getAllContributionFileError(@PathVariable int contributionFileId) {
         return ResponseEntity.ok(contributionFileService.getAllContributionFileError(contributionFileId));
     }
 
+    @Operation(description = "Retrieve a single contribution file error by its unique IDs")
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ContributionFileErrorResponse.class)))
+    @StandardApiResponse
+    @NotFoundApiResponse
     @GetMapping("/{contributionFileId}/error/{contributionId}")
     public ResponseEntity<ContributionFileErrorResponse> getContributionFileError(@PathVariable int contributionFileId,
                                                                                   @PathVariable int contributionId) {
-        return ResponseEntity.of(contributionFileService.getContributionFileError(contributionId, contributionFileId));
+        return ResponseEntity.ok(contributionFileService.getContributionFileError(contributionId, contributionFileId).orElseThrow(
+                () -> new RequestedObjectNotFoundException("Contribution file error not found"))); // to get ErrorDTO
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ContributionFileController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ContributionFileController.java
@@ -1,0 +1,38 @@
+package gov.uk.courtdata.dces.controller;
+
+import gov.uk.courtdata.dces.response.ContributionFileErrorResponse;
+import gov.uk.courtdata.dces.response.ContributionFileResponse;
+import gov.uk.courtdata.dces.service.ContributionFileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("${api-endpoints.debt-collection-enforcement-domain}/contribution-file")
+@Slf4j
+@RequiredArgsConstructor
+public class ContributionFileController {
+    private final ContributionFileService contributionFileService;
+
+    @GetMapping("/{contributionFileId}")
+    public ResponseEntity<ContributionFileResponse> getContributionFile(@PathVariable int contributionFileId) {
+        return ResponseEntity.of(contributionFileService.getContributionFile(contributionFileId));
+    }
+
+    @GetMapping("/{contributionFileId}/error")
+    public ResponseEntity<List<ContributionFileErrorResponse>> getAllContributionFileError(@PathVariable int contributionFileId) {
+        return ResponseEntity.ok(contributionFileService.getAllContributionFileError(contributionFileId));
+    }
+
+    @GetMapping("/{contributionFileId}/error/{contributionId}")
+    public ResponseEntity<ContributionFileErrorResponse> getContributionFileError(@PathVariable int contributionFileId,
+                                                                                  @PathVariable int contributionId) {
+        return ResponseEntity.of(contributionFileService.getContributionFileError(contributionId, contributionFileId));
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/mapper/ContributionFileMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/mapper/ContributionFileMapper.java
@@ -1,6 +1,9 @@
 package gov.uk.courtdata.dces.mapper;
 
 import gov.uk.courtdata.dces.request.CreateFileRequest;
+import gov.uk.courtdata.dces.response.ContributionFileErrorResponse;
+import gov.uk.courtdata.dces.response.ContributionFileResponse;
+import gov.uk.courtdata.entity.ContributionFileErrorsEntity;
 import gov.uk.courtdata.entity.ContributionFilesEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -14,4 +17,9 @@ public interface ContributionFileMapper {
     @Mapping(source = "xmlFileName", target = "fileName")
     ContributionFilesEntity toContributionFileEntity(CreateFileRequest dto);
 
+    @Mapping(target = "id", source = "fileId")
+    @Mapping(target = "xmlFileName", source = "fileName")
+    ContributionFileResponse toContributionFileResponse(ContributionFilesEntity contributionFilesEntity);
+
+    ContributionFileErrorResponse toContributionFileErrorResponse(ContributionFileErrorsEntity contributionFileErrorsEntity);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/response/ContributionFileErrorResponse.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/response/ContributionFileErrorResponse.java
@@ -1,0 +1,19 @@
+package gov.uk.courtdata.dces.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class ContributionFileErrorResponse {
+    private final Integer contributionFileId;
+    private final Integer contributionId;
+    private final Integer repId;
+    private final String errorText;
+    private final String fixAction;
+    private final Integer fdcContributionId;
+    private final Integer concorContributionId;
+    private final LocalDateTime dateCreated;
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/response/ContributionFileResponse.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/response/ContributionFileResponse.java
@@ -1,0 +1,23 @@
+package gov.uk.courtdata.dces.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class ContributionFileResponse {
+    private final Integer id;
+    private final String xmlFileName;
+    private final Integer recordsSent;
+    private final Integer recordsReceived;
+    private final LocalDate dateCreated;
+    private final String userCreated;
+    private final LocalDate dateModified;
+    private final String userModified;
+    private final String xmlContent;
+    private final LocalDate dateSent;
+    private final LocalDate dateReceived;
+    private final String ackXmlContent;
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ContributionFileService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ContributionFileService.java
@@ -1,0 +1,37 @@
+package gov.uk.courtdata.dces.service;
+
+import gov.uk.courtdata.dces.mapper.ContributionFileMapper;
+import gov.uk.courtdata.dces.response.ContributionFileErrorResponse;
+import gov.uk.courtdata.dces.response.ContributionFileResponse;
+import gov.uk.courtdata.model.id.ContributionFileErrorsId;
+import gov.uk.courtdata.repository.ContributionFileErrorsRepository;
+import gov.uk.courtdata.repository.ContributionFilesRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ContributionFileService {
+    private final ContributionFilesRepository contributionFileRepository;
+    private final ContributionFileErrorsRepository contributionFileErrorRepository;
+    private final ContributionFileMapper contributionFileMapper;
+
+    public Optional<ContributionFileResponse> getContributionFile(int contributionFileId) {
+        // TODO is it necessary to back-fill the xmlContent (problem with JPA and large text fields, but is it only on INSERT)?
+        return contributionFileRepository.findById(contributionFileId).map(contributionFileMapper::toContributionFileResponse);
+    }
+
+    public List<ContributionFileErrorResponse> getAllContributionFileError(int contributionFileId) {
+        return contributionFileErrorRepository.findByContributionFileId(contributionFileId).stream().map(contributionFileMapper::toContributionFileErrorResponse).toList();
+    }
+
+    public Optional<ContributionFileErrorResponse> getContributionFileError(int contributionId, int contributionFileId) {
+        var primaryKey = new ContributionFileErrorsId(contributionId, contributionFileId);
+        return contributionFileErrorRepository.findById(primaryKey).map(contributionFileMapper::toContributionFileErrorResponse);
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ContributionFileService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ContributionFileService.java
@@ -22,12 +22,12 @@ public class ContributionFileService {
     private final ContributionFileMapper contributionFileMapper;
 
     public Optional<ContributionFileResponse> getContributionFile(int contributionFileId) {
-        // TODO is it necessary to back-fill the xmlContent (problem with JPA and large text fields, but is it only on INSERT)?
         return contributionFileRepository.findById(contributionFileId).map(contributionFileMapper::toContributionFileResponse);
     }
 
     public List<ContributionFileErrorResponse> getAllContributionFileError(int contributionFileId) {
-        return contributionFileErrorRepository.findByContributionFileId(contributionFileId).stream().map(contributionFileMapper::toContributionFileErrorResponse).toList();
+        return contributionFileErrorRepository.findByContributionFileId(contributionFileId).stream()
+                .map(contributionFileMapper::toContributionFileErrorResponse).toList();
     }
 
     public Optional<ContributionFileErrorResponse> getContributionFileError(int contributionId, int contributionFileId) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ContributionFileErrorsRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ContributionFileErrorsRepository.java
@@ -5,7 +5,9 @@ import gov.uk.courtdata.model.id.ContributionFileErrorsId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ContributionFileErrorsRepository extends JpaRepository<ContributionFileErrorsEntity, ContributionFileErrorsId> {
-
+    List<ContributionFileErrorsEntity> findByContributionFileId(Integer contributionFileId);
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -589,9 +589,9 @@ public class TestEntityDataBuilder {
                 .build();
     }
 
-    public static ContributionFilesEntity getPopulatedContributionFilesEntity() {
+    public static ContributionFilesEntity getPopulatedContributionFilesEntity(Integer fileId) {
         return ContributionFilesEntity.builder()
-                .fileId(99)
+                .fileId(fileId)
                 .fileName("CONTRIBUTIONS_202405210958")
                 .recordsSent(53)
                 .recordsReceived(42)
@@ -606,10 +606,10 @@ public class TestEntityDataBuilder {
                 .build();
     }
 
-    public static ContributionFileErrorsEntity getContributionFileErrorsEntity() {
+    public static ContributionFileErrorsEntity getContributionFileErrorsEntity(int fileId, int contributionId) {
         return ContributionFileErrorsEntity.builder()
-                .contributionFileId(99)
-                .contributionId(888)
+                .contributionFileId(fileId)
+                .contributionId(contributionId)
                 .repId(REP_ID)
                 .errorText("error")
                 .fixAction("action")

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -613,8 +613,8 @@ public class TestEntityDataBuilder {
                 .repId(REP_ID)
                 .errorText("error")
                 .fixAction("action")
-                .fdcContributionId(66666)
-                .concorContributionId(555555)
+                .fdcContributionId(null)
+                .concorContributionId(contributionId)
                 .dateCreated(TEST_DATE)
                 .build();
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -589,6 +589,36 @@ public class TestEntityDataBuilder {
                 .build();
     }
 
+    public static ContributionFilesEntity getPopulatedContributionFilesEntity() {
+        return ContributionFilesEntity.builder()
+                .fileId(99)
+                .fileName("CONTRIBUTIONS_202405210958")
+                .recordsSent(53)
+                .recordsReceived(42)
+                .dateCreated(TEST_DATE.toLocalDate())
+                .userCreated(USER_CREATED_TEST_S)
+                .dateModified(TEST_DATE.toLocalDate().plusDays(3))
+                .userModified(TEST_USER)
+                .xmlContent("<xml>content</xml>")
+                .dateSent(TEST_DATE.toLocalDate().plusDays(1))
+                .dateReceived(TEST_DATE.toLocalDate().plusDays(2))
+                .ackXmlContent("<ackXml>content</ackXml>")
+                .build();
+    }
+
+    public static ContributionFileErrorsEntity getContributionFileErrorsEntity() {
+        return ContributionFileErrorsEntity.builder()
+                .contributionFileId(99)
+                .contributionId(888)
+                .repId(REP_ID)
+                .errorText("error")
+                .fixAction("action")
+                .fdcContributionId(66666)
+                .concorContributionId(555555)
+                .dateCreated(TEST_DATE)
+                .build();
+    }
+
     public static RepOrderCCOutComeEntity getRepOrderCCOutcomeEntity(Integer repOderOutComeId, RepOrderEntity repOrder) {
         return RepOrderCCOutComeEntity.builder()
                 .repOrder(repOrder)

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ContributionFileControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ContributionFileControllerTest.java
@@ -124,11 +124,11 @@ class ContributionFileControllerTest {
     void givenIncorrectParameters_whenGetContributionFileErrorInvoked_thenNotFound() throws Exception {
         final int incorrectFileId = 666;
         final int incorrectContributionId = 777;
-        when(contributionFileService.getContributionFileError(incorrectFileId, incorrectContributionId)).thenReturn(Optional.empty());
+        when(contributionFileService.getContributionFileError(incorrectContributionId, incorrectFileId)).thenReturn(Optional.empty());
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", incorrectFileId, incorrectContributionId))
                 .andExpect(status().isNotFound());
-        verify(contributionFileService).getContributionFileError(incorrectFileId, incorrectContributionId);
+        verify(contributionFileService).getContributionFileError(incorrectContributionId, incorrectFileId);
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ContributionFileControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ContributionFileControllerTest.java
@@ -18,8 +18,12 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ContributionFileController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -49,26 +53,27 @@ class ContributionFileControllerTest {
 
     @Test
     void givenIncorrectParameters_whenGetContributionFileInvoked_thenNotFound() throws Exception {
-        final int INCORRECT_FILE_ID = 666;
-        when(contributionFileService.getContributionFile(INCORRECT_FILE_ID)).thenReturn(Optional.empty());
+        final int incorrectFileId = 666;
+        when(contributionFileService.getContributionFile(incorrectFileId)).thenReturn(Optional.empty());
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", INCORRECT_FILE_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", incorrectFileId))
                 .andExpect(status().isNotFound());
-        verify(contributionFileService).getContributionFile(INCORRECT_FILE_ID);
+        verify(contributionFileService).getContributionFile(incorrectFileId);
     }
 
     @Test
     void givenInvalidParameters_whenGetContributionFileInvoked_thenBadRequest() throws Exception {
-        final String INVALID_FILE_ID = "crouton";
+        final String invalidFileId = "crouton";
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", INVALID_FILE_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", invalidFileId))
                 .andExpect(status().isBadRequest());
         verify(contributionFileService, never()).getContributionFile(anyInt());
     }
 
     @Test
     void givenCorrectParameters_whenGetAllContributionFileErrorInvoked_thenResponseIsReturned() throws Exception {
-        final int fileId = 99, contributionId = 888;
+        final int fileId = 99;
+        final int contributionId = 888;
         final var item = mapper.toContributionFileErrorResponse(TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId));
         when(contributionFileService.getAllContributionFileError(fileId)).thenReturn(List.of(item));
 
@@ -81,28 +86,29 @@ class ContributionFileControllerTest {
 
     @Test
     void givenIncorrectParameters_whenGetAllContributionFileErrorInvoked_thenResponseIsEmpty() throws Exception {
-        final int INCORRECT_FILE_ID = 666;
-        when(contributionFileService.getAllContributionFileError(INCORRECT_FILE_ID)).thenReturn(Collections.emptyList());
+        final int incorrectFileId = 666;
+        when(contributionFileService.getAllContributionFileError(incorrectFileId)).thenReturn(Collections.emptyList());
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", INCORRECT_FILE_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", incorrectFileId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.length()").value(0));
-        verify(contributionFileService).getAllContributionFileError(INCORRECT_FILE_ID);
+        verify(contributionFileService).getAllContributionFileError(incorrectFileId);
     }
 
     @Test
     void givenInvalidParameters_whenGetAllContributionFileInvoked_thenBadRequest() throws Exception {
-        final String INVALID_FILE_ID = "muffin";
+        final String invalidFiledId = "muffin";
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", INVALID_FILE_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", invalidFiledId))
                 .andExpect(status().isBadRequest());
         verify(contributionFileService, never()).getAllContributionFileError(anyInt());
     }
 
     @Test
     void givenCorrectParameters_whenGetContributionFileErrorInvoked_thenResponseIsReturned() throws Exception {
-        final int fileId = 99, contributionId = 888;
+        final int fileId = 99;
+        final int contributionId = 888;
         final var response = mapper.toContributionFileErrorResponse(TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId));
         when(contributionFileService.getContributionFileError(contributionId, fileId)).thenReturn(Optional.of(response));
 
@@ -116,19 +122,21 @@ class ContributionFileControllerTest {
 
     @Test
     void givenIncorrectParameters_whenGetContributionFileErrorInvoked_thenNotFound() throws Exception {
-        final int INCORRECT_FILE_ID = 666, INCORRECT_CONTRIBUTION_ID = 666;
-        when(contributionFileService.getContributionFileError(INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID)).thenReturn(Optional.empty());
+        final int incorrectFileId = 666;
+        final int incorrectContributionId = 777;
+        when(contributionFileService.getContributionFileError(incorrectFileId, incorrectContributionId)).thenReturn(Optional.empty());
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", incorrectFileId, incorrectContributionId))
                 .andExpect(status().isNotFound());
-        verify(contributionFileService).getContributionFileError(INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID);
+        verify(contributionFileService).getContributionFileError(incorrectFileId, incorrectContributionId);
     }
 
     @Test
     void givenInvalidParameters_whenGetContributionFileErrorInvoked_thenBadRequest() throws Exception {
-        final String INVALID_FILE_ID = "muffin", INVALID_CONTRIBUTION_ID = "crumpet";
+        final String invalidFiledId = "muffin";
+        final String invalidContributionId = "crumpet";
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", INVALID_FILE_ID, INVALID_CONTRIBUTION_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", invalidFiledId, invalidContributionId))
                 .andExpect(status().isBadRequest());
         verify(contributionFileService, never()).getContributionFileError(anyInt(), anyInt());
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ContributionFileControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ContributionFileControllerTest.java
@@ -1,0 +1,136 @@
+package gov.uk.courtdata.dces.controller;
+
+import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.dces.mapper.ContributionFileMapper;
+import gov.uk.courtdata.dces.mapper.ContributionFileMapperImpl;
+import gov.uk.courtdata.dces.service.ContributionFileService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ContributionFileController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ContributionFileControllerTest {
+    private static final String BASE_URL = "/api/internal/v1/debt-collection-enforcement/contribution-file";
+
+    private final ContributionFileMapper mapper = new ContributionFileMapperImpl();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ContributionFileService contributionFileService;
+
+    @Test
+    void givenCorrectParameters_whenGetContributionFileInvoked_thenResponseIsReturned() throws Exception {
+        final var response = mapper.toContributionFileResponse(TestEntityDataBuilder.getPopulatedContributionFilesEntity());
+        final int fileId = response.getId(); // test should fail if null
+        when(contributionFileService.getContributionFile(fileId)).thenReturn(Optional.of(response));
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + fileId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(fileId));
+        verify(contributionFileService).getContributionFile(fileId);
+    }
+
+    @Test
+    void givenIncorrectParameters_whenGetContributionFileInvoked_thenNotFound() throws Exception {
+        final int INCORRECT_ID = 666;
+        when(contributionFileService.getContributionFile(INCORRECT_ID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + INCORRECT_ID))
+                .andExpect(status().isNotFound());
+        verify(contributionFileService).getContributionFile(INCORRECT_ID);
+    }
+
+    @Test
+    void givenInvalidParameters_whenGetContributionFileInvoked_thenBadRequest() throws Exception {
+        final var INVALID_ID = "crouton";
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + INVALID_ID))
+                .andExpect(status().isBadRequest());
+        verify(contributionFileService, never()).getContributionFile(anyInt());
+    }
+
+    @Test
+    void givenCorrectParameters_whenGetAllContributionFileErrorInvoked_thenResponseIsReturned() throws Exception {
+        final var item = mapper.toContributionFileErrorResponse(TestEntityDataBuilder.getContributionFileErrorsEntity());
+        final int fileId = item.getContributionFileId(); // test should fail if null
+        when(contributionFileService.getAllContributionFileError(fileId)).thenReturn(List.of(item));
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + fileId + "/error"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(1));
+        verify(contributionFileService).getAllContributionFileError(fileId);
+    }
+
+    @Test
+    void givenIncorrectParameters_whenGetAllContributionFileErrorInvoked_thenResponseIsEmpty() throws Exception {
+        final int INCORRECT_ID = 666;
+        when(contributionFileService.getAllContributionFileError(INCORRECT_ID)).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + INCORRECT_ID + "/error"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(0));
+        verify(contributionFileService).getAllContributionFileError(INCORRECT_ID);
+    }
+
+    @Test
+    void givenInvalidParameters_whenGetAllContributionFileInvoked_thenBadRequest() throws Exception {
+        final var INVALID_ID = "muffin";
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + INVALID_ID + "/error"))
+                .andExpect(status().isBadRequest());
+        verify(contributionFileService, never()).getAllContributionFileError(anyInt());
+    }
+
+    @Test
+    void givenCorrectParameters_whenGetContributionFileErrorInvoked_thenResponseIsReturned() throws Exception {
+        final var response = mapper.toContributionFileErrorResponse(TestEntityDataBuilder.getContributionFileErrorsEntity());
+        final int fileId = response.getContributionFileId(); // test should fail if null
+        final int contId = response.getContributionId(); // test should fail if null
+        when(contributionFileService.getContributionFileError(contId, fileId)).thenReturn(Optional.of(response));
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + fileId + "/error/" + contId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.contributionFileId").value(fileId))
+                .andExpect(jsonPath("$.contributionId").value(contId));
+        verify(contributionFileService).getContributionFileError(contId, fileId);
+    }
+
+    @Test
+    void givenIncorrectParameters_whenGetContributionFileErrorInvoked_thenNotFound() throws Exception {
+        final int INCORRECT_ID = 666;
+        when(contributionFileService.getContributionFileError(INCORRECT_ID, INCORRECT_ID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + INCORRECT_ID + "/error/" + INCORRECT_ID))
+                .andExpect(status().isNotFound());
+        verify(contributionFileService).getContributionFileError(INCORRECT_ID, INCORRECT_ID);
+    }
+
+    @Test
+    void givenInvalidParameters_whenGetContributionFileErrorInvoked_thenBadRequest() throws Exception {
+        final var INVALID_ID = "crumpet";
+
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/" + INVALID_ID + "/error/" + INVALID_ID))
+                .andExpect(status().isBadRequest());
+        verify(contributionFileService, never()).getContributionFileError(anyInt(), anyInt());
+    }
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/mapper/ContributionFileMapperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/mapper/ContributionFileMapperTest.java
@@ -39,14 +39,14 @@ class ContributionFileMapperTest {
 
     @Test
     void testEntityToContributionFileResponse() {
-        var entity = TestEntityDataBuilder.getPopulatedContributionFilesEntity();
+        var entity = TestEntityDataBuilder.getPopulatedContributionFilesEntity(99);
         var mapped = mapper.toContributionFileResponse(entity);
         assertValidMappedObject(mapped, entity);
     }
 
     @Test
     void testEntityToContributionFileErrorResponse() {
-        var entity = TestEntityDataBuilder.getContributionFileErrorsEntity();
+        var entity = TestEntityDataBuilder.getContributionFileErrorsEntity(99, 888);
         var mapped = mapper.toContributionFileErrorResponse(entity);
         assertValidMappedObject(mapped, entity);
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/mapper/ContributionFileMapperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/mapper/ContributionFileMapperTest.java
@@ -1,18 +1,21 @@
 package gov.uk.courtdata.dces.mapper;
 
+import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.dces.request.CreateContributionFileRequest;
 import gov.uk.courtdata.dces.request.CreateFdcFileRequest;
 import gov.uk.courtdata.dces.request.CreateFileRequest;
+import gov.uk.courtdata.dces.response.ContributionFileErrorResponse;
+import gov.uk.courtdata.dces.response.ContributionFileResponse;
+import gov.uk.courtdata.entity.ContributionFileErrorsEntity;
 import gov.uk.courtdata.entity.ContributionFilesEntity;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Objects;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
 class ContributionFileMapperTest {
@@ -23,38 +26,76 @@ class ContributionFileMapperTest {
     void fdcMappingTest(){
         CreateFdcFileRequest request = createFdcRequest();
         ContributionFilesEntity mapped = mapper.toContributionFileEntity(request);
-        assertTrue(validateMappedObject(mapped, request),"Mapping the fdc request was incorrect.");
+        assertValidMappedObject(mapped, request);
     }
 
     @Test
     void contributionMappingTest(){
         CreateContributionFileRequest request = createContributionRequest();
         ContributionFilesEntity mapped = mapper.toContributionFileEntity(request);
-        assertTrue(validateMappedObject(mapped, request),"Mapping the fdc request was incorrect.");
+        assertValidMappedObject(mapped, request);
 
     }
 
-    private boolean validateMappedObject(ContributionFilesEntity mapped, CreateFileRequest request){
+    @Test
+    void testEntityToContributionFileResponse() {
+        var entity = TestEntityDataBuilder.getPopulatedContributionFilesEntity();
+        var mapped = mapper.toContributionFileResponse(entity);
+        assertValidMappedObject(mapped, entity);
+    }
+
+    @Test
+    void testEntityToContributionFileErrorResponse() {
+        var entity = TestEntityDataBuilder.getContributionFileErrorsEntity();
+        var mapped = mapper.toContributionFileErrorResponse(entity);
+        assertValidMappedObject(mapped, entity);
+    }
+
+    private static void assertValidMappedObject(ContributionFilesEntity mapped, CreateFileRequest request){
         assertEquals(request.getXmlContent(), mapped.getXmlContent());
         assertEquals(request.getAckXmlContent(), mapped.getAckXmlContent());
         assertEquals(request.getRecordsSent(), mapped.getRecordsSent());
         assertEquals(request.getXmlFileName(), mapped.getFileName());
         // validate non-map-related fields are unset. No stray mappings.
-        assertTrue(assertNonMappedAreNull(mapped.getFileId()));
-        assertTrue(assertNonMappedAreNull(mapped.getFileId()));
-        assertTrue(assertNonMappedAreNull(mapped.getDateReceived()));
-        assertTrue(assertNonMappedAreNull(mapped.getDateCreated()));
-        assertTrue(assertNonMappedAreNull(mapped.getDateModified()));
-        assertTrue(assertNonMappedAreNull(mapped.getUserModified()));
-        assertTrue(assertNonMappedAreNull(mapped.getDateSent()));
-        assertTrue(assertNonMappedAreNull(mapped.getDateReceived()));
+        assertNonMappedAreNull(mapped.getFileId());
+        assertNonMappedAreNull(mapped.getRecordsReceived());
+        assertNonMappedAreNull(mapped.getDateCreated());
+        assertNonMappedAreNull(mapped.getDateModified());
+        assertNonMappedAreNull(mapped.getUserModified());
+        assertNonMappedAreNull(mapped.getDateSent());
+        assertNonMappedAreNull(mapped.getDateReceived());
         // should have a default of DCES for the created.
         assertEquals("DCES", mapped.getUserCreated());
-        return true;
     }
 
-    private boolean assertNonMappedAreNull(Object o){
-        return Objects.isNull(o);
+    private static void assertNonMappedAreNull(Object fieldInMappedObject){
+        assertNull(fieldInMappedObject);
+    }
+
+    private static void assertValidMappedObject(ContributionFileResponse mapped, ContributionFilesEntity entity) {
+        assertEquals(entity.getFileId(), mapped.getId());
+        assertEquals(entity.getFileName(), mapped.getXmlFileName());
+        assertEquals(entity.getRecordsSent(), mapped.getRecordsSent());
+        assertEquals(entity.getRecordsReceived(), mapped.getRecordsReceived());
+        assertEquals(entity.getDateCreated(), mapped.getDateCreated());
+        assertEquals(entity.getUserCreated(), mapped.getUserCreated());
+        assertEquals(entity.getDateModified(), mapped.getDateModified());
+        assertEquals(entity.getUserModified(), mapped.getUserModified());
+        assertEquals(entity.getXmlContent(), mapped.getXmlContent());
+        assertEquals(entity.getDateSent(), mapped.getDateSent());
+        assertEquals(entity.getDateReceived(), mapped.getDateReceived());
+        assertEquals(entity.getAckXmlContent(), mapped.getAckXmlContent());
+    }
+
+    private static void assertValidMappedObject(ContributionFileErrorResponse mapped, ContributionFileErrorsEntity entity) {
+        assertEquals(entity.getContributionFileId(), mapped.getContributionFileId());
+        assertEquals(entity.getContributionId(), mapped.getContributionId());
+        assertEquals(entity.getRepId(), mapped.getRepId());
+        assertEquals(entity.getErrorText(), mapped.getErrorText());
+        assertEquals(entity.getFixAction(), mapped.getFixAction());
+        assertEquals(entity.getFdcContributionId(), mapped.getFdcContributionId());
+        assertEquals(entity.getConcorContributionId(), mapped.getConcorContributionId());
+        assertEquals(entity.getDateCreated(), mapped.getDateCreated());
     }
 
     private CreateContributionFileRequest createContributionRequest(){

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/mapper/ContributionFileMapperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/mapper/ContributionFileMapperTest.java
@@ -14,23 +14,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
 class ContributionFileMapperTest {
-
-    private static final ContributionFileMapper mapper = new ContributionFileMapperImpl();
+    private final ContributionFileMapper mapper = new ContributionFileMapperImpl();
 
     @Test
-    void fdcMappingTest(){
+    void fdcMappingTest() {
         CreateFdcFileRequest request = createFdcRequest();
         ContributionFilesEntity mapped = mapper.toContributionFileEntity(request);
         assertValidMappedObject(mapped, request);
     }
 
     @Test
-    void contributionMappingTest(){
+    void contributionMappingTest() {
         CreateContributionFileRequest request = createContributionRequest();
         ContributionFilesEntity mapped = mapper.toContributionFileEntity(request);
         assertValidMappedObject(mapped, request);
@@ -51,54 +51,57 @@ class ContributionFileMapperTest {
         assertValidMappedObject(mapped, entity);
     }
 
-    private static void assertValidMappedObject(ContributionFilesEntity mapped, CreateFileRequest request){
-        assertEquals(request.getXmlContent(), mapped.getXmlContent());
-        assertEquals(request.getAckXmlContent(), mapped.getAckXmlContent());
-        assertEquals(request.getRecordsSent(), mapped.getRecordsSent());
-        assertEquals(request.getXmlFileName(), mapped.getFileName());
-        // validate non-map-related fields are unset. No stray mappings.
-        assertNonMappedAreNull(mapped.getFileId());
-        assertNonMappedAreNull(mapped.getRecordsReceived());
-        assertNonMappedAreNull(mapped.getDateCreated());
-        assertNonMappedAreNull(mapped.getDateModified());
-        assertNonMappedAreNull(mapped.getUserModified());
-        assertNonMappedAreNull(mapped.getDateSent());
-        assertNonMappedAreNull(mapped.getDateReceived());
-        // should have a default of DCES for the created.
-        assertEquals("DCES", mapped.getUserCreated());
+    private static void assertValidMappedObject(ContributionFilesEntity mapped, CreateFileRequest request) {
+        assertAll(() -> assertEquals(request.getXmlContent(), mapped.getXmlContent()),
+                () -> assertEquals(request.getAckXmlContent(), mapped.getAckXmlContent()),
+                () -> assertEquals(request.getRecordsSent(), mapped.getRecordsSent()),
+                () -> assertEquals(request.getXmlFileName(), mapped.getFileName()),
+                // validate non-map-related fields are unset. No stray mappings
+                () -> assertNonMappedAreNull(mapped.getFileId()),
+                () -> assertNonMappedAreNull(mapped.getRecordsReceived()),
+                () -> assertNonMappedAreNull(mapped.getDateCreated()),
+                () -> assertNonMappedAreNull(mapped.getDateModified()),
+                () -> assertNonMappedAreNull(mapped.getUserModified()),
+                () -> assertNonMappedAreNull(mapped.getDateSent()),
+                () -> assertNonMappedAreNull(mapped.getDateReceived()),
+                // should have a default of DCES for the created
+                () -> assertEquals("DCES", mapped.getUserCreated())
+        );
     }
 
-    private static void assertNonMappedAreNull(Object fieldInMappedObject){
+    private static void assertNonMappedAreNull(Object fieldInMappedObject) {
         assertNull(fieldInMappedObject);
     }
 
     private static void assertValidMappedObject(ContributionFileResponse mapped, ContributionFilesEntity entity) {
-        assertEquals(entity.getFileId(), mapped.getId());
-        assertEquals(entity.getFileName(), mapped.getXmlFileName());
-        assertEquals(entity.getRecordsSent(), mapped.getRecordsSent());
-        assertEquals(entity.getRecordsReceived(), mapped.getRecordsReceived());
-        assertEquals(entity.getDateCreated(), mapped.getDateCreated());
-        assertEquals(entity.getUserCreated(), mapped.getUserCreated());
-        assertEquals(entity.getDateModified(), mapped.getDateModified());
-        assertEquals(entity.getUserModified(), mapped.getUserModified());
-        assertEquals(entity.getXmlContent(), mapped.getXmlContent());
-        assertEquals(entity.getDateSent(), mapped.getDateSent());
-        assertEquals(entity.getDateReceived(), mapped.getDateReceived());
-        assertEquals(entity.getAckXmlContent(), mapped.getAckXmlContent());
+        assertAll(() -> assertEquals(entity.getFileId(), mapped.getId()),
+                () -> assertEquals(entity.getFileName(), mapped.getXmlFileName()),
+                () -> assertEquals(entity.getRecordsSent(), mapped.getRecordsSent()),
+                () -> assertEquals(entity.getRecordsReceived(), mapped.getRecordsReceived()),
+                () -> assertEquals(entity.getDateCreated(), mapped.getDateCreated()),
+                () -> assertEquals(entity.getUserCreated(), mapped.getUserCreated()),
+                () -> assertEquals(entity.getDateModified(), mapped.getDateModified()),
+                () -> assertEquals(entity.getUserModified(), mapped.getUserModified()),
+                () -> assertEquals(entity.getXmlContent(), mapped.getXmlContent()),
+                () -> assertEquals(entity.getDateSent(), mapped.getDateSent()),
+                () -> assertEquals(entity.getDateReceived(), mapped.getDateReceived()),
+                () -> assertEquals(entity.getAckXmlContent(), mapped.getAckXmlContent())
+        );
     }
 
     private static void assertValidMappedObject(ContributionFileErrorResponse mapped, ContributionFileErrorsEntity entity) {
-        assertEquals(entity.getContributionFileId(), mapped.getContributionFileId());
-        assertEquals(entity.getContributionId(), mapped.getContributionId());
-        assertEquals(entity.getRepId(), mapped.getRepId());
-        assertEquals(entity.getErrorText(), mapped.getErrorText());
-        assertEquals(entity.getFixAction(), mapped.getFixAction());
-        assertEquals(entity.getFdcContributionId(), mapped.getFdcContributionId());
-        assertEquals(entity.getConcorContributionId(), mapped.getConcorContributionId());
-        assertEquals(entity.getDateCreated(), mapped.getDateCreated());
+        assertAll(() -> assertEquals(entity.getContributionFileId(), mapped.getContributionFileId()),
+                () -> assertEquals(entity.getContributionId(), mapped.getContributionId()),
+                () -> assertEquals(entity.getRepId(), mapped.getRepId()),
+                () -> assertEquals(entity.getErrorText(), mapped.getErrorText()),
+                () -> assertEquals(entity.getFixAction(), mapped.getFixAction()),
+                () -> assertEquals(entity.getFdcContributionId(), mapped.getFdcContributionId()),
+                () -> assertEquals(entity.getConcorContributionId(), mapped.getConcorContributionId()),
+                () -> assertEquals(entity.getDateCreated(), mapped.getDateCreated())
+        );
     }
 
-    private CreateContributionFileRequest createContributionRequest(){
+    private CreateContributionFileRequest createContributionRequest() {
         return CreateContributionFileRequest.builder()
                 .concorContributionIds(Set.of(1))
                 .xmlContent("<xml>content</xml>")
@@ -108,7 +111,7 @@ class ContributionFileMapperTest {
                 .build();
     }
 
-    private CreateFdcFileRequest createFdcRequest(){
+    private CreateFdcFileRequest createFdcRequest() {
         return CreateFdcFileRequest.builder()
                 .fdcIds(Set.of(1))
                 .xmlContent("<xml>content</xml>")
@@ -117,5 +120,4 @@ class ContributionFileMapperTest {
                 .xmlFileName("testFilename.xml")
                 .build();
     }
-
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ContributionFileServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ContributionFileServiceTest.java
@@ -1,0 +1,101 @@
+package gov.uk.courtdata.dces.service;
+
+import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.dces.mapper.ContributionFileMapper;
+import gov.uk.courtdata.dces.mapper.ContributionFileMapperImpl;
+import gov.uk.courtdata.model.id.ContributionFileErrorsId;
+import gov.uk.courtdata.repository.ContributionFileErrorsRepository;
+import gov.uk.courtdata.repository.ContributionFilesRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.CollectionAssert.assertThatCollection;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ContributionFileServiceTest {
+    @InjectMocks
+    private ContributionFileService contributionFileService;
+
+    @Mock
+    private ContributionFilesRepository contributionFileRepository;
+
+    @Mock
+    private ContributionFileErrorsRepository contributionFileErrorRepository;
+
+    @Spy // injected into contributionFileService
+    private ContributionFileMapper contributionFileMapper = new ContributionFileMapperImpl();
+
+    @Test
+    void givenCorrectArguments_whenGetContributionFileIsInvoked_thenReturnIsFound() {
+        final var entity = TestEntityDataBuilder.getPopulatedContributionFilesEntity();
+        final int fileId = entity.getFileId(); // test should fail if null
+        when(contributionFileRepository.findById(fileId)).thenReturn(Optional.of(entity));
+        final var optional = contributionFileService.getContributionFile(fileId);
+        verify(contributionFileRepository).findById(fileId);
+        assertThat(optional).isPresent();
+        assertThat(optional.orElseThrow().getId()).isEqualTo(fileId);
+    }
+
+    @Test
+    void givenIncorrectArguments_whenGetContributionFileIsInvoked_thenReturnIsEmpty() {
+        final int INCORRECT_ID = 666;
+        when(contributionFileRepository.findById(INCORRECT_ID)).thenReturn(Optional.empty());
+        final var optional = contributionFileService.getContributionFile(INCORRECT_ID);
+        verify(contributionFileRepository).findById(INCORRECT_ID);
+        assertThat(optional).isEmpty();
+    }
+
+    @Test
+    void givenCorrectArguments_whenGetAllContributionFileErrorIsInvoked_thenReturnIsFound() {
+        final var entity = TestEntityDataBuilder.getContributionFileErrorsEntity();
+        final int fileId = entity.getContributionFileId(); // test should fail if null
+        when(contributionFileErrorRepository.findByContributionFileId(fileId)).thenReturn(List.of(entity));
+        final var list = contributionFileService.getAllContributionFileError(fileId);
+        verify(contributionFileErrorRepository).findByContributionFileId(fileId);
+        assertThatCollection(list).isNotEmpty();
+        assertThat(list.get(0).getContributionFileId()).isEqualTo(fileId);
+    }
+
+    @Test
+    void givenIncorrectArguments_whenGetAllContributionFileErrorIsInvoked_thenReturnIsEmpty() {
+        final int INCORRECT_ID = 666;
+        when(contributionFileErrorRepository.findByContributionFileId(INCORRECT_ID)).thenReturn(Collections.emptyList());
+        final var list = contributionFileService.getAllContributionFileError(INCORRECT_ID);
+        verify(contributionFileErrorRepository).findByContributionFileId(INCORRECT_ID);
+        assertThatCollection(list).isEmpty();
+    }
+
+    @Test
+    void givenCorrectArguments_whenGetContributionFileErrorIsInvoked_thenReturnIsFound() {
+        final var entity = TestEntityDataBuilder.getContributionFileErrorsEntity();
+        final int fileId = entity.getContributionFileId(); // test should fail if null
+        final int contId = entity.getContributionId(); // test should fail if null
+        final var compositeId = new ContributionFileErrorsId(contId, fileId);
+        when(contributionFileErrorRepository.findById(eq(compositeId))).thenReturn(Optional.of(entity));
+        final var optional = contributionFileService.getContributionFileError(contId, fileId);
+        verify(contributionFileErrorRepository).findById(eq(compositeId));
+        assertThat(optional).isPresent();
+        assertThat(optional.orElseThrow().getContributionFileId()).isEqualTo(fileId);
+        assertThat(optional.orElseThrow().getContributionId()).isEqualTo(contId);
+    }
+
+    @Test
+    void givenIncorrectArguments_whenGetContributionFileErrorIsInvoked_thenReturnIsEmpty() {
+        final int INCORRECT_ID = 666;
+        final var compositeId = new ContributionFileErrorsId(INCORRECT_ID, INCORRECT_ID);
+        when(contributionFileErrorRepository.findById(eq(compositeId))).thenReturn(Optional.empty());
+        final var optional = contributionFileService.getContributionFileError(INCORRECT_ID, INCORRECT_ID);
+        verify(contributionFileErrorRepository).findById(eq(compositeId));
+        assertThat(optional).isEmpty();
+    }
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ContributionFileServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ContributionFileServiceTest.java
@@ -19,7 +19,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.CollectionAssert.assertThatCollection;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ContributionFileServiceTest {
@@ -40,6 +42,7 @@ class ContributionFileServiceTest {
         final int fileId = 99;
         final var entity = TestEntityDataBuilder.getPopulatedContributionFilesEntity(fileId);
         when(contributionFileRepository.findById(fileId)).thenReturn(Optional.of(entity));
+
         final var optional = contributionFileService.getContributionFile(fileId);
         verify(contributionFileRepository).findById(fileId);
         assertThat(optional).isPresent();
@@ -48,18 +51,21 @@ class ContributionFileServiceTest {
 
     @Test
     void givenIncorrectArguments_whenGetContributionFileIsInvoked_thenReturnIsEmpty() {
-        final int INCORRECT_FILE_ID = 666;
-        when(contributionFileRepository.findById(INCORRECT_FILE_ID)).thenReturn(Optional.empty());
-        final var optional = contributionFileService.getContributionFile(INCORRECT_FILE_ID);
-        verify(contributionFileRepository).findById(INCORRECT_FILE_ID);
+        final int incorrectFileId = 666;
+        when(contributionFileRepository.findById(incorrectFileId)).thenReturn(Optional.empty());
+
+        final var optional = contributionFileService.getContributionFile(incorrectFileId);
+        verify(contributionFileRepository).findById(incorrectFileId);
         assertThat(optional).isEmpty();
     }
 
     @Test
     void givenCorrectArguments_whenGetAllContributionFileErrorIsInvoked_thenReturnIsFound() {
-        final int fileId = 99, contributionId = 888;
+        final int fileId = 99;
+        final int contributionId = 888;
         final var entity = TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId);
         when(contributionFileErrorRepository.findByContributionFileId(fileId)).thenReturn(List.of(entity));
+
         final var list = contributionFileService.getAllContributionFileError(fileId);
         verify(contributionFileErrorRepository).findByContributionFileId(fileId);
         assertThatCollection(list).isNotEmpty();
@@ -68,19 +74,22 @@ class ContributionFileServiceTest {
 
     @Test
     void givenIncorrectArguments_whenGetAllContributionFileErrorIsInvoked_thenReturnIsEmpty() {
-        final int INCORRECT_FILE_ID = 666;
-        when(contributionFileErrorRepository.findByContributionFileId(INCORRECT_FILE_ID)).thenReturn(Collections.emptyList());
-        final var list = contributionFileService.getAllContributionFileError(INCORRECT_FILE_ID);
-        verify(contributionFileErrorRepository).findByContributionFileId(INCORRECT_FILE_ID);
+        final int incorrectFileId = 666;
+        when(contributionFileErrorRepository.findByContributionFileId(incorrectFileId)).thenReturn(Collections.emptyList());
+
+        final var list = contributionFileService.getAllContributionFileError(incorrectFileId);
+        verify(contributionFileErrorRepository).findByContributionFileId(incorrectFileId);
         assertThatCollection(list).isEmpty();
     }
 
     @Test
     void givenCorrectArguments_whenGetContributionFileErrorIsInvoked_thenReturnIsFound() {
-        final int fileId = 99, contributionId = 888;
+        final int fileId = 99;
+        final int contributionId = 888;
         final var entity = TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId);
         final var compositeId = new ContributionFileErrorsId(contributionId, fileId);
         when(contributionFileErrorRepository.findById(eq(compositeId))).thenReturn(Optional.of(entity));
+
         final var optional = contributionFileService.getContributionFileError(contributionId, fileId);
         verify(contributionFileErrorRepository).findById(eq(compositeId));
         assertThat(optional).isPresent();
@@ -90,10 +99,12 @@ class ContributionFileServiceTest {
 
     @Test
     void givenIncorrectArguments_whenGetContributionFileErrorIsInvoked_thenReturnIsEmpty() {
-        final int INCORRECT_FILE_ID = 666, INCORRECT_CONTRIBUTION_ID = 666;
-        final var compositeId = new ContributionFileErrorsId(INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID);
+        final int incorrectFileId = 666;
+        final int incorrectContribtutionId = 666;
+        final var compositeId = new ContributionFileErrorsId(incorrectFileId, incorrectContribtutionId);
         when(contributionFileErrorRepository.findById(eq(compositeId))).thenReturn(Optional.empty());
-        final var optional = contributionFileService.getContributionFileError(INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID);
+
+        final var optional = contributionFileService.getContributionFileError(incorrectFileId, incorrectContribtutionId);
         verify(contributionFileErrorRepository).findById(eq(compositeId));
         assertThat(optional).isEmpty();
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ContributionFileServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ContributionFileServiceTest.java
@@ -33,12 +33,12 @@ class ContributionFileServiceTest {
     private ContributionFileErrorsRepository contributionFileErrorRepository;
 
     @Spy // injected into contributionFileService
-    private ContributionFileMapper contributionFileMapper = new ContributionFileMapperImpl();
+    private ContributionFileMapper mapper = new ContributionFileMapperImpl();
 
     @Test
     void givenCorrectArguments_whenGetContributionFileIsInvoked_thenReturnIsFound() {
-        final var entity = TestEntityDataBuilder.getPopulatedContributionFilesEntity();
-        final int fileId = entity.getFileId(); // test should fail if null
+        final int fileId = 99;
+        final var entity = TestEntityDataBuilder.getPopulatedContributionFilesEntity(fileId);
         when(contributionFileRepository.findById(fileId)).thenReturn(Optional.of(entity));
         final var optional = contributionFileService.getContributionFile(fileId);
         verify(contributionFileRepository).findById(fileId);
@@ -48,17 +48,17 @@ class ContributionFileServiceTest {
 
     @Test
     void givenIncorrectArguments_whenGetContributionFileIsInvoked_thenReturnIsEmpty() {
-        final int INCORRECT_ID = 666;
-        when(contributionFileRepository.findById(INCORRECT_ID)).thenReturn(Optional.empty());
-        final var optional = contributionFileService.getContributionFile(INCORRECT_ID);
-        verify(contributionFileRepository).findById(INCORRECT_ID);
+        final int INCORRECT_FILE_ID = 666;
+        when(contributionFileRepository.findById(INCORRECT_FILE_ID)).thenReturn(Optional.empty());
+        final var optional = contributionFileService.getContributionFile(INCORRECT_FILE_ID);
+        verify(contributionFileRepository).findById(INCORRECT_FILE_ID);
         assertThat(optional).isEmpty();
     }
 
     @Test
     void givenCorrectArguments_whenGetAllContributionFileErrorIsInvoked_thenReturnIsFound() {
-        final var entity = TestEntityDataBuilder.getContributionFileErrorsEntity();
-        final int fileId = entity.getContributionFileId(); // test should fail if null
+        final int fileId = 99, contributionId = 888;
+        final var entity = TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId);
         when(contributionFileErrorRepository.findByContributionFileId(fileId)).thenReturn(List.of(entity));
         final var list = contributionFileService.getAllContributionFileError(fileId);
         verify(contributionFileErrorRepository).findByContributionFileId(fileId);
@@ -68,33 +68,32 @@ class ContributionFileServiceTest {
 
     @Test
     void givenIncorrectArguments_whenGetAllContributionFileErrorIsInvoked_thenReturnIsEmpty() {
-        final int INCORRECT_ID = 666;
-        when(contributionFileErrorRepository.findByContributionFileId(INCORRECT_ID)).thenReturn(Collections.emptyList());
-        final var list = contributionFileService.getAllContributionFileError(INCORRECT_ID);
-        verify(contributionFileErrorRepository).findByContributionFileId(INCORRECT_ID);
+        final int INCORRECT_FILE_ID = 666;
+        when(contributionFileErrorRepository.findByContributionFileId(INCORRECT_FILE_ID)).thenReturn(Collections.emptyList());
+        final var list = contributionFileService.getAllContributionFileError(INCORRECT_FILE_ID);
+        verify(contributionFileErrorRepository).findByContributionFileId(INCORRECT_FILE_ID);
         assertThatCollection(list).isEmpty();
     }
 
     @Test
     void givenCorrectArguments_whenGetContributionFileErrorIsInvoked_thenReturnIsFound() {
-        final var entity = TestEntityDataBuilder.getContributionFileErrorsEntity();
-        final int fileId = entity.getContributionFileId(); // test should fail if null
-        final int contId = entity.getContributionId(); // test should fail if null
-        final var compositeId = new ContributionFileErrorsId(contId, fileId);
+        final int fileId = 99, contributionId = 888;
+        final var entity = TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId);
+        final var compositeId = new ContributionFileErrorsId(contributionId, fileId);
         when(contributionFileErrorRepository.findById(eq(compositeId))).thenReturn(Optional.of(entity));
-        final var optional = contributionFileService.getContributionFileError(contId, fileId);
+        final var optional = contributionFileService.getContributionFileError(contributionId, fileId);
         verify(contributionFileErrorRepository).findById(eq(compositeId));
         assertThat(optional).isPresent();
         assertThat(optional.orElseThrow().getContributionFileId()).isEqualTo(fileId);
-        assertThat(optional.orElseThrow().getContributionId()).isEqualTo(contId);
+        assertThat(optional.orElseThrow().getContributionId()).isEqualTo(contributionId);
     }
 
     @Test
     void givenIncorrectArguments_whenGetContributionFileErrorIsInvoked_thenReturnIsEmpty() {
-        final int INCORRECT_ID = 666;
-        final var compositeId = new ContributionFileErrorsId(INCORRECT_ID, INCORRECT_ID);
+        final int INCORRECT_FILE_ID = 666, INCORRECT_CONTRIBUTION_ID = 666;
+        final var compositeId = new ContributionFileErrorsId(INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID);
         when(contributionFileErrorRepository.findById(eq(compositeId))).thenReturn(Optional.empty());
-        final var optional = contributionFileService.getContributionFileError(INCORRECT_ID, INCORRECT_ID);
+        final var optional = contributionFileService.getContributionFileError(INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID);
         verify(contributionFileErrorRepository).findById(eq(compositeId));
         assertThat(optional).isEmpty();
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ContributionFileControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ContributionFileControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package gov.uk.courtdata.integration.dces;
 
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.entity.ConcorContributionsEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,8 +11,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import static gov.uk.courtdata.enums.ConcorContributionStatus.SENT;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class ContributionFileControllerIntegrationTest extends MockMvcIntegrationTest {
@@ -29,17 +30,9 @@ public class ContributionFileControllerIntegrationTest extends MockMvcIntegratio
                 TestEntityDataBuilder.getPopulatedContributionFilesEntity(null));
         this.fileId = contributionFile.getFileId();
 
-        var correspondence = TestEntityDataBuilder.getCorrespondenceEntity(1);
-        correspondence.setRepId(repId);
-        correspondence = repos.correspondence.saveAndFlush(correspondence);
-        final int correspondenceId = correspondence.getId();
-
-        var contribution = TestEntityDataBuilder.getContributionsEntity();
-        contribution.setCorrespondenceId(correspondenceId);
-        contribution.setContributionFileId(fileId);
-        contribution.setRepOrder(repOrder);
-        contribution = repos.contributions.saveAndFlush(contribution);
-        this.contributionId = contribution.getId();
+        final var concorContribution = ConcorContributionsEntity.builder().repId(repId).contribFileId(fileId).status(SENT).build();
+        repos.concorContributions.saveAndFlush(concorContribution);
+        this.contributionId = concorContribution.getId();
 
         repos.contributionFileErrors.saveAndFlush(
                 TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId));

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ContributionFileControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ContributionFileControllerIntegrationTest.java
@@ -12,7 +12,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static gov.uk.courtdata.enums.ConcorContributionStatus.SENT;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class ContributionFileControllerIntegrationTest extends MockMvcIntegrationTest {
@@ -54,17 +56,17 @@ public class ContributionFileControllerIntegrationTest extends MockMvcIntegratio
 
     @Test
     void givenIncorrectParameters_whenGetContributionFileInvoked_thenNotFound() throws Exception {
-        final int INCORRECT_FILE_ID = fileId + 666;
+        final int incorrectFileId = fileId + 666;
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", INCORRECT_FILE_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", incorrectFileId))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void givenInvalidParameters_whenGetContributionFileInvoked_thenBadRequest() throws Exception {
-        final String INVALID_FILE_ID = "crouton";
+        final String invalidFileId = "crouton";
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", INVALID_FILE_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", invalidFileId))
                 .andExpect(status().isBadRequest());
     }
 
@@ -78,9 +80,9 @@ public class ContributionFileControllerIntegrationTest extends MockMvcIntegratio
 
     @Test
     void givenIncorrectParameters_whenGetAllContributionFileErrorInvoked_thenResponseIsEmpty() throws Exception {
-        final int INCORRECT_FILE_ID = fileId + 666;
+        final int incorrectFileId = fileId + 666;
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", INCORRECT_FILE_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", incorrectFileId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.length()").value(0));
@@ -88,9 +90,9 @@ public class ContributionFileControllerIntegrationTest extends MockMvcIntegratio
 
     @Test
     void givenInvalidParameters_whenGetAllContributionFileInvoked_thenBadRequest() throws Exception {
-        final String INVALID_FILE_ID = "muffin";
+        final String invalidFileId = "muffin";
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", INVALID_FILE_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", invalidFileId))
                 .andExpect(status().isBadRequest());
     }
 
@@ -105,17 +107,19 @@ public class ContributionFileControllerIntegrationTest extends MockMvcIntegratio
 
     @Test
     void givenIncorrectParameters_whenGetContributionFileErrorInvoked_thenNotFound() throws Exception {
-        final int INCORRECT_FILE_ID = fileId + 666, INCORRECT_CONTRIBUTION_ID = contributionId + 666;
+        final int incorrectFileId = fileId + 666;
+        final int incorrectContributionId = contributionId + 666;
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", incorrectFileId, incorrectContributionId))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void givenInvalidParameters_whenGetContributionFileErrorInvoked_thenBadRequest() throws Exception {
-        final String INVALID_FILE_ID = "muffin", INVALID_CONTRIBUTION_ID = "crumpet";
+        final String invalidFileId = "muffin";
+        final String invalidContributionId = "crumpet";
 
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", INVALID_FILE_ID, INVALID_CONTRIBUTION_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", invalidFileId, invalidContributionId))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ContributionFileControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ContributionFileControllerIntegrationTest.java
@@ -1,60 +1,70 @@
-package gov.uk.courtdata.dces.controller;
+package gov.uk.courtdata.integration.dces;
 
+import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
-import gov.uk.courtdata.dces.mapper.ContributionFileMapper;
-import gov.uk.courtdata.dces.mapper.ContributionFileMapperImpl;
-import gov.uk.courtdata.dces.service.ContributionFileService;
+import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(ContributionFileController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class ContributionFileControllerTest {
+@SpringBootTest(classes = {MAATCourtDataApplication.class})
+public class ContributionFileControllerIntegrationTest extends MockMvcIntegrationTest {
     private static final String BASE_URL = "/api/internal/v1/debt-collection-enforcement/contribution-file";
 
-    private final ContributionFileMapper mapper = new ContributionFileMapperImpl();
+    private Integer fileId;
+    private Integer contributionId;
 
-    @Autowired
-    private MockMvc mockMvc;
+    @BeforeEach
+    public void setUp() {
+        final var repOrder = repos.repOrder.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
+        final int repId = repOrder.getId();
 
-    @MockBean
-    private ContributionFileService contributionFileService;
+        final var contributionFile = repos.contributionFiles.saveAndFlush(
+                TestEntityDataBuilder.getPopulatedContributionFilesEntity(null));
+        this.fileId = contributionFile.getFileId();
+
+        var correspondence = TestEntityDataBuilder.getCorrespondenceEntity(1);
+        correspondence.setRepId(repId);
+        correspondence = repos.correspondence.saveAndFlush(correspondence);
+        final int correspondenceId = correspondence.getId();
+
+        var contribution = TestEntityDataBuilder.getContributionsEntity();
+        contribution.setCorrespondenceId(correspondenceId);
+        contribution.setContributionFileId(fileId);
+        contribution.setRepOrder(repOrder);
+        contribution = repos.contributions.saveAndFlush(contribution);
+        this.contributionId = contribution.getId();
+
+        repos.contributionFileErrors.saveAndFlush(
+                TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId));
+    }
+
+    @AfterEach
+    public void clearUp() {
+        this.fileId = null;
+        this.contributionId = null;
+    }
 
     @Test
     void givenCorrectParameters_whenGetContributionFileInvoked_thenResponseIsReturned() throws Exception {
-        final int fileId = 99;
-        final var response = mapper.toContributionFileResponse(TestEntityDataBuilder.getPopulatedContributionFilesEntity(fileId));
-        when(contributionFileService.getContributionFile(fileId)).thenReturn(Optional.of(response));
-
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", fileId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").value(fileId));
-        verify(contributionFileService).getContributionFile(fileId);
     }
 
     @Test
     void givenIncorrectParameters_whenGetContributionFileInvoked_thenNotFound() throws Exception {
-        final int INCORRECT_FILE_ID = 666;
-        when(contributionFileService.getContributionFile(INCORRECT_FILE_ID)).thenReturn(Optional.empty());
+        final int INCORRECT_FILE_ID = fileId + 666;
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", INCORRECT_FILE_ID))
                 .andExpect(status().isNotFound());
-        verify(contributionFileService).getContributionFile(INCORRECT_FILE_ID);
     }
 
     @Test
@@ -63,32 +73,24 @@ class ContributionFileControllerTest {
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}", INVALID_FILE_ID))
                 .andExpect(status().isBadRequest());
-        verify(contributionFileService, never()).getContributionFile(anyInt());
     }
 
     @Test
     void givenCorrectParameters_whenGetAllContributionFileErrorInvoked_thenResponseIsReturned() throws Exception {
-        final int fileId = 99, contributionId = 888;
-        final var item = mapper.toContributionFileErrorResponse(TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId));
-        when(contributionFileService.getAllContributionFileError(fileId)).thenReturn(List.of(item));
-
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", fileId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.length()").value(1));
-        verify(contributionFileService).getAllContributionFileError(fileId);
     }
 
     @Test
     void givenIncorrectParameters_whenGetAllContributionFileErrorInvoked_thenResponseIsEmpty() throws Exception {
-        final int INCORRECT_FILE_ID = 666;
-        when(contributionFileService.getAllContributionFileError(INCORRECT_FILE_ID)).thenReturn(Collections.emptyList());
+        final int INCORRECT_FILE_ID = fileId + 666;
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", INCORRECT_FILE_ID))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.length()").value(0));
-        verify(contributionFileService).getAllContributionFileError(INCORRECT_FILE_ID);
     }
 
     @Test
@@ -97,31 +99,23 @@ class ContributionFileControllerTest {
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error", INVALID_FILE_ID))
                 .andExpect(status().isBadRequest());
-        verify(contributionFileService, never()).getAllContributionFileError(anyInt());
     }
 
     @Test
     void givenCorrectParameters_whenGetContributionFileErrorInvoked_thenResponseIsReturned() throws Exception {
-        final int fileId = 99, contributionId = 888;
-        final var response = mapper.toContributionFileErrorResponse(TestEntityDataBuilder.getContributionFileErrorsEntity(fileId, contributionId));
-        when(contributionFileService.getContributionFileError(contributionId, fileId)).thenReturn(Optional.of(response));
-
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", fileId, contributionId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.contributionFileId").value(fileId))
                 .andExpect(jsonPath("$.contributionId").value(contributionId));
-        verify(contributionFileService).getContributionFileError(contributionId, fileId);
     }
 
     @Test
     void givenIncorrectParameters_whenGetContributionFileErrorInvoked_thenNotFound() throws Exception {
-        final int INCORRECT_FILE_ID = 666, INCORRECT_CONTRIBUTION_ID = 666;
-        when(contributionFileService.getContributionFileError(INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID)).thenReturn(Optional.empty());
+        final int INCORRECT_FILE_ID = fileId + 666, INCORRECT_CONTRIBUTION_ID = contributionId + 666;
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID))
                 .andExpect(status().isNotFound());
-        verify(contributionFileService).getContributionFileError(INCORRECT_FILE_ID, INCORRECT_CONTRIBUTION_ID);
     }
 
     @Test
@@ -130,6 +124,5 @@ class ContributionFileControllerTest {
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{fileId}/error/{contributionId}", INVALID_FILE_ID, INVALID_CONTRIBUTION_ID))
                 .andExpect(status().isBadRequest());
-        verify(contributionFileService, never()).getContributionFileError(anyInt(), anyInt());
     }
 }


### PR DESCRIPTION
## What

* [DCES-335](https://dsdmoj.atlassian.net/browse/DCES-335) Add endpoints to get contribution_file and contribution_file_error entities by ID
  - Add REST controller and simple service for DCES endpoints
  - Add DTO (`-Response`) classes for the endpoints (which currently mirror the entities)
  - Extend the contribution_file_error repository to allow getting all errors for a file

* DCES-335 Add unit tests for contribution_file endpoints
  - Add test entity creation to the `TestEntityDataBuilder` class used by tests
  - Add `MockMvc` based `@SpringBootTest` to test the controller
  - Add Mockito based vanilla unit test for the service class and changes to the mapper

* DCES-335 Add Swagger annotations to document controller endpoints
  - Add `@Tag`, `@Operation`, `@ApiResponse` annotations to document REST services
  - Change `ResponseEntity.of(Optional)` to `ResponseEntity.ok()` with `orElseThrow()` and `RequestedObjectNotFoundException` so that the Advice class is involved in a status 404 response and the response body matches the `@NotFoundApiResponse` Swagger documentation.

* DCES-335 Add integration tests for contribution file endpoints
  - Update `TestEntityDataBuilder` so ids are parameters (can be null for CF).
  - Update existing code that consumes CF and CFE methods in `TestEntityDataBuilder`
  - Update existing controller and service unit test to use parameterized paths (controller) and separate variables for `fileId` and `contributionId` (controller and service)
  - Add the integration test itself with test double database setup method

* DCES-335 Make integration test reflect actual DB schema usage
  - Fix usage of `contribution_file_errors.contr_id` (which is not a fk to `contributions` table) but to one of the `concor_contributions` or `fdc_contributions` tables (depending on other fields)

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[DCES-335]: https://dsdmoj.atlassian.net/browse/DCES-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ