### PR TITLE
DCES-368 Endpoint for Rep Order Candidates for Fdc Delayed Pickup and Fdc Fast Track

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -238,7 +238,7 @@ public class RepOrderController {
                                                                  @RequestParam(value = "numRecords") int numRecords,
                                                                  @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
     {
-        log.info("Get Rep Orders Ids For Fdc Fast-Track Received");
+        log.info("Get Rep Order Ids For Fdc Fast-Track Received");
         Set<Integer> repIdList = repOrderService.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
         return ResponseEntity.ok(repIdList);
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -213,8 +213,8 @@ public class RepOrderController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping(value = "/eligibleForFdcDelayedPickup", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(description = "Retrieve a set of rep order records that have passed the Final Defence Cost delay period")
+    @GetMapping(value = "/eligible-for-fdc-delayed-pickup", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(description = "Retrieve a set of rep order ids that have passed the Final Defence Cost delay period")
     @ApiResponse(responseCode = "200",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
     )
@@ -228,8 +228,8 @@ public class RepOrderController {
         return ResponseEntity.ok(repIdList);
     }
 
-    @GetMapping(value = "/eligibleForFdcFastTracking", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(description = "Retrieve a set of rep order records eligible for Final Defence Cost Fast-Tracking")
+    @GetMapping(value = "/eligible-for-fdc-fast-tracking", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(description = "Retrieve a set of rep order ids eligible for Final Defence Cost Fast-Tracking")
     @ApiResponse(responseCode = "200",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
     )

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -236,11 +236,10 @@ public class RepOrderController {
     @StandardApiResponse
     public ResponseEntity<Object> findEligibleForFdcFastTracking(@RequestParam(value = "delay") int delayPeriod,
                                                                  @RequestParam(value = "numRecords") int numRecords,
-                                                                 @RequestParam(value = "startingMonth") int startingMonth,
                                                                  @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
     {
         log.info("Get Rep Orders For Fdc Fast-Track Received");
-        List<Integer> repIdList = repOrderService.findEligibleForFdcFastTracking(delayPeriod, dateReceived, startingMonth, numRecords);
+        List<Integer> repIdList = repOrderService.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
         return ResponseEntity.ok(repIdList);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -219,12 +219,12 @@ public class RepOrderController {
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
     )
     @StandardApiResponse
-    public ResponseEntity<Object> findEligibleForFdcDelayedPickup(@RequestParam(value = "delay") int delayPeriod,
+    public ResponseEntity<Set<Integer>> findEligibleForFdcDelayedPickup(@RequestParam(value = "delay") int delayPeriod,
                                                              @RequestParam(value = "numRecords") int numRecords,
                                                              @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
     {
         log.info("Get Rep Orders For Fdc Delay Received");
-        List<Integer> repIdList = repOrderService.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
+        Set<Integer> repIdList = repOrderService.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
         return ResponseEntity.ok(repIdList);
     }
 
@@ -234,12 +234,12 @@ public class RepOrderController {
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
     )
     @StandardApiResponse
-    public ResponseEntity<Object> findEligibleForFdcFastTracking(@RequestParam(value = "delay") int delayPeriod,
+    public ResponseEntity<Set<Integer>> findEligibleForFdcFastTracking(@RequestParam(value = "delay") int delayPeriod,
                                                                  @RequestParam(value = "numRecords") int numRecords,
                                                                  @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
     {
         log.info("Get Rep Orders For Fdc Fast-Track Received");
-        List<Integer> repIdList = repOrderService.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
+        Set<Integer> repIdList = repOrderService.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
         return ResponseEntity.ok(repIdList);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -223,7 +223,7 @@ public class RepOrderController {
                                                              @RequestParam(value = "numRecords") int numRecords,
                                                              @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
     {
-        log.info("Get Rep Orders For Fdc Delay Received");
+        log.info("Get Rep Order Ids For Fdc Delay Received");
         Set<Integer> repIdList = repOrderService.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
         return ResponseEntity.ok(repIdList);
     }
@@ -238,7 +238,7 @@ public class RepOrderController {
                                                                  @RequestParam(value = "numRecords") int numRecords,
                                                                  @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
     {
-        log.info("Get Rep Orders For Fdc Fast-Track Received");
+        log.info("Get Rep Orders Ids For Fdc Fast-Track Received");
         Set<Integer> repIdList = repOrderService.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
         return ResponseEntity.ok(repIdList);
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -213,30 +213,30 @@ public class RepOrderController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping(value = "/eligible-for-fdc-delayed-pickup", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, params = {"fdcDelayedPickup=true"})
     @Operation(description = "Retrieve a set of rep order ids that have passed the Final Defence Cost delay period")
     @ApiResponse(responseCode = "200",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
     )
     @StandardApiResponse
-    public ResponseEntity<Set<Integer>> findEligibleForFdcDelayedPickup(@RequestParam(value = "delay") int delayPeriod,
-                                                             @RequestParam(value = "numRecords") int numRecords,
-                                                             @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
+    public ResponseEntity<Set<Integer>> findEligibleForFdcDelayedPickup(@Valid @RequestParam(value = "delay") int delayPeriod,
+                                                                        @Valid @RequestParam(value = "numRecords") int numRecords,
+                                                                        @Valid @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
     {
         log.info("Get Rep Order Ids For Fdc Delay Received");
         Set<Integer> repIdList = repOrderService.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
         return ResponseEntity.ok(repIdList);
     }
 
-    @GetMapping(value = "/eligible-for-fdc-fast-tracking", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, params = {"fdcFastTrack=true"})
     @Operation(description = "Retrieve a set of rep order ids eligible for Final Defence Cost Fast-Tracking")
     @ApiResponse(responseCode = "200",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
     )
     @StandardApiResponse
-    public ResponseEntity<Set<Integer>> findEligibleForFdcFastTracking(@RequestParam(value = "delay") int delayPeriod,
-                                                                 @RequestParam(value = "numRecords") int numRecords,
-                                                                 @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
+    public ResponseEntity<Set<Integer>> findEligibleForFdcFastTracking(@Valid @RequestParam(value = "delay") int delayPeriod,
+                                                                       @Valid @RequestParam(value = "numRecords") int numRecords,
+                                                                       @Valid @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
     {
         log.info("Get Rep Order Ids For Fdc Fast-Track Received");
         Set<Integer> repIdList = repOrderService.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -209,5 +211,36 @@ public class RepOrderController {
         log.info("Partial Update of Rep Order Request Received");
     repOrderService.update(repId, updatedFields);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = "/eligibleForFdcDelayedPickup", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(description = "Retrieve a set of rep order records that have passed the Final Defence Cost delay period")
+    @ApiResponse(responseCode = "200",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+    )
+    @StandardApiResponse
+    public ResponseEntity<Object> findEligibleForFdcDelayedPickup(@RequestParam(value = "delay") int delayPeriod,
+                                                             @RequestParam(value = "numRecords") int numRecords,
+                                                             @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
+    {
+        log.info("Get Rep Orders For Fdc Delay Received");
+        List<Integer> repIdList = repOrderService.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
+        return ResponseEntity.ok(repIdList);
+    }
+
+    @GetMapping(value = "/eligibleForFdcFastTracking", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(description = "Retrieve a set of rep order records eligible for Final Defence Cost Fast-Tracking")
+    @ApiResponse(responseCode = "200",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+    )
+    @StandardApiResponse
+    public ResponseEntity<Object> findEligibleForFdcFastTracking(@RequestParam(value = "delay") int delayPeriod,
+                                                                 @RequestParam(value = "numRecords") int numRecords,
+                                                                 @RequestParam(value = "startingMonth") int startingMonth,
+                                                                 @RequestParam(value = "dateReceived")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateReceived)
+    {
+        log.info("Get Rep Orders For Fdc Fast-Track Received");
+        List<Integer> repIdList = repOrderService.findEligibleForFdcFastTracking(delayPeriod, dateReceived, startingMonth, numRecords);
+        return ResponseEntity.ok(repIdList);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/impl/RepOrderImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/impl/RepOrderImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Set;
 
 import static gov.uk.courtdata.reporder.specification.RepOrderSpecification.hasId;
 import static gov.uk.courtdata.reporder.specification.RepOrderSpecification.hasSentenceOrderDate;
@@ -50,11 +50,11 @@ public class RepOrderImpl {
         repOrderRepository.deleteById(repId);
     }
 
-    public List<Integer> findEligibleForFdcDelayedPickup(int delayPeriod, LocalDate dateReceived, int numRecords){
+    public Set<Integer> findEligibleForFdcDelayedPickup(int delayPeriod, LocalDate dateReceived, int numRecords){
         return repOrderRepository.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
     }
 
-    public List<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int numRecords){
+    public Set<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int numRecords){
         return repOrderRepository.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/impl/RepOrderImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/impl/RepOrderImpl.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static gov.uk.courtdata.reporder.specification.RepOrderSpecification.hasId;
 import static gov.uk.courtdata.reporder.specification.RepOrderSpecification.hasSentenceOrderDate;
@@ -46,5 +48,13 @@ public class RepOrderImpl {
 
     public void delete(Integer repId) {
         repOrderRepository.deleteById(repId);
+    }
+
+    public List<Integer> findEligibleForFdcDelayedPickup(int delayPeriod, LocalDate dateReceived, int numRecords){
+        return repOrderRepository.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
+    }
+
+    public List<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int startingMonth, int numRecords){
+        return repOrderRepository.findEligibleForFdcFastTracking(delayPeriod, dateReceived, startingMonth, numRecords);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/impl/RepOrderImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/impl/RepOrderImpl.java
@@ -54,7 +54,7 @@ public class RepOrderImpl {
         return repOrderRepository.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
     }
 
-    public List<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int startingMonth, int numRecords){
-        return repOrderRepository.findEligibleForFdcFastTracking(delayPeriod, dateReceived, startingMonth, numRecords);
+    public List<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int numRecords){
+        return repOrderRepository.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
@@ -12,6 +12,7 @@ import gov.uk.courtdata.reporder.mapper.RepOrderMapper;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -118,5 +119,13 @@ public class RepOrderService {
         }
 
         return repOrderMapper.createIOJAssessorDetails(repOrderOptional.get());
+    }
+
+    public List<Integer> findEligibleForFdcDelayedPickup(int delayPeriod, LocalDate dateReceived, int numRecords){
+        return repOrderImpl.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
+    }
+
+    public List<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int startingMonth, int numRecords){
+        return repOrderImpl.findEligibleForFdcFastTracking(delayPeriod, dateReceived, startingMonth, numRecords);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
@@ -125,7 +125,7 @@ public class RepOrderService {
         return repOrderImpl.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
     }
 
-    public List<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int startingMonth, int numRecords){
-        return repOrderImpl.findEligibleForFdcFastTracking(delayPeriod, dateReceived, startingMonth, numRecords);
+    public List<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int numRecords){
+        return repOrderImpl.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
@@ -12,9 +12,10 @@ import gov.uk.courtdata.reporder.mapper.RepOrderMapper;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -121,11 +122,11 @@ public class RepOrderService {
         return repOrderMapper.createIOJAssessorDetails(repOrderOptional.get());
     }
 
-    public List<Integer> findEligibleForFdcDelayedPickup(int delayPeriod, LocalDate dateReceived, int numRecords){
+    public Set<Integer> findEligibleForFdcDelayedPickup(int delayPeriod, LocalDate dateReceived, int numRecords){
         return repOrderImpl.findEligibleForFdcDelayedPickup(delayPeriod, dateReceived, numRecords);
     }
 
-    public List<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int numRecords){
+    public Set<Integer> findEligibleForFdcFastTracking(int delayPeriod, LocalDate dateReceived, int numRecords){
         return repOrderImpl.findEligibleForFdcFastTracking(delayPeriod, dateReceived, numRecords);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
@@ -18,8 +18,8 @@ public interface RepOrderRepository extends JpaRepository<RepOrderEntity, Intege
     @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND TRUNC( ADD_MONTHS( NVL(RO.SENTENCE_ORDER_DATE, SYSDATE ), :delayPeriod) ) <= TRUNC(SYSDATE) AND RO.DATE_RECEIVED< :dateReceived ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
     List<Integer> findEligibleForFdcDelayedPickup(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
 
-    @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND RO.DATE_RECEIVED > :dateReceived AND NVL(RO.SENTENCE_ORDER_DATE,ADD_MONTHS(TRUNC(SYSDATE),:startingMonth)) < ADD_MONTHS(TRUNC(SYSDATE),:delayPeriod) ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
-    List<Integer> findEligibleForFdcFastTracking(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("startingMonth") int startingMonth, @Param("numRecords") int numRecords);
+    @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND RO.DATE_RECEIVED > :dateReceived AND RO.SENTENCE_ORDER_DATE < ADD_MONTHS(TRUNC(SYSDATE),:delayPeriod) ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
+    List<Integer> findEligibleForFdcFastTracking(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
 
 }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
@@ -3,13 +3,23 @@ package gov.uk.courtdata.repository;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 
 @Repository
 public interface RepOrderRepository extends JpaRepository<RepOrderEntity, Integer>, JpaSpecificationExecutor<RepOrderEntity> {
     List<RepOrderEntity> findByUsn(Integer usn);
+
+    @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND TRUNC( ADD_MONTHS( NVL(RO.SENTENCE_ORDER_DATE, SYSDATE ), :delayPeriod) ) <= TRUNC(SYSDATE) AND RO.DATE_RECEIVED< :dateReceived ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
+    List<Integer> findEligibleForFdcDelayedPickup(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
+
+    @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND RO.DATE_RECEIVED > :dateReceived AND NVL(RO.SENTENCE_ORDER_DATE,ADD_MONTHS(TRUNC(SYSDATE),:startingMonth)) < ADD_MONTHS(TRUNC(SYSDATE),:delayPeriod) ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
+    List<Integer> findEligibleForFdcFastTracking(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("startingMonth") int startingMonth, @Param("numRecords") int numRecords);
+
 }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
@@ -16,10 +16,45 @@ import java.util.Set;
 public interface RepOrderRepository extends JpaRepository<RepOrderEntity, Integer>, JpaSpecificationExecutor<RepOrderEntity> {
     List<RepOrderEntity> findByUsn(Integer usn);
 
-    @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND TRUNC( ADD_MONTHS( NVL(RO.SENTENCE_ORDER_DATE, SYSDATE ), :delayPeriod) ) <= TRUNC(SYSDATE) AND RO.DATE_RECEIVED< :dateReceived ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
+    @Query(value = """
+                        SELECT *
+                        FROM (
+                            SELECT DISTINCT RO.ID
+                            FROM
+                                TOGDATA.CONCOR_CONTRIBUTIONS CC,
+                                TOGDATA.REP_ORDERS RO,
+                                TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO
+                            WHERE
+                                CC.REP_ID = RO.ID
+                                AND RO.ID = ROCCO.REP_ID
+                                AND CC.STATUS = 'SENT'
+                                AND ROCCO.CCOO_OUTCOME IS NOT NULL
+                                AND RO.SENTENCE_ORDER_DATE IS NOT NULL
+                                AND TRUNC( ADD_MONTHS( NVL(RO.SENTENCE_ORDER_DATE, SYSDATE ), :delayPeriod) ) <= TRUNC(SYSDATE)
+                                AND RO.DATE_RECEIVED< :dateReceived
+                            )
+                        WHERE ROWNUM <= :numRecords
+                        """, nativeQuery = true)
     Set<Integer> findEligibleForFdcDelayedPickup(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
 
-    @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND RO.DATE_RECEIVED > :dateReceived AND RO.SENTENCE_ORDER_DATE < ADD_MONTHS(TRUNC(SYSDATE),:delayPeriod) ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
+    @Query(value = """
+                        SELECT *
+                        FROM (
+                            SELECT DISTINCT RO.ID
+                            FROM
+                                TOGDATA.CONCOR_CONTRIBUTIONS CC,
+                                TOGDATA.REP_ORDERS RO,
+                                TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO
+                            WHERE
+                                CC.REP_ID = RO.ID
+                                AND RO.ID = ROCCO.REP_ID
+                                AND CC.STATUS = 'SENT'
+                                AND ROCCO.CCOO_OUTCOME IS NOT NULL
+                                AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND RO.DATE_RECEIVED > :dateReceived
+                                AND RO.SENTENCE_ORDER_DATE < ADD_MONTHS(TRUNC(SYSDATE),:delayPeriod)
+                            )
+                        WHERE ROWNUM <= :numRecords
+                        """, nativeQuery = true)
     Set<Integer> findEligibleForFdcFastTracking(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
 
 @Repository
@@ -16,10 +17,10 @@ public interface RepOrderRepository extends JpaRepository<RepOrderEntity, Intege
     List<RepOrderEntity> findByUsn(Integer usn);
 
     @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND TRUNC( ADD_MONTHS( NVL(RO.SENTENCE_ORDER_DATE, SYSDATE ), :delayPeriod) ) <= TRUNC(SYSDATE) AND RO.DATE_RECEIVED< :dateReceived ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
-    List<Integer> findEligibleForFdcDelayedPickup(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
+    Set<Integer> findEligibleForFdcDelayedPickup(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
 
     @Query(value = "SELECT * FROM ( SELECT DISTINCT RO.ID FROM TOGDATA.CONCOR_CONTRIBUTIONS CC, TOGDATA.REP_ORDERS RO, TOGDATA.REP_ORDER_CROWN_COURT_OUTCOMES ROCCO WHERE CC.REP_ID = RO.ID AND RO.ID = ROCCO.REP_ID AND CC.STATUS = 'SENT' AND ROCCO.CCOO_OUTCOME IS NOT NULL AND RO.SENTENCE_ORDER_DATE IS NOT NULL AND RO.DATE_RECEIVED > :dateReceived AND RO.SENTENCE_ORDER_DATE < ADD_MONTHS(TRUNC(SYSDATE),:delayPeriod) ) WHERE ROWNUM <= :numRecords", nativeQuery = true)
-    List<Integer> findEligibleForFdcFastTracking(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
+    Set<Integer> findEligibleForFdcFastTracking(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
 
 }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -66,6 +66,21 @@ public class TestEntityDataBuilder {
                 .build();
     }
 
+    public static RepOrderEntity getPopulatedRepOrder(LocalDate sentenceOrderDate, LocalDate dateReceived) {
+        return RepOrderEntity.builder()
+                .catyCaseType("case-type")
+                .magsOutcome("outcome")
+                .magsOutcomeDate(TEST_DATE.toString())
+                .magsOutcomeDateSet(TEST_DATE)
+                .committalDate(TEST_DATE.toLocalDate())
+                .decisionReasonCode("rder-code")
+                .crownRepOrderDecision("cc-rep-doc")
+                .crownRepOrderType("cc-rep-type")
+                .sentenceOrderDate(sentenceOrderDate)
+                .dateReceived(dateReceived)
+                .build();
+    }
+
     public static ApplicantDisabilitiesEntity getApplicantDisabilitiesEntity() {
         return ApplicantDisabilitiesEntity.builder()
                 .applId(5136528)
@@ -589,6 +604,15 @@ public class TestEntityDataBuilder {
                 .build();
     }
 
+    public static ConcorContributionsEntity getConcorContributionsEntity(Integer repId, ConcorContributionStatus status){
+        return ConcorContributionsEntity.builder()
+                .status(status)
+                .repId(repId)
+                .dateCreated(TEST_DATE.toLocalDate())
+                .userCreated(TEST_USER)
+                .build();
+    }
+
     public static RepOrderCCOutComeEntity getRepOrderCCOutcomeEntity(Integer repOderOutComeId, RepOrderEntity repOrder) {
         return RepOrderCCOutComeEntity.builder()
                 .repOrder(repOrder)
@@ -598,6 +622,17 @@ public class TestEntityDataBuilder {
                 .crownCourtCode("430")
                 .outcomeDate(TEST_DATE)
                 .id(repOderOutComeId)
+                .build();
+    }
+
+    public static RepOrderCCOutComeEntity getRepOrderCCOutcomeEntity(RepOrderEntity repOrder, String outcome){
+        return RepOrderCCOutComeEntity.builder()
+                .repOrder(repOrder)
+                .outcome(outcome)
+                .userCreated(TEST_USER)
+                .caseNumber(TEST_CASE_ID.toString())
+                .crownCourtCode("430")
+                .outcomeDate(TEST_DATE)
                 .build();
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
@@ -54,8 +54,8 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     public static final String SLASH = "/";
     private static final String MVO_REG_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo-reg";
     private static final String MVO_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo";
-    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-delayed-pickup?delay={delay}&dateReceived={dateReceived}&numRecords={numRecords}";
-    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-fast-tracking?delay={delay}&dateReceived={dateReceived}&numRecords={numRecords}";
+    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders?fdcDelayedPickup=true&delay={delay}&dateReceived={dateReceived}&numRecords={numRecords}";
+    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders?fdcFastTrack=true&delay={delay}&dateReceived={dateReceived}&numRecords={numRecords}";
     private static final String CURRENT_REGISTRATION = "current-registration";
     private static final String VEHICLE_OWNER_INDICATOR_YES = "Y";
     private RepOrderEntity repOrderValid;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
@@ -348,7 +348,7 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenTooLargeAsk_whenFdcFastTrackCalled_thenAllAvailableValidRepOrdersReturned() throws Exception {
         setUpFdcMinDelayAppliesEntities();
-        mockMvc.perform(MockMvcRequestBuilders.get(buildFdcFastTrackEndpointURL(5, 0, LocalDate.now(), 5))
+        mockMvc.perform(MockMvcRequestBuilders.get(buildFdcFastTrackEndpointURL(5, LocalDate.now(), 5))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -359,7 +359,7 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenSingleAsk_whenFdcFastTrackCalled_thenOnlyOneValidRepOrdersReturned() throws Exception {
         setUpFdcMinDelayAppliesEntities();
-        mockMvc.perform(MockMvcRequestBuilders.get(buildFdcFastTrackEndpointURL(5, 0,LocalDate.now(), 1))
+        mockMvc.perform(MockMvcRequestBuilders.get(buildFdcFastTrackEndpointURL(5, LocalDate.now(), 1))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -373,10 +373,10 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
         return FDC_DELAYED_ENDPOINT_URL +parameterString;
     }
 
-    private String buildFdcFastTrackEndpointURL(int delayPeriod, int startingMonth, LocalDate dateReceived, int numRecords){
+    private String buildFdcFastTrackEndpointURL(int delayPeriod, LocalDate dateReceived, int numRecords){
         //delay=5&dateReceived=01.10.2010&numRecords=5&startingMonth=0
         String date = dateReceived.format(DateTimeFormatter.ISO_DATE);
-        String parameterString = "?delay=%s&dateReceived=%s&numRecords=%s&startingMonth=%s".formatted(delayPeriod, date, numRecords, startingMonth);
+        String parameterString = "?delay=%s&dateReceived=%s&numRecords=%s".formatted(delayPeriod, date, numRecords);
         return FDC_FAST_TRACK_ENDPOINT_URL +parameterString;
     }
     private void setUpFdcMinDelayAppliesEntities() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
@@ -54,8 +54,8 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     public static final String SLASH = "/";
     private static final String MVO_REG_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo-reg";
     private static final String MVO_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo";
-    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-delayed-pickup";
-    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-fast-tracking";
+    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-delayed-pickup?delay={delay}&dateReceived={dateReceived}&numRecords={numRecords}";
+    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-fast-tracking?delay={delay}&dateReceived={dateReceived}&numRecords={numRecords}";
     private static final String CURRENT_REGISTRATION = "current-registration";
     private static final String VEHICLE_OWNER_INDICATOR_YES = "Y";
     private RepOrderEntity repOrderValid;
@@ -324,9 +324,7 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenTooLargeAsk_whenFdcDelayedCalled_thenAllAvailableValidRepOrdersReturned() throws Exception {
         setUpFdcMinDelayAppliesEntities();
-
-
-        mockMvc.perform(MockMvcRequestBuilders.get(buildFdcDelayedEndpointURL(5,LocalDate.now(), 5))
+        mockMvc.perform(MockMvcRequestBuilders.get(FDC_DELAYED_ENDPOINT_URL,5, LocalDate.now(), 5)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -337,7 +335,7 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenSingleAsk_whenFdcDelayedCalled_thenOnlyOneValidRepOrdersReturned() throws Exception {
         setUpFdcMinDelayAppliesEntities();
-        mockMvc.perform(MockMvcRequestBuilders.get(buildFdcDelayedEndpointURL(5,LocalDate.now(), 1))
+        mockMvc.perform(MockMvcRequestBuilders.get(FDC_DELAYED_ENDPOINT_URL,5, LocalDate.now(), 1)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -348,7 +346,7 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenTooLargeAsk_whenFdcFastTrackCalled_thenAllAvailableValidRepOrdersReturned() throws Exception {
         setUpFdcMinDelayAppliesEntities();
-        mockMvc.perform(MockMvcRequestBuilders.get(buildFdcFastTrackEndpointURL(5, LocalDate.now(), 5))
+        mockMvc.perform(MockMvcRequestBuilders.get(FDC_FAST_TRACK_ENDPOINT_URL,5, LocalDate.now(), 5)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -359,26 +357,14 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenSingleAsk_whenFdcFastTrackCalled_thenOnlyOneValidRepOrdersReturned() throws Exception {
         setUpFdcMinDelayAppliesEntities();
-        mockMvc.perform(MockMvcRequestBuilders.get(buildFdcFastTrackEndpointURL(5, LocalDate.now(), 1))
+        mockMvc.perform(MockMvcRequestBuilders.get(FDC_FAST_TRACK_ENDPOINT_URL,5, LocalDate.now(), 1)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$", Matchers.containsInAnyOrder(repOrderFuture.getId())));
     }
-    private String buildFdcDelayedEndpointURL(int delayPeriod, LocalDate dateReceived, int numRecords){
-        //delay=5&dateReceived=01.10.2010&numRecords=5
-        String date = dateReceived.format(DateTimeFormatter.ISO_DATE);
-        String parameterString = "?delay=%s&dateReceived=%s&numRecords=%s".formatted(delayPeriod, date, numRecords);
-        return FDC_DELAYED_ENDPOINT_URL +parameterString;
-    }
 
-    private String buildFdcFastTrackEndpointURL(int delayPeriod, LocalDate dateReceived, int numRecords){
-        //delay=5&dateReceived=01.10.2010&numRecords=5&startingMonth=0
-        String date = dateReceived.format(DateTimeFormatter.ISO_DATE);
-        String parameterString = "?delay=%s&dateReceived=%s&numRecords=%s".formatted(delayPeriod, date, numRecords);
-        return FDC_FAST_TRACK_ENDPOINT_URL +parameterString;
-    }
     private void setUpFdcMinDelayAppliesEntities() {
         LocalDate dateJan2010 = LocalDate.of(2010,1,1);
         LocalDate dateFuture = LocalDate.now().plus(1, ChronoUnit.MONTHS);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
@@ -54,8 +54,8 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
     public static final String SLASH = "/";
     private static final String MVO_REG_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo-reg";
     private static final String MVO_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo";
-    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligibleForFdcDelayedPickup";
-    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligibleForFdcFastTracking";
+    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-delayed-pickup";
+    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-fast-tracking";
     private static final String CURRENT_REGISTRATION = "current-registration";
     private static final String VEHICLE_OWNER_INDICATOR_YES = "Y";
     private RepOrderEntity repOrderValid;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
@@ -344,7 +344,7 @@ class RepOrderControllerTest {
 
     @Test
     void givenValidParameters_whenFindFdcFastTrackingInvoked_thenIdsAreReturned() throws Exception {
-        List<Integer> expectedIds = List.of(5,6);
+        Set<Integer> expectedIds = Set.of(5,6);
         LocalDate date = LocalDate.now();
         when(repOrderService.findEligibleForFdcFastTracking(5, date, 2)).thenReturn(expectedIds);
         mvc.perform(MockMvcRequestBuilders.get(FDC_FAST_TRACK_ENDPOINT_URL)
@@ -391,7 +391,7 @@ class RepOrderControllerTest {
 
     @Test
     void givenValidParameters_whenFindFdcDelayedPickupInvoked_thenIdsAreReturned() throws Exception {
-        List<Integer> expectedIds = List.of(5,6);
+        Set<Integer> expectedIds = Set.of(5,6);
         LocalDate date = LocalDate.now();
         when(repOrderService.findEligibleForFdcDelayedPickup(5, date, 2)).thenReturn(expectedIds);
         mvc.perform(MockMvcRequestBuilders.get(FDC_DELAYED_ENDPOINT_URL)

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
@@ -44,8 +44,8 @@ class RepOrderControllerTest {
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders";
     private static final String MVO_REG_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo-reg";
     private static final String MVO_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo";
-    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligibleForFdcDelayedPickup";
-    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligibleForFdcFastTracking";
+    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-delayed-pickup";
+    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-fast-tracking";
     private static final String VEHICLE_OWNER_INDICATOR_YES = "Y";
     private static final String CURRENT_REGISTRATION = "current-registration";
     private static final Integer USN = 12345;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
@@ -44,8 +44,6 @@ class RepOrderControllerTest {
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders";
     private static final String MVO_REG_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo-reg";
     private static final String MVO_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/rep-order-mvo";
-    private static final String FDC_DELAYED_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-delayed-pickup";
-    private static final String FDC_FAST_TRACK_ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/eligible-for-fdc-fast-tracking";
     private static final String VEHICLE_OWNER_INDICATOR_YES = "Y";
     private static final String CURRENT_REGISTRATION = "current-registration";
     private static final Integer USN = 12345;
@@ -347,7 +345,8 @@ class RepOrderControllerTest {
         Set<Integer> expectedIds = Set.of(5,6);
         LocalDate date = LocalDate.now();
         when(repOrderService.findEligibleForFdcFastTracking(5, date, 2)).thenReturn(expectedIds);
-        mvc.perform(MockMvcRequestBuilders.get(FDC_FAST_TRACK_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL)
+                        .param("fdcFastTrack", "true")
                         .param("delay", "5")
                         .param("dateReceived", date.format(DateTimeFormatter.ISO_DATE))
                         .param("numRecords", "2")
@@ -361,7 +360,8 @@ class RepOrderControllerTest {
     @Test
     void givenInvalidParameters_whenFindFdcFastTrackingInvoked_thenErrorIsReturned() throws Exception {
         LocalDate date = LocalDate.now();
-        mvc.perform(MockMvcRequestBuilders.get(FDC_FAST_TRACK_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL)
+                        .param("fdcFastTrack", "true")
                         .param("dateReceived", date.format(DateTimeFormatter.ISO_DATE))
                         .param("numRecords", "2")
                 )
@@ -370,7 +370,8 @@ class RepOrderControllerTest {
                 .andExpect(jsonPath("detail").value("Required parameter 'delay' is not present."))
                 .andExpect(jsonPath("title").value("Bad Request"));
 
-        mvc.perform(MockMvcRequestBuilders.get(FDC_FAST_TRACK_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL)
+                        .param("fdcFastTrack", "true")
                         .param("delay", "5")
                         .param("numRecords", "2")
                 )
@@ -379,7 +380,8 @@ class RepOrderControllerTest {
                 .andExpect(jsonPath("detail").value("Required parameter 'dateReceived' is not present."))
                 .andExpect(jsonPath("title").value("Bad Request"));
 
-        mvc.perform(MockMvcRequestBuilders.get(FDC_FAST_TRACK_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL)
+                        .param("fdcFastTrack", "true")
                         .param("delay", "5")
                         .param("dateReceived", date.format(DateTimeFormatter.ISO_DATE))
                 )
@@ -394,7 +396,8 @@ class RepOrderControllerTest {
         Set<Integer> expectedIds = Set.of(5,6);
         LocalDate date = LocalDate.now();
         when(repOrderService.findEligibleForFdcDelayedPickup(5, date, 2)).thenReturn(expectedIds);
-        mvc.perform(MockMvcRequestBuilders.get(FDC_DELAYED_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL)
+                        .param("fdcDelayedPickup", "true")
                         .param("delay", "5")
                         .param("dateReceived", date.format(DateTimeFormatter.ISO_DATE))
                         .param("numRecords", "2")
@@ -408,7 +411,8 @@ class RepOrderControllerTest {
     @Test
     void givenInvalidParameters_whenFindFdcDelayedPickupInvoked_thenErrorIsReturned() throws Exception {
         LocalDate date = LocalDate.now();
-        mvc.perform(MockMvcRequestBuilders.get(FDC_DELAYED_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL)
+                        .param("fdcDelayedPickup", "true")
                         .param("dateReceived", date.format(DateTimeFormatter.ISO_DATE))
                         .param("numRecords", "2")
                 )
@@ -417,7 +421,8 @@ class RepOrderControllerTest {
                 .andExpect(jsonPath("detail").value("Required parameter 'delay' is not present."))
                 .andExpect(jsonPath("title").value("Bad Request"));
 
-        mvc.perform(MockMvcRequestBuilders.get(FDC_DELAYED_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL)
+                        .param("fdcDelayedPickup", "true")
                         .param("delay", "5")
                         .param("numRecords", "2")
                 )
@@ -426,7 +431,8 @@ class RepOrderControllerTest {
                 .andExpect(jsonPath("detail").value("Required parameter 'dateReceived' is not present."))
                 .andExpect(jsonPath("title").value("Bad Request"));
 
-        mvc.perform(MockMvcRequestBuilders.get(FDC_DELAYED_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL)
+                        .param("fdcDelayedPickup", "true")
                         .param("delay", "5")
                         .param("dateReceived", date.format(DateTimeFormatter.ISO_DATE))
                 )

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/impl/RepOrderImplTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/impl/RepOrderImplTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -52,5 +53,19 @@ class RepOrderImplTest {
     void givenAValidRepId_whenCountByIdAndSentenceOrderDateIsNotNullInvoked_thenRepOrderCountIsRetrieved() {
         repOrderImpl.countWithSentenceOrderDate(TestModelDataBuilder.REP_ID);
         verify(repOrderRepository).count(ArgumentMatchers.<Specification<RepOrderEntity>>any());
+    }
+
+    @Test
+    void givenValidValues_whenFindingForFdcFastTracking_thenInvokesRepository() {
+        LocalDate date = LocalDate.now();
+        repOrderImpl.findEligibleForFdcFastTracking(5, LocalDate.now(), 5);
+        verify(repOrderRepository).findEligibleForFdcFastTracking(5, date, 5);
+    }
+
+    @Test
+    void givenValidValues_whenFindingForFdcDelayedPickup_thenInvokesRepository() {
+        LocalDate date = LocalDate.now();
+        repOrderImpl.findEligibleForFdcDelayedPickup(5, LocalDate.now(), 5);
+        verify(repOrderRepository).findEligibleForFdcDelayedPickup(5, date, 5);
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderServiceTest.java
@@ -19,8 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -92,14 +92,14 @@ class RepOrderServiceTest {
 
     @Test
     void givenAllInputs_whenFdcFastTrackingIsInvoked_thenReturnList() {
-        List<Integer> idList = List.of(5,6);
+        Set<Integer> idList = Set.of(5,6);
         when(repOrderImpl.findEligibleForFdcFastTracking(anyInt(), any(), anyInt()))
                 .thenReturn(idList);
         assertThat(repOrderService.findEligibleForFdcFastTracking(5, LocalDate.now(), 5)).isEqualTo(idList);
     }
     @Test
     void givenAllInputs_whenFdcDelayedPickupIsInvoked_thenReturnList() {
-        List<Integer> idList = List.of(5,6);
+        Set<Integer> idList = Set.of(5,6);
         when(repOrderImpl.findEligibleForFdcDelayedPickup(anyInt(), any(), anyInt()))
                 .thenReturn(idList);
         assertThat(repOrderService.findEligibleForFdcDelayedPickup(5, LocalDate.now(), 5)).isEqualTo(idList);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderServiceTest.java
@@ -3,7 +3,6 @@ package gov.uk.courtdata.reporder.service;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.dto.AssessorDetails;
-import gov.uk.courtdata.entity.Applicant;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.model.assessment.UpdateAppDateCompleted;
@@ -18,7 +17,9 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,6 +88,21 @@ class RepOrderServiceTest {
         when(repOrderImpl.countWithSentenceOrderDate(any()))
                 .thenReturn(1L);
         assertThat(repOrderService.exists(TestModelDataBuilder.REP_ID)).isTrue();
+    }
+
+    @Test
+    void givenAllInputs_whenFdcFastTrackingIsInvoked_thenReturnList() {
+        List<Integer> idList = List.of(5,6);
+        when(repOrderImpl.findEligibleForFdcFastTracking(anyInt(), any(), anyInt()))
+                .thenReturn(idList);
+        assertThat(repOrderService.findEligibleForFdcFastTracking(5, LocalDate.now(), 5)).isEqualTo(idList);
+    }
+    @Test
+    void givenAllInputs_whenFdcDelayedPickupIsInvoked_thenReturnList() {
+        List<Integer> idList = List.of(5,6);
+        when(repOrderImpl.findEligibleForFdcDelayedPickup(anyInt(), any(), anyInt()))
+                .thenReturn(idList);
+        assertThat(repOrderService.findEligibleForFdcDelayedPickup(5, LocalDate.now(), 5)).isEqualTo(idList);
     }
 
     @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-368)

Adding 2 endpoints for use in testing by the Debt Collection & Enforcement Service team. 
Endpoints will be used to validate the Final Defence Cost Global Update sql statements via integration testing. 
These endpoints return Rep Orders which are candidates for both halves of the Global Update, which can be further modified by other endpoints developed separately.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
