### PR TITLE
DCES-392 Fix DCES tests (received files and modified date/user)

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -1,18 +1,16 @@
 package gov.uk.courtdata.dces.service;
 
-import static gov.uk.courtdata.enums.ConcorContributionStatus.SENT;
-
 import gov.uk.courtdata.dces.mapper.ConcorContributionMapper;
+import gov.uk.courtdata.dces.mapper.ContributionFileMapper;
 import gov.uk.courtdata.dces.request.CreateContributionFileRequest;
 import gov.uk.courtdata.dces.request.LogContributionProcessedRequest;
 import gov.uk.courtdata.dces.request.UpdateConcorContributionStatusRequest;
 import gov.uk.courtdata.dces.response.ConcorContributionResponse;
 import gov.uk.courtdata.dces.response.ConcorContributionResponseDTO;
 import gov.uk.courtdata.dces.util.ContributionFileUtil;
-import gov.uk.courtdata.enums.ConcorContributionStatus;
-import gov.uk.courtdata.dces.mapper.ContributionFileMapper;
 import gov.uk.courtdata.entity.ConcorContributionsEntity;
 import gov.uk.courtdata.entity.ContributionFilesEntity;
+import gov.uk.courtdata.enums.ConcorContributionStatus;
 import gov.uk.courtdata.exception.MAATCourtDataException;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.repository.ConcorContributionsRepository;
@@ -25,16 +23,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
+import static gov.uk.courtdata.enums.ConcorContributionStatus.SENT;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ConcorContributionsService {
-
     private final ConcorContributionsRepository concorRepository;
     private final ContributionFileMapper contributionFileMapper;
     private final DebtCollectionRepository debtCollectionRepository;
@@ -43,10 +43,8 @@ public class ConcorContributionsService {
 
     /** Resets a number of concor_contribution rows to status = ACTIVE | REPLACED, contrib_file_id = (null). */
     @Transactional
-    public List<Integer> updateConcorContributionStatusAndResetContribFile(UpdateConcorContributionStatusRequest request){
-
+    public List<Integer> updateConcorContributionStatusAndResetContribFile(UpdateConcorContributionStatusRequest request) {
         List<Integer> idsToUpdate = concorRepository.findIdsForUpdate(Pageable.ofSize(request.getRecordCount()));
-
         if (!idsToUpdate.isEmpty()) {
             concorRepository.updateStatusAndResetContribFileForIds(request.getStatus(), idsToUpdate);
         }
@@ -56,8 +54,7 @@ public class ConcorContributionsService {
     public List<ConcorContributionResponse> getConcorContributionFiles(ConcorContributionStatus status) {
         log.info("Getting concor contribution file with status with the -> {}", status);
         final List<ConcorContributionsEntity> concorFileList = concorRepository.findByStatus(status);
-
-        return concorFileList.stream().map( cc -> ConcorContributionResponse.builder()
+        return concorFileList.stream().map(cc -> ConcorContributionResponse.builder()
                         .concorContributionId(cc.getId())
                         .xmlContent(cc.getCurrentXml())
                         .build()).toList();
@@ -66,10 +63,8 @@ public class ConcorContributionsService {
     @Transactional(rollbackFor = MAATCourtDataException.class)
     @NotNull
     public Integer createContributionAndUpdateConcorStatus(CreateContributionFileRequest contributionRequest){
-
         ValidationUtils.isNull(contributionRequest,"contributionRequest object is null");
         ValidationUtils.isEmptyOrHasNullElement(contributionRequest.getConcorContributionIds(),"ContributionIds are empty/null.");
-
         final ContributionFilesEntity contributionFilesEntity = createContributionFile(contributionRequest);
         if (!updateConcorContributionStatusAndSetContribFile(contributionRequest.getConcorContributionIds(), SENT, contributionFilesEntity.getFileId())) {
             throw new NoSuchElementException("No concor_contribution status values were updated"); // did not rollback previously
@@ -82,24 +77,20 @@ public class ConcorContributionsService {
 
     @Transactional(rollbackFor =  MAATCourtDataException.class)
     @NotNull
-    public Integer logContributionProcessed(LogContributionProcessedRequest request){
+    public Integer logContributionProcessed(LogContributionProcessedRequest request) {
         ConcorContributionsEntity concorEntity = concorRepository.findById(request.getConcorId())
                 .orElseThrow(() -> new RequestedObjectNotFoundException("concor_contribution could not be found by id"));
         log.info("Contribution found: {}", concorEntity.getId());
-        if (!debtCollectionService.updateContributionFileReceivedCount(concorEntity.getContribFileId())) {
+        if (!StringUtils.isEmpty(request.getErrorText())) {
+            saveErrorMessage(request, concorEntity);
+        } else if (!debtCollectionService.updateContributionFileReceivedCount(concorEntity.getContribFileId())) {
             throw new NoSuchElementException("No associated contribution_file found for concur_contribution");
         }
-        if(!StringUtils.isEmpty(request.getErrorText()) ){
-            saveErrorMessage(request, concorEntity);
-        }
-
         return concorEntity.getContribFileId();
     }
 
-    public ConcorContributionResponseDTO getConcorContribution(Integer concorContributionId){
-
+    public ConcorContributionResponseDTO getConcorContribution(Integer concorContributionId) {
         Optional<ConcorContributionsEntity> concorContributionEntity = concorRepository.findById(concorContributionId);
-
         if (concorContributionEntity.isPresent()) {
             log.info("Concor Contribution found: {}", concorContributionEntity.get().getId());
             return concorContributionMapper.toConcorContributionResponseDTO(concorContributionEntity.get());
@@ -109,19 +100,17 @@ public class ConcorContributionsService {
         return null;
     }
 
-    private boolean saveErrorMessage(LogContributionProcessedRequest request, ConcorContributionsEntity concorEntity){
-        return debtCollectionService.saveError(ContributionFileUtil.buildContributionFileError(request, concorEntity));
+    private void saveErrorMessage(LogContributionProcessedRequest request, ConcorContributionsEntity concorEntity) {
+        debtCollectionService.saveError(ContributionFileUtil.buildContributionFileError(request, concorEntity));
     }
 
     private ContributionFilesEntity createContributionFile(CreateContributionFileRequest contributionRequest) {
-
         final ContributionFilesEntity contributionFileEntity;
         try {
             log.info("Updating the concor contribution file ref  -> {}", contributionRequest);
             ContributionFileUtil.assessFilename(contributionRequest);
             contributionFileEntity = contributionFileMapper.toContributionFileEntity(contributionRequest);
             debtCollectionRepository.saveContributionFilesEntity(contributionFileEntity);
-
         } catch (Exception e) {
             throw new MAATCourtDataException("Failed to map ConcorContributionRequest to ContributionFilesEntity and persist: [%s]".formatted(e.getMessage()));
         }
@@ -129,17 +118,15 @@ public class ConcorContributionsService {
     }
 
     /** Sets specific concor_contribution rows to status = SENT, contrib_file_id = (non-null). */
-    private boolean updateConcorContributionStatusAndSetContribFile(Set<Integer> ids, ConcorContributionStatus status, final Integer contributionFileId ){
-
+    private boolean updateConcorContributionStatusAndSetContribFile(Set<Integer> ids, ConcorContributionStatus status, final Integer contributionFileId) {
         final List<ConcorContributionsEntity> concorFileList = concorRepository.findByIdIn(ids);
-
         log.info("Concor Contributions for status update - count {}", concorFileList.size());
         concorFileList.forEach(cc -> {
             cc.setUserModified("DCES");
+            cc.setDateModified(LocalDate.now());
             cc.setStatus(status);
             cc.setContribFileId(contributionFileId);
         });
-
         if (!concorFileList.isEmpty()) {
             concorRepository.saveAll(concorFileList);
             log.info("Updated all concor contribution file for contributionFileId {} and count {}",

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionService.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class DebtCollectionService {
-
     private final DebtCollectionRepository debtCollectionRepository;
     private final ContributionFileErrorsRepository contributionFileErrorsRepository;
     private final ContributionFilesRepository contributionFilesRepository;
@@ -35,40 +34,36 @@ public class DebtCollectionService {
     }
 
     String convertToCorrectDateFormat(LocalDate localDate) {
-
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
         log.info("Printing before date " + localDate.toString());
         log.info("Printing after date " + localDate.format(dateTimeFormatter));
         return localDate.format(dateTimeFormatter);
     }
 
-    public boolean saveError(ContributionFileErrorsEntity entity){
+    public void saveError(ContributionFileErrorsEntity entity) {
         contributionFileErrorsRepository.save(entity);
-        return true;
     }
 
-
-    public boolean updateContributionFileReceivedCount(Integer fileId){
-        if(Objects.isNull(fileId)){
+    public boolean updateContributionFileReceivedCount(Integer fileId) {
+        if (Objects.isNull(fileId)) {
             log.info("No associated file was found for contribution");
             return false;
         }
         ContributionFilesEntity filesEntity = getContributionFile(fileId);
-        if ( Objects.nonNull(filesEntity)){
+        if (Objects.nonNull(filesEntity)) {
             filesEntity.incrementReceivedCount();
             filesEntity.setDateReceived(LocalDate.now());
             debtCollectionRepository.updateContributionFilesEntity(filesEntity);
             log.info("Update of file id : {} successful", fileId);
             return true;
-        }
-        else {
+        } else {
             throw new MAATCourtDataException("No file was found for the fdc.");
         }
     }
 
-    private ContributionFilesEntity getContributionFile(int fileId){
+    private ContributionFilesEntity getContributionFile(int fileId) {
         Optional<ContributionFilesEntity> optionalEntity = contributionFilesRepository.findById(fileId);
-        if(optionalEntity.isPresent()){
+        if (optionalEntity.isPresent()) {
             return optionalEntity.get().toBuilder().build();
             // Saving should be done via the JDBCTemplate, not JPA.
             // So in order to avoid JPA @Transaction saving, in addition to the JDBCTemplate,
@@ -76,6 +71,4 @@ public class DebtCollectionService {
         }
         return null;
     }
-
-
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -29,6 +29,8 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -57,35 +59,33 @@ public class FdcContributionsService {
                     .dateCalculated(entity.getDateCalculated())
                     .lgfsCost(entity.getLgfsCost())
                     .agfsCost(entity.getAgfsCost())
-                    .sentenceOrderDate(Objects.nonNull(entity.getRepOrderEntity())?entity.getRepOrderEntity().getSentenceOrderDate():null)
+                    .sentenceOrderDate(Objects.nonNull(entity.getRepOrderEntity()) ? entity.getRepOrderEntity().getSentenceOrderDate() : null)
                     .build();
 
     public FdcContributionsResponse getFdcContributionFiles(FdcContributionsStatus status) {
         log.info("Getting fdc contribution file with status with the -> {}", status);
         final List<FdcContributionsEntity> fdcFileList = fdcContributionsRepository.findByStatus(status);
-
         List<FdcContributionEntry> fdcContributionEntries = fdcFileList.stream()
                 .map(BUILD_FDC_ENTRY)
                 .toList();
         return FdcContributionsResponse.builder().fdcContributions(fdcContributionEntries).build();
     }
 
-    public FdcContributionsGlobalUpdateResponse fdcContributionGlobalUpdate(){
+    public FdcContributionsGlobalUpdateResponse fdcContributionGlobalUpdate() {
         log.info("Running global update process for Final Defence Cost contributions.");
         int numberOfUpdates;
         boolean updateSuccessful;
-        try{
+        try {
             numberOfUpdates = executeGlobalUpdate();
-            updateSuccessful=true;
-        } catch(Exception e){
+            updateSuccessful = true;
+        } catch (Exception e) {
             log.error("FDC Global update failed with: {}", e.getMessage(), e);
             throw e;
         }
         return FdcContributionsGlobalUpdateResponse.builder().numberOfUpdates(numberOfUpdates).successful(updateSuccessful).build();
     }
 
-
-    private int executeGlobalUpdate(){
+    private int executeGlobalUpdate() {
         log.info("executeGlobalUpdate entered");
         String delay = fdcContributionsRepository.callGetFdcCalculationDelay();
         int update1Result = debtCollectionRepository.globalUpdatePart1(delay);
@@ -99,8 +99,7 @@ public class FdcContributionsService {
 
     @Transactional(rollbackFor = MAATCourtDataException.class)
     @NotNull
-    public Integer createContributionFileAndUpdateFdcStatus(CreateFdcFileRequest fdcRequest){
-
+    public Integer createContributionFileAndUpdateFdcStatus(CreateFdcFileRequest fdcRequest) {
         ValidationUtils.isNull(fdcRequest,"fdcRequest object is null");
         ValidationUtils.isEmptyOrHasNullElement(fdcRequest.getFdcIds(),"FdcIds is empty/null.");
         log.info("Request Validated");
@@ -115,13 +114,14 @@ public class FdcContributionsService {
         return contributionFilesEntity.getFileId();
     }
 
-    private boolean updateStatusForFdc(Set<Integer> fdcIds, ContributionFilesEntity contributionFilesEntity){
+    private boolean updateStatusForFdc(Set<Integer> fdcIds, ContributionFilesEntity contributionFilesEntity) {
         List<FdcContributionsEntity> fdcEntities = fdcContributionsRepository.findByIdIn(fdcIds);
-        if(!fdcEntities.isEmpty()) {
+        if (!fdcEntities.isEmpty()) {
             fdcEntities.forEach(fdc -> {
                 fdc.setStatus(SENT);
                 fdc.setContFileId(contributionFilesEntity.getFileId());
                 fdc.setUserModified("DCES");
+                fdc.setDateModified(LocalDate.now());
             });
             log.info("Saving {} Fdc Contributions", Optional.of(fdcEntities.size()));
             fdcContributionsRepository.saveAll(fdcEntities);
@@ -130,7 +130,7 @@ public class FdcContributionsService {
         return false;
     }
 
-    private ContributionFilesEntity createFdcFile(CreateFdcFileRequest fdcFileRequest){
+    private ContributionFilesEntity createFdcFile(CreateFdcFileRequest fdcFileRequest) {
         log.info("Updating the fdc file ref  -> {}", fdcFileRequest);
         ContributionFileUtil.assessFilename(fdcFileRequest);
         ContributionFilesEntity contributionFileEntity = contributionFileMapper.toContributionFileEntity(fdcFileRequest);
@@ -141,27 +141,24 @@ public class FdcContributionsService {
     @Transactional(rollbackFor =  MAATCourtDataException.class)
     @NotNull
     public Integer logFdcProcessed(LogFdcProcessedRequest request) {
-        FdcContributionsEntity fdcEntity = fdcContributionsRepository.findById(Integer.valueOf(request.getFdcId()))
+        FdcContributionsEntity fdcEntity = fdcContributionsRepository.findById(request.getFdcId())
                 .orElseThrow(() -> new RequestedObjectNotFoundException("fdc_contribution could not be found by id"));
         log.info("Contribution found: {}", fdcEntity.getId());
-        if (!debtCollectionService.updateContributionFileReceivedCount(fdcEntity.getContFileId())) {
-            throw new RequestedObjectNotFoundException("Contribution file could not be updated");
-        }
-        if(!StringUtils.isEmpty(request.getErrorText()) ){
+        if (!StringUtils.isEmpty(request.getErrorText())) {
             saveErrorMessage(request, fdcEntity);
+        } else if (!debtCollectionService.updateContributionFileReceivedCount(fdcEntity.getContFileId())) {
+            throw new NoSuchElementException("No associated contribution_file found for fdc_contribution");
         }
         return fdcEntity.getContFileId();
     }
 
-    private boolean saveErrorMessage(LogFdcProcessedRequest request, FdcContributionsEntity fdcEntity){
-        return debtCollectionService.saveError(ContributionFileUtil.buildContributionFileError(request, fdcEntity));
+    private void saveErrorMessage(LogFdcProcessedRequest request, FdcContributionsEntity fdcEntity) {
+        debtCollectionService.saveError(ContributionFileUtil.buildContributionFileError(request, fdcEntity));
     }
 
     public FdcItemsEntity createFdcItems(CreateFdcItemRequest fdcRequest) {
-
         try {
             log.info("Create createFdcItems {}", fdcRequest);
-
             FdcItemsEntity fdcItemsEntity = FdcItemsEntity.builder()
                 .fdcId(fdcRequest.getFdcId())
                 .latestCostInd(fdcRequest.getLatestCostInd())
@@ -171,17 +168,14 @@ public class FdcContributionsService {
                 .paidAsClaimed(fdcRequest.getPaidAsClaimed())
                 .dateCreated(fdcRequest.getDateCreated().toLocalDate())
                 .build();
-
             return fdcItemsRepository.save(fdcItemsEntity);
-
-        } catch(Exception e){
+        } catch (Exception e) {
             log.error("Failed to persist data for FdcItemsEntity {}", e.getMessage());
             throw e;
         }
     }
 
     public long deleteFdcItems(Integer fdcId) {
-
         log.info("Delete FdcItemsEntity with fdcId {}", fdcId);
         try {
             return fdcItemsRepository.deleteByFdcId(fdcId);
@@ -204,7 +198,6 @@ public class FdcContributionsService {
                     .accelerate(request.getManualAcceleration())
                     .status(request.getStatus())
                     .build();
-
             return fdcContributionsRepository.save(fdcContributionsEntity);
         } catch (Exception exception) {
             log.error("Failed to persist data for FdcContributionsEntity {}", exception.getMessage());
@@ -215,7 +208,6 @@ public class FdcContributionsService {
     @Transactional
     public Integer updateFdcContribution(UpdateFdcContributionRequest request) {
         try {
-
             if (request.getPreviousStatus() == null) {
                 log.info("Updating status to {} for all based on rep order id {}", request.getNewStatus(), request.getRepId());
                 return fdcContributionsRepository.updateStatusByRepId(request.getRepId(), request.getNewStatus());
@@ -223,14 +215,13 @@ public class FdcContributionsService {
                 log.info("Updating status to {} from {} for rep order id {}", request.getNewStatus(), request.getPreviousStatus(), request.getRepId());
                 return fdcContributionsRepository.updateStatus(request.getRepId(), request.getNewStatus(), request.getPreviousStatus());
             }
-
         } catch (Exception exception) {
             log.error("Failed to update data for FdcContributionsEntity {}", exception.getMessage());
             throw new MAATCourtDataException (exception.getMessage());
         }
     }
 
-    public FdcContributionEntry getFdcContribution(Integer fdcContributionId){
+    public FdcContributionEntry getFdcContribution(Integer fdcContributionId) {
         FdcContributionsEntity fdcEntity = fdcContributionsRepository.findById(fdcContributionId)
                 .orElseThrow(() -> new RequestedObjectNotFoundException("fdc_contribution could not be found by id"));
         log.info("FDC Contribution found: {}", fdcEntity.getId());

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ConcorContributionsRestControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ConcorContributionsRestControllerIntegrationTest.java
@@ -1,14 +1,5 @@
 package gov.uk.courtdata.integration.dces;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import gov.uk.MAATCourtDataApplication;
 import gov.uk.courtdata.dces.service.DebtCollectionRepository;
 import gov.uk.courtdata.entity.ConcorContributionsEntity;
@@ -16,9 +7,6 @@ import gov.uk.courtdata.entity.ContributionFileErrorsEntity;
 import gov.uk.courtdata.entity.ContributionFilesEntity;
 import gov.uk.courtdata.enums.ConcorContributionStatus;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -31,11 +19,23 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegrationTest {
-
     private static final String ATOMIC_UPDATE_ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/create-contribution-file";
 
     private static final String ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/concor-contribution-files?status=";
@@ -59,14 +59,13 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
         file1Id = repos.contributionFiles.save(buildFileEntity(fileOne, false)).getFileId();
         file2Id = repos.contributionFiles.save(buildFileEntity(fileTwo, true)).getFileId();
 
-
         savedEntityId1 = repos.concorContributions.save(buildConcorEntity(ConcorContributionStatus.ACTIVE, "<xml 1 content dummy",file1Id)).getId();
         savedEntityId2 = repos.concorContributions.save(buildConcorEntity(ConcorContributionStatus.SENT, "<xml 2 content dummy",file1Id)).getId();
         savedEntityId3 = repos.concorContributions.save(buildConcorEntity(ConcorContributionStatus.ACTIVE, "<xml 3 content dummy",null)).getId();
         savedEntityId4 = repos.concorContributions.save(buildConcorEntity(ConcorContributionStatus.SENT, "<xml 4 content dummy",file2Id)).getId();
     }
 
-    private ConcorContributionsEntity buildConcorEntity(ConcorContributionStatus status, String xml, Integer fileId){
+    private ConcorContributionsEntity buildConcorEntity(ConcorContributionStatus status, String xml, Integer fileId) {
         return ConcorContributionsEntity.builder()
                 .status(status)
                 .currentXml(xml)
@@ -74,13 +73,13 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
                 .build();
     }
 
-    private ContributionFilesEntity buildFileEntity(String fileIdentifier, boolean isBlankXml){
+    private ContributionFilesEntity buildFileEntity(String fileIdentifier, boolean isBlankXml) {
         ContributionFilesEntity entity = ContributionFilesEntity.builder()
                 .fileName(fileIdentifier)
                 .recordsReceived(0)
                 .recordsSent(10)
                 .build();
-        if(!isBlankXml){
+        if (!isBlankXml) {
             entity.setXmlContent("<xml>"+fileIdentifier+"</xml>");
             entity.setAckXmlContent("<ackXml>"+fileIdentifier+"</ackXml>");
         }
@@ -121,7 +120,7 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
     @Test
     void givenAListOfIds_whenAtomicUpdate_theStatusIsUpdated() throws Exception {
         // removed the xml values as it cannot be tested due to xmlType. The double refuses to handle XMLTYPE(?) as that is oracle specific.
-        int expectedFileListSize = repos.contributionFiles.findAll().size()+1;
+        int expectedFileListSize = repos.contributionFiles.findAll().size() + 1;
         String expectedFilename = "TestFilename.xml";
         int expectedRecordsSent = 2;
         String s = """
@@ -134,7 +133,6 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
         mockMvc.perform(MockMvcRequestBuilders.post(ATOMIC_UPDATE_ENDPOINT_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // verify the content of the saved entity.
@@ -163,13 +161,12 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
         mockMvc.perform(MockMvcRequestBuilders.post(DRC_UPDATE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check we've updated the received count.
         Optional<ContributionFilesEntity> fileEntity = repos.contributionFiles.findById(file2Id);
         assertTrue(fileEntity.isPresent());
-        assertEquals(1,fileEntity.get().getRecordsReceived());
+        assertEquals(1, fileEntity.get().getRecordsReceived());
 
         // check no values in errors
         assertEquals(0, repos.contributionFileErrors.count());
@@ -184,13 +181,12 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
         mockMvc.perform(MockMvcRequestBuilders.post(DRC_UPDATE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check we've updated the received count.
         Optional<ContributionFilesEntity> fileEntity = repos.contributionFiles.findById(file2Id);
         assertTrue(fileEntity.isPresent());
-        assertEquals(1,fileEntity.get().getRecordsReceived());
+        assertEquals(0, fileEntity.get().getRecordsReceived());
 
         // check no values in errors
         assertEquals(1, repos.contributionFileErrors.count());
@@ -203,7 +199,6 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
         assertEquals(dateTimeCheck.getDayOfMonth(), errorEntity.getDateCreated().getDayOfMonth());
         assertEquals(dateTimeCheck.getMonth(), errorEntity.getDateCreated().getMonth());
         assertEquals(dateTimeCheck.getYear(), errorEntity.getDateCreated().getYear());
-
     }
 
     @Test
@@ -213,19 +208,17 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
         mockMvc.perform(MockMvcRequestBuilders.post(DRC_UPDATE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().is4xxClientError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check no values in errors
         assertEquals(0, repos.contributionFileErrors.count());
     }
 
-    private String createLogDrcProcessedRequest(Integer id, String errorText){
+    private String createLogDrcProcessedRequest(Integer id, String errorText) {
         return  """
                     {
                         "concorId" : %s,
                         "errorText" : "%s"
                     }""".formatted(id,errorText);
     }
-
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/FdcContributionsIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/FdcContributionsIntegrationTest.java
@@ -24,12 +24,16 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
-
     private static final String FDC_CONTRIBUTION_FILES_ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/fdc-contribution-files";
     private static final String GLOBAL_UPDATE_ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/prepare-fdc-contributions-files";
     private static final String ATOMIC_UPDATE_ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/create-fdc-file";
@@ -62,7 +66,6 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
     @Captor
     private ArgumentCaptor<ContributionFilesEntity> contributionFileEntityCaptor;
 
-
     @BeforeEach
     public void setUp() {
         file1Id = repos.contributionFiles.save(buildFileEntity(fileOne, false)).getFileId();
@@ -78,13 +81,13 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         repId4 = expectedId4;
     }
 
-    private ContributionFilesEntity buildFileEntity(String fileIdentifier, boolean isBlankXml){
+    private ContributionFilesEntity buildFileEntity(String fileIdentifier, boolean isBlankXml) {
         ContributionFilesEntity entity = ContributionFilesEntity.builder()
                 .fileName(fileIdentifier)
                 .recordsReceived(0)
                 .recordsSent(10)
                 .build();
-        if(!isBlankXml){
+        if (!isBlankXml){
             entity.setXmlContent("<xml>"+fileIdentifier+"</xml>");
             entity.setAckXmlContent("<ackXml>"+fileIdentifier+"</ackXml>");
         }
@@ -158,11 +161,10 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
                                     "fdcIds": [%s],
                                     "xmlFileName" : "%s"
                                 }""";
-        s = s.formatted( expectedRecordsSent, expectedId4, expectedFilename);
+        s = s.formatted(expectedRecordsSent, expectedId4, expectedFilename);
         mockMvc.perform(MockMvcRequestBuilders.post(ATOMIC_UPDATE_ENDPOINT_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // verify the content of the saved entity.
@@ -181,10 +183,7 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         FdcContributionsEntity fdcContributionsEntity = updatedFdc.get();
         assertEquals(savedFileEntity.getFileId(), fdcContributionsEntity.getContFileId());
         assertEquals(FdcContributionsStatus.SENT, fdcContributionsEntity.getStatus());
-
     }
-
-
 
     @Test
     void testLogDrcProcessedNoErrors() throws Exception {
@@ -193,7 +192,6 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post(DRC_UPDATE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check we've updated the received count.
@@ -214,13 +212,12 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post(DRC_UPDATE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check we've updated the received count.
         Optional<ContributionFilesEntity> fileEntity = repos.contributionFiles.findById(file2Id);
         assertTrue(fileEntity.isPresent());
-        assertEquals(1,fileEntity.get().getRecordsReceived());
+        assertEquals(0, fileEntity.get().getRecordsReceived());
 
         // check no values in errors
         assertEquals(1, repos.contributionFileErrors.count());
@@ -233,7 +230,6 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         assertEquals(dateTimeCheck.getDayOfMonth(), errorEntity.getDateCreated().getDayOfMonth());
         assertEquals(dateTimeCheck.getMonth(), errorEntity.getDateCreated().getMonth());
         assertEquals(dateTimeCheck.getYear(), errorEntity.getDateCreated().getYear());
-
     }
 
     @Test
@@ -243,7 +239,6 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post(DRC_UPDATE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().is4xxClientError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check no values in errors
@@ -258,7 +253,6 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post(DRC_UPDATE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().is5xxServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check no values in errors
@@ -274,7 +268,6 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post(DRC_UPDATE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(s))
-
                 .andExpect(status().is4xxClientError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // check no values in errors
@@ -285,12 +278,11 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
         assertEquals(0, filesEntity.getRecordsReceived()); // ensure the increment is rolled back.
     }
 
-    private String createLogDrcProcessedRequest(Integer id, String errorText){
+    private String createLogDrcProcessedRequest(Integer id, String errorText) {
         return  """
                     {
                         "fdcId" : %s,
                         "errorText" : "%s"
                     }""".formatted(id,errorText);
     }
-
 }


### PR DESCRIPTION
## What

[DCES-392](https://dsdmoj.atlassian.net/browse/DCES-392) Fix DCES tests (received files and modified date/user)

- Don't increment the contribution file's received count or update its last modified date when creating a contribution file error
- Ensure the last modified user and last modified date of a contribution file are updated whenever the contribution file is updated
- Modify boolean `save*` methods that always returned `true` to void
- In tests, consistently use `never()` instead of `times(0)` and remove `times(1)` where it is the default anyway
- Fix tests that failed due to the changes in persistence behavior
- Optimize imports and improve code formatting in modified source files

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
