### PR TITLE
DCES-381 - Global Update naming conventions.

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
@@ -114,8 +114,8 @@ public class DebtCollectionRepository {
     }
 
     @SuppressWarnings("squid:S1192") // ignore "Can be a constant" as is not relevant here.
-    public int globalUpdatePart1(String delay) {
-        log.info("globalUpdatePart1 entered");
+    public int eligibleForFdcDelayedPickup(String delay) {
+        log.info("eligibleForFdcDelayedPickup entered");
         String query = """
                 MERGE INTO TOGDATA.FDC_CONTRIBUTIONS FC 
                  USING  
@@ -178,8 +178,8 @@ public class DebtCollectionRepository {
     }
 
     @SuppressWarnings("squid:S1192") // ignore "Can be a constant" as is not relevant here.
-    public int globalUpdatePart2(String delay) {
-        log.info("globalUpdatePart2 entered");
+    public int eligibleForFdcFastTracking(String delay) {
+        log.info("eligibleForFdcFastTracking entered");
         String query = """
                 MERGE INTO TOGDATA.FDC_CONTRIBUTIONS FC 
                 USING  

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
@@ -114,7 +114,7 @@ public class DebtCollectionRepository {
     }
 
     @SuppressWarnings("squid:S1192") // ignore "Can be a constant" as is not relevant here.
-    public int eligibleForFdcDelayedPickup(String delay) {
+    public int setEligibleForFdcDelayedPickup(String delay) {
         log.info("eligibleForFdcDelayedPickup entered");
         String query = """
                 MERGE INTO TOGDATA.FDC_CONTRIBUTIONS FC 
@@ -178,7 +178,7 @@ public class DebtCollectionRepository {
     }
 
     @SuppressWarnings("squid:S1192") // ignore "Can be a constant" as is not relevant here.
-    public int eligibleForFdcFastTracking(String delay) {
+    public int setEligibleForFdcFastTracking(String delay) {
         log.info("eligibleForFdcFastTracking entered");
         String query = """
                 MERGE INTO TOGDATA.FDC_CONTRIBUTIONS FC 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -88,9 +88,9 @@ public class FdcContributionsService {
     private int executeGlobalUpdate() {
         log.info("executeGlobalUpdate entered");
         String delay = fdcContributionsRepository.callGetFdcCalculationDelay();
-        int fdcDelayedPickupResult = debtCollectionRepository.eligibleForFdcDelayedPickup(delay);
+        int fdcDelayedPickupResult = debtCollectionRepository.setEligibleForFdcDelayedPickup(delay);
         log.info("FDC Global update: eligibleForFdcDelayedPickup: affected: {}", Optional.of(fdcDelayedPickupResult));
-        int fdcFastTrackingResult = debtCollectionRepository.eligibleForFdcFastTracking(delay);
+        int fdcFastTrackingResult = debtCollectionRepository.setEligibleForFdcFastTracking(delay);
         log.info("FDC Global update: eligibleForFdcFastTracking: affected: {}", Optional.of(fdcFastTrackingResult));
         int response = fdcDelayedPickupResult+fdcFastTrackingResult;
         log.info("executeGlobalUpdate exiting");

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -88,11 +88,11 @@ public class FdcContributionsService {
     private int executeGlobalUpdate() {
         log.info("executeGlobalUpdate entered");
         String delay = fdcContributionsRepository.callGetFdcCalculationDelay();
-        int update1Result = debtCollectionRepository.globalUpdatePart1(delay);
-        log.info("FDC Global update Part 1 affected: {}", Optional.of(update1Result));
-        int update2Result = debtCollectionRepository.globalUpdatePart2(delay);
-        log.info("FDC Global update Part 2 affected: {}", Optional.of(update2Result));
-        int response = update1Result+update2Result;
+        int fdcDelayedPickupResult = debtCollectionRepository.eligibleForFdcDelayedPickup(delay);
+        log.info("FDC Global update: eligibleForFdcDelayedPickup: affected: {}", Optional.of(fdcDelayedPickupResult));
+        int fdcFastTrackingResult = debtCollectionRepository.eligibleForFdcFastTracking(delay);
+        log.info("FDC Global update: eligibleForFdcFastTracking: affected: {}", Optional.of(fdcFastTrackingResult));
+        int response = fdcDelayedPickupResult+fdcFastTrackingResult;
         log.info("executeGlobalUpdate exiting");
         return response;
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/DebtCollectionRepositoryTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/DebtCollectionRepositoryTest.java
@@ -26,31 +26,31 @@ class DebtCollectionRepositoryTest {
 
     @Mock
     JdbcTemplate jdbcTemplate;
-    private static final byte[] fdcMerge1StatementHash = new byte[]{-47, -40, -68, -99, 85, -77, -119, -64, 1, 3, 83, -92, -76, 27, -114, 107, -83, -31, -66, 60, -122, -24, 127, 55, 120, -112, 96, -51, -105, 62, 1, -18};
-    private static final byte[] fdcMerge2StatementHash = new byte[]{-17, -92, -125, -62, -12, 18, 39, -68, -70, 54, 77, -42, 16, 113, 24, -106, -124, 116, 44, -63, -103, 78, 66, -78, 15, -41, -42, -65, -66, -45, -74, -48};
+    private static final byte[] fdcDelayedPickupStatementHash = new byte[]{-47, -40, -68, -99, 85, -77, -119, -64, 1, 3, 83, -92, -76, 27, -114, 107, -83, -31, -66, 60, -122, -24, 127, 55, 120, -112, 96, -51, -105, 62, 1, -18};
+    private static final byte[] fdcFastTrackingStatementHash = new byte[]{-17, -92, -125, -62, -12, 18, 39, -68, -70, 54, 77, -42, 16, 113, 24, -106, -124, 116, 44, -63, -103, 78, 66, -78, 15, -41, -42, -65, -66, -45, -74, -48};
 
     @Captor
     ArgumentCaptor<String> mergeSQLCaptor;
 
     @Test
-    void verifyMergeStatement1_IsExpected() {
+    void verifyEligibleForFdcDelayedPickupStatement_IsExpected() {
         when(jdbcTemplate.update(mergeSQLCaptor.capture(),anyString()))
                 .thenReturn(1);
-        debtCollectionRepository.globalUpdatePart1("?");
+        debtCollectionRepository.eligibleForFdcDelayedPickup("?");
 
         assertNotNull(mergeSQLCaptor);
-        Assertions.assertArrayEquals(fdcMerge1StatementHash, getCaptorHash(), "A change has been detected in the debtCollectionRepository.globalUpdatePart1() please verify changes are correct. And update this test.");
+        Assertions.assertArrayEquals(fdcDelayedPickupStatementHash, getCaptorHash(), "A change has been detected in the debtCollectionRepository.globalUpdatePart1() please verify changes are correct. And update this test.");
     }
 
     @Test
     void verifyMergeStatement2_IsExpected() {
         when(jdbcTemplate.update(mergeSQLCaptor.capture(),anyString()))
                 .thenReturn(1);
-        debtCollectionRepository.globalUpdatePart2("?");
+        debtCollectionRepository.eligibleForFdcFastTracking("?");
 
 
         assertNotNull(mergeSQLCaptor);
-        Assertions.assertArrayEquals(fdcMerge2StatementHash,getCaptorHash(),"A change has been detected in the debtCollectionRepository.globalUpdatePart1() please verify changes are correct. And update this test.");
+        Assertions.assertArrayEquals(fdcFastTrackingStatementHash,getCaptorHash(),"A change has been detected in the debtCollectionRepository.globalUpdatePart1() please verify changes are correct. And update this test.");
     }
 
     byte[] getCaptorHash(){

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/DebtCollectionRepositoryTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/DebtCollectionRepositoryTest.java
@@ -36,7 +36,7 @@ class DebtCollectionRepositoryTest {
     void verifyEligibleForFdcDelayedPickupStatement_IsExpected() {
         when(jdbcTemplate.update(mergeSQLCaptor.capture(),anyString()))
                 .thenReturn(1);
-        debtCollectionRepository.eligibleForFdcDelayedPickup("?");
+        debtCollectionRepository.setEligibleForFdcDelayedPickup("?");
 
         assertNotNull(mergeSQLCaptor);
         Assertions.assertArrayEquals(fdcDelayedPickupStatementHash, getCaptorHash(), "A change has been detected in the debtCollectionRepository.globalUpdatePart1() please verify changes are correct. And update this test.");
@@ -46,7 +46,7 @@ class DebtCollectionRepositoryTest {
     void verifyMergeStatement2_IsExpected() {
         when(jdbcTemplate.update(mergeSQLCaptor.capture(),anyString()))
                 .thenReturn(1);
-        debtCollectionRepository.eligibleForFdcFastTracking("?");
+        debtCollectionRepository.setEligibleForFdcFastTracking("?");
 
 
         assertNotNull(mergeSQLCaptor);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/FdcContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/FdcContributionsServiceTest.java
@@ -45,7 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -116,8 +115,8 @@ class FdcContributionsServiceTest {
         int expected1 = 2;
         int expected2 = 5;
 
-        when(debtCollectionRepository.globalUpdatePart1("5")).thenReturn(expected1);
-        when(debtCollectionRepository.globalUpdatePart2("5")).thenReturn(expected2);
+        when(debtCollectionRepository.eligibleForFdcDelayedPickup("5")).thenReturn(expected1);
+        when(debtCollectionRepository.eligibleForFdcFastTracking("5")).thenReturn(expected2);
         when(fdcContributionsRepository.callGetFdcCalculationDelay()).thenReturn("5");
         FdcContributionsGlobalUpdateResponse response = fdcContributionsService.fdcContributionGlobalUpdate();
         assertNotNull(response);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/FdcContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/FdcContributionsServiceTest.java
@@ -115,8 +115,8 @@ class FdcContributionsServiceTest {
         int expected1 = 2;
         int expected2 = 5;
 
-        when(debtCollectionRepository.eligibleForFdcDelayedPickup("5")).thenReturn(expected1);
-        when(debtCollectionRepository.eligibleForFdcFastTracking("5")).thenReturn(expected2);
+        when(debtCollectionRepository.setEligibleForFdcDelayedPickup("5")).thenReturn(expected1);
+        when(debtCollectionRepository.setEligibleForFdcFastTracking("5")).thenReturn(expected2);
         when(fdcContributionsRepository.callGetFdcCalculationDelay()).thenReturn("5");
         FdcContributionsGlobalUpdateResponse response = fdcContributionsService.fdcContributionGlobalUpdate();
         assertNotNull(response);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-381)

Changing naming for GlobalUpdate submethods with proper naming. Changing away from nondescript merge1 and merge2

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
