### PR TITLE
DCES-393 Complete user/date modified auditing

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -35,6 +35,7 @@ import static gov.uk.courtdata.enums.ConcorContributionStatus.SENT;
 @Service
 @RequiredArgsConstructor
 public class ConcorContributionsService {
+    private static final String USER_AUDIT = "DCES";
     private final ConcorContributionsRepository concorRepository;
     private final ContributionFileMapper contributionFileMapper;
     private final DebtCollectionRepository debtCollectionRepository;
@@ -46,7 +47,7 @@ public class ConcorContributionsService {
     public List<Integer> updateConcorContributionStatusAndResetContribFile(UpdateConcorContributionStatusRequest request) {
         List<Integer> idsToUpdate = concorRepository.findIdsForUpdate(Pageable.ofSize(request.getRecordCount()));
         if (!idsToUpdate.isEmpty()) {
-            concorRepository.updateStatusAndResetContribFileForIds(request.getStatus(), idsToUpdate);
+            concorRepository.updateStatusAndResetContribFileForIds(request.getStatus(), USER_AUDIT, idsToUpdate);
         }
         return idsToUpdate;
     }
@@ -123,7 +124,7 @@ public class ConcorContributionsService {
         final List<ConcorContributionsEntity> concorFileList = concorRepository.findByIdIn(ids);
         log.info("Concor Contributions for status update - count {}", concorFileList.size());
         concorFileList.forEach(cc -> {
-            cc.setUserModified("DCES");
+            cc.setUserModified(USER_AUDIT);
             cc.setDateModified(LocalDate.now());
             cc.setStatus(status);
             cc.setContribFileId(contributionFileId);

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 @Slf4j
 public class DebtCollectionRepository {
     private final JdbcTemplate jdbcTemplate;
-    private static final String DB_USER_NAME = "DCES";
+    private static final String USER_AUDIT = "DCES";
 
     List<String> getContributionFiles(final String fromDate, final String toDate) {
         String query = "SELECT cf.xml_content FROM TOGDATA.CONTRIBUTION_FILES CF " +
@@ -41,9 +41,9 @@ public class DebtCollectionRepository {
     }
 
     public boolean saveContributionFilesEntity(ContributionFilesEntity contributionFilesEntity) {
-        contributionFilesEntity.setUserCreated(DB_USER_NAME);
+        contributionFilesEntity.setUserCreated(USER_AUDIT);
         contributionFilesEntity.setDateCreated(LocalDate.now());
-        contributionFilesEntity.setUserModified(DB_USER_NAME);
+        contributionFilesEntity.setUserModified(USER_AUDIT);
         contributionFilesEntity.setDateModified(LocalDate.now());
         contributionFilesEntity.setDateSent(LocalDate.now());
 
@@ -53,7 +53,7 @@ public class DebtCollectionRepository {
     }
 
     public boolean updateContributionFilesEntity(ContributionFilesEntity contributionFilesEntity) {
-        contributionFilesEntity.setUserModified(DB_USER_NAME);
+        contributionFilesEntity.setUserModified(USER_AUDIT);
         contributionFilesEntity.setDateModified(LocalDate.now());
         log.info("Updating TOGDATA.CONTRIBUTION_FILES using jdbcTemplate");
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
@@ -173,7 +173,9 @@ public class DebtCollectionRepository {
                                  ) MERGERESULT 
                  ON (FC.ID = MERGERESULT.ID) 
                  WHEN MATCHED THEN 
-                   UPDATE SET FC.STATUS = MERGERESULT.NEWSTATUS""";
+                   UPDATE SET FC.STATUS = MERGERESULT.NEWSTATUS,
+                              FC.DATE_MODIFIED = SYSTIMESTAMP,
+                              FC.USER_MODIFIED = 'DCES'""";
         return jdbcTemplate.update(query, delay);
     }
 
@@ -323,7 +325,9 @@ public class DebtCollectionRepository {
                                 ) QUERY1 
                 ON (FC.ID = QUERY1.ID) 
                 WHEN MATCHED THEN 
-                  UPDATE SET FC.STATUS = QUERY1.NEWSTATUS""";
+                  UPDATE SET FC.STATUS = QUERY1.NEWSTATUS,
+                             FC.DATE_MODIFIED = SYSTIMESTAMP,
+                             FC.USER_MODIFIED = 'DCES'""";
         return jdbcTemplate.update(query,delay);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -44,6 +44,7 @@ import static gov.uk.courtdata.enums.FdcContributionsStatus.SENT;
 @Service
 @RequiredArgsConstructor
 public class FdcContributionsService {
+    private static final String USER_AUDIT = "DCES";
     private final FdcContributionsRepository fdcContributionsRepository;
     private final FdcItemsRepository fdcItemsRepository;
     private final ContributionFileMapper contributionFileMapper;
@@ -120,7 +121,7 @@ public class FdcContributionsService {
             fdcEntities.forEach(fdc -> {
                 fdc.setStatus(SENT);
                 fdc.setContFileId(contributionFilesEntity.getFileId());
-                fdc.setUserModified("DCES");
+                fdc.setUserModified(USER_AUDIT);
                 fdc.setDateModified(LocalDate.now());
             });
             log.info("Saving {} Fdc Contributions", Optional.of(fdcEntities.size()));
@@ -168,6 +169,8 @@ public class FdcContributionsService {
                 .userCreated(fdcRequest.getUserCreated())
                 .paidAsClaimed(fdcRequest.getPaidAsClaimed())
                 .dateCreated(fdcRequest.getDateCreated().toLocalDate())
+                .dateModified(fdcRequest.getDateCreated().toLocalDate())
+                .userModified(fdcRequest.getUserCreated())
                 .build();
             return fdcItemsRepository.save(fdcItemsEntity);
         } catch (Exception e) {
@@ -198,6 +201,10 @@ public class FdcContributionsService {
                     .agfsComplete(request.getAgfsComplete())
                     .accelerate(request.getManualAcceleration())
                     .status(request.getStatus())
+                    .dateCreated(LocalDate.now())
+                    .dateModified(LocalDate.now())
+                    .userCreated(USER_AUDIT)
+                    .userModified(USER_AUDIT)
                     .build();
             return fdcContributionsRepository.save(fdcContributionsEntity);
         } catch (Exception exception) {
@@ -211,10 +218,10 @@ public class FdcContributionsService {
         try {
             if (request.getPreviousStatus() == null) {
                 log.info("Updating status to {} for all based on rep order id {}", request.getNewStatus(), request.getRepId());
-                return fdcContributionsRepository.updateStatusByRepId(request.getRepId(), request.getNewStatus());
+                return fdcContributionsRepository.updateStatusByRepId(request.getRepId(), USER_AUDIT, request.getNewStatus());
             } else {
                 log.info("Updating status to {} from {} for rep order id {}", request.getNewStatus(), request.getPreviousStatus(), request.getRepId());
-                return fdcContributionsRepository.updateStatus(request.getRepId(), request.getNewStatus(), request.getPreviousStatus());
+                return fdcContributionsRepository.updateStatus(request.getRepId(), USER_AUDIT, request.getNewStatus(), request.getPreviousStatus());
             }
         } catch (Exception exception) {
             log.error("Failed to update data for FdcContributionsEntity {}", exception.getMessage());

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
@@ -17,12 +17,25 @@ public interface ConcorContributionsRepository extends JpaRepository<ConcorContr
     List<ConcorContributionsEntity> findByStatus(ConcorContributionStatus status);
     List<ConcorContributionsEntity> findByIdIn(Set<Integer> ids);
 
-    @Query("SELECT cc.id FROM ConcorContributionsEntity cc WHERE cc.status = 'SENT' AND cc.fullXml IS NOT NULL AND cc.dateModified IS NOT NULL ORDER BY cc.id DESC")
+    @Query("""
+           SELECT cc.id
+               FROM ConcorContributionsEntity cc
+               WHERE cc.status = 'SENT'
+               AND cc.fullXml IS NOT NULL
+               AND cc.dateModified IS NOT NULL
+               ORDER BY cc.id DESC""")
     List<Integer> findIdsForUpdate(Pageable pageable);
 
     @Modifying
     @Transactional
-    @Query("UPDATE ConcorContributionsEntity cc SET cc.status = :newStatus, cc.contribFileId = NULL WHERE cc.id IN :ids")
-    int updateStatusAndResetContribFileForIds(@Param("newStatus") ConcorContributionStatus newStatus, @Param("ids") List<Integer> ids);
-
+    @Query("""
+           UPDATE ConcorContributionsEntity cc
+               SET cc.status = :newStatus,
+               cc.contribFileId = NULL,
+               cc.dateModified = CURRENT_DATE,
+               cc.userModified = :userModified
+               WHERE cc.id IN :ids""")
+    int updateStatusAndResetContribFileForIds(@Param("newStatus") ConcorContributionStatus newStatus,
+                                              @Param("userModified") String userModified,
+                                              @Param("ids") List<Integer> ids);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/FdcContributionsRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/FdcContributionsRepository.java
@@ -20,10 +20,26 @@ public interface FdcContributionsRepository extends JpaRepository<FdcContributio
     String callGetFdcCalculationDelay();
 
     @Modifying
-    @Query("UPDATE FdcContributionsEntity f SET f.status = :newStatus WHERE f.repOrderEntity.id = :repId AND f.status = :previousStatus")
-    Integer updateStatus(@Param("repId") Integer repId, @Param("newStatus") FdcContributionsStatus newStatus, @Param("previousStatus") FdcContributionsStatus previousStatus);
+    @Query("""
+           UPDATE FdcContributionsEntity f
+               SET f.status = :newStatus,
+               f.userModified = :userModified,
+               f.dateModified = CURRENT_DATE
+               WHERE f.repOrderEntity.id = :repId
+               AND f.status = :previousStatus""")
+    Integer updateStatus(@Param("repId") Integer repId,
+                         @Param("userModified") String userModified,
+                         @Param("newStatus") FdcContributionsStatus newStatus,
+                         @Param("previousStatus") FdcContributionsStatus previousStatus);
 
     @Modifying
-    @Query("UPDATE FdcContributionsEntity f SET f.status = :newStatus WHERE f.repOrderEntity.id = :repId")
-    Integer updateStatusByRepId(@Param("repId") Integer repId, @Param("newStatus") FdcContributionsStatus newStatus);
+    @Query("""
+           UPDATE FdcContributionsEntity f
+               SET f.status = :newStatus,
+               f.userModified = :userModified,
+               f.dateModified = CURRENT_DATE
+               WHERE f.repOrderEntity.id = :repId""")
+    Integer updateStatusByRepId(@Param("repId") Integer repId,
+                                @Param("userModified") String userModified,
+                                @Param("newStatus") FdcContributionsStatus newStatus);
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.doNothing;
@@ -259,13 +260,13 @@ class ConcorContributionsServiceTest {
     @Test
     void testUpdateConcorContributionsStatus() {
         when(concorRepository.findIdsForUpdate(any())).thenReturn(List.of(1111, 2222));
-        when(concorRepository.updateStatusAndResetContribFileForIds(any(), any())).thenReturn(2);
+        when(concorRepository.updateStatusAndResetContribFileForIds(any(), anyString(), any())).thenReturn(2);
 
         List<Integer> response = concorService.updateConcorContributionStatusAndResetContribFile(UpdateConcorContributionStatusRequest.builder().recordCount(2)
                 .status(ConcorContributionStatus.SENT).build());
 
         verify(concorRepository).findIdsForUpdate(any());
-        verify(concorRepository).updateStatusAndResetContribFileForIds(any(), any());
+        verify(concorRepository).updateStatusAndResetContribFileForIds(any(), anyString(), any());
         assertEquals(2, response.size());
     }
 
@@ -277,7 +278,7 @@ class ConcorContributionsServiceTest {
                 .status(ConcorContributionStatus.SENT).build());
 
         verify(concorRepository).findIdsForUpdate(any());
-        verify(concorRepository,never()).updateStatusAndResetContribFileForIds(any(), any());
+        verify(concorRepository,never()).updateStatusAndResetContribFileForIds(any(), anyString(), any());
         assertEquals(0, response.size());
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/DebtCollectionRepositoryTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/DebtCollectionRepositoryTest.java
@@ -14,46 +14,46 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DebtCollectionRepositoryTest {
-
     @InjectMocks
     private DebtCollectionRepository debtCollectionRepository;
 
     @Mock
     JdbcTemplate jdbcTemplate;
-    private static final byte[] fdcDelayedPickupStatementHash = new byte[]{-47, -40, -68, -99, 85, -77, -119, -64, 1, 3, 83, -92, -76, 27, -114, 107, -83, -31, -66, 60, -122, -24, 127, 55, 120, -112, 96, -51, -105, 62, 1, -18};
-    private static final byte[] fdcFastTrackingStatementHash = new byte[]{-17, -92, -125, -62, -12, 18, 39, -68, -70, 54, 77, -42, 16, 113, 24, -106, -124, 116, 44, -63, -103, 78, 66, -78, 15, -41, -42, -65, -66, -45, -74, -48};
+
+    private static final byte[] fdcDelayedPickupStatementHash = new byte[] { 99, 42, 80, -85, 61, 50, -120, 64, -112, -102, -79, 107, -47, 77, 20, -25, -109, 45, -26, -60, -99, 71, 81, 62, -87, -124, 92, 84, 108, -40, -79, -27 };
+    private static final byte[] fdcFastTrackingStatementHash = new byte[] { -35, -77, 94, -100, 60, 8, 52, 93, 50, -65, -94, 80, 96, 15, -128, 48, -101, 3, -28, 36, 41, -42, 40, -84, 16, -17, 16, 79, 15, -68, 42, -120 };
 
     @Captor
     ArgumentCaptor<String> mergeSQLCaptor;
 
     @Test
     void verifyEligibleForFdcDelayedPickupStatement_IsExpected() {
-        when(jdbcTemplate.update(mergeSQLCaptor.capture(),anyString()))
+        when(jdbcTemplate.update(mergeSQLCaptor.capture(), anyString()))
                 .thenReturn(1);
         debtCollectionRepository.setEligibleForFdcDelayedPickup("?");
 
         assertNotNull(mergeSQLCaptor);
-        Assertions.assertArrayEquals(fdcDelayedPickupStatementHash, getCaptorHash(), "A change has been detected in the debtCollectionRepository.globalUpdatePart1() please verify changes are correct. And update this test.");
+        assertArrayEquals(fdcDelayedPickupStatementHash, getCaptorHash(), "A change has been detected in the DebtCollectionRepository.setEligibleForFdcDelayedPickup() please verify changes are correct. And update this test.");
     }
 
     @Test
-    void verifyMergeStatement2_IsExpected() {
-        when(jdbcTemplate.update(mergeSQLCaptor.capture(),anyString()))
+    void verifyEligibleForFdcFastTracking_IsExpected() {
+        when(jdbcTemplate.update(mergeSQLCaptor.capture(), anyString()))
                 .thenReturn(1);
         debtCollectionRepository.setEligibleForFdcFastTracking("?");
 
-
         assertNotNull(mergeSQLCaptor);
-        Assertions.assertArrayEquals(fdcFastTrackingStatementHash,getCaptorHash(),"A change has been detected in the debtCollectionRepository.globalUpdatePart1() please verify changes are correct. And update this test.");
+        assertArrayEquals(fdcFastTrackingStatementHash, getCaptorHash(), "A change has been detected in the DebtCollectionRepository.setEligibleForFdcFastTracking() please verify changes are correct. And update this test.");
     }
 
-    byte[] getCaptorHash(){
+    byte[] getCaptorHash() {
         MessageDigest messageDigest;
         try {
             messageDigest = MessageDigest.getInstance("SHA-256");

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/FdcContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/FdcContributionsServiceTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doNothing;
@@ -261,7 +262,7 @@ class FdcContributionsServiceTest {
     void testUpdateFdcContributionWhenRowsUpdated() {
         UpdateFdcContributionRequest request = getUpdateFdcContributionRequest();
 
-        when(fdcContributionsRepository.updateStatus(anyInt(), any(), any())).thenReturn(1);
+        when(fdcContributionsRepository.updateStatus(anyInt(), anyString(), any(), any())).thenReturn(1);
 
         Integer result = fdcContributionsService.updateFdcContribution(request);
         assertEquals(1, result);
@@ -271,7 +272,7 @@ class FdcContributionsServiceTest {
     void testUpdateFdcContributionWhenNoRowsUpdated() {
         UpdateFdcContributionRequest request = getUpdateFdcContributionRequest();
 
-        when(fdcContributionsRepository.updateStatus(anyInt(), any(), any())).thenReturn(0);
+        when(fdcContributionsRepository.updateStatus(anyInt(), anyString(), any(), any())).thenReturn(0);
 
         Integer result = fdcContributionsService.updateFdcContribution(request);
         assertEquals(0, result);
@@ -281,7 +282,7 @@ class FdcContributionsServiceTest {
     void testUpdateFdcContributionWhenExceptionOccurs() {
         UpdateFdcContributionRequest request = getUpdateFdcContributionRequest();
 
-        when(fdcContributionsRepository.updateStatus(anyInt(), any(), any())).thenThrow(new RuntimeException("Database error"));
+        when(fdcContributionsRepository.updateStatus(anyInt(), anyString(), any(), any())).thenThrow(new RuntimeException("Database error"));
 
         Exception exception = assertThrows(RuntimeException.class,
                 () -> fdcContributionsService.updateFdcContribution(request));


### PR DESCRIPTION
## What

[DCES-393](https://dsdmoj.atlassian.net/browse/DCES-393) Add audit for DCES entities through JPA (JPQL queries)
- Ensure audit user/date modified is set for DCES entities
- Use Java text blocks for easier-to-read multiline query strings

[DCES-393](https://dsdmoj.atlassian.net/browse/DCES-393) Add audit to DCES FDC contribution prep (native queries)
- Add date/user modified to the big SQL merge statements
- Fix failing SQL text MD5 test

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
