### PR TITLE
DCES-429 Improve performance of contribution file updates

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ContributionFilesRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ContributionFilesRepository.java
@@ -2,7 +2,9 @@ package gov.uk.courtdata.repository;
 
 import gov.uk.courtdata.entity.ContributionFilesEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -18,4 +20,15 @@ public interface ContributionFilesRepository extends JpaRepository<ContributionF
     @Query(value = "SELECT cf.xml_content FROM TOGDATA.CONTRIBUTION_FILES CF WHERE CF.FILE_NAME like '%%FDC%%' AND CF.DATE_CREATED BETWEEN fromDate and toDate",
             nativeQuery = true)
     List<String> getFDC(LocalDate fromDate, LocalDate toDate);
+
+    @Modifying
+    @Query("""
+           UPDATE ContributionFilesEntity cf
+           SET cf.recordsReceived = COALESCE(cf.recordsReceived, 0) + 1,
+               cf.dateReceived = CURRENT_DATE,
+               cf.dateModified = CURRENT_DATE,
+               cf.userModified = :userModified
+           WHERE cf.fileId = :id""")
+    int incrementRecordsReceived(@Param("id") Integer id,
+                                 @Param("userModified") String userModified);
 }


### PR DESCRIPTION
## What

[DCES-429](https://dsdmoj.atlassian.net/browse/DCES-429) Improve performance of contribution file updates

- Add specific increment of recordsReceived to Repository
- Update Service to use Repository class instead of Entity
- Simplify tests given simpler implementation

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[DCES-429]: https://dsdmoj.atlassian.net/browse/DCES-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ