### PR TITLE
LASB-3486 Expose Spring Actuator endpoint in non-prod environments

### DIFF
--- a/aws/application/application.template
+++ b/aws/application/application.template
@@ -683,6 +683,22 @@ Resources:
       RouteKey: 'ANY /open-api'
       AuthorizationType: NONE
       Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
+  ApiRouteOpenAPI:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: cNonProd
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: 'ANY /actuator/{proxy+}'
+      AuthorizationType: NONE
+      Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
+  ApiRouteOpenAPIBaseURL:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: cNonProd
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: 'ANY /actuator'
+      AuthorizationType: NONE
+      Target: !Join [ '/', [ integrations, !Ref ApiIntegration ] ]
   ApiAuthorizer:
     Type: 'AWS::ApiGatewayV2::Authorizer'
     Properties:


### PR DESCRIPTION
## Expose Spring Actuator endpoint in non-prod environments

[Link to story - LASB-3486](https://dsdmoj.atlassian.net/browse/LASB-3486)

e.g.` /actuator/info`


![Screenshot 2024-08-09 at 13 35 07](https://github.com/user-attachments/assets/9fca2421-c7c7-43f6-8614-9fb4345c3eca)


## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
