### PR TITLE
LCAM 1526 Fix Integrity Constraint Violation on Status When Creating In Progress Hardship

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/impl/HardshipReviewImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/impl/HardshipReviewImpl.java
@@ -36,7 +36,6 @@ public class HardshipReviewImpl {
     public HardshipReviewEntity create(final HardshipReviewDTO hardshipReviewDTO) {
         HardshipReviewEntity hardshipReview =
                 hardshipReviewMapper.hardshipReviewDTOToHardshipReviewEntity(hardshipReviewDTO);
-                hardshipReviewMapper.hardshipReviewDTOToHardshipReviewEntity(hardshipReviewDTO);
         return hardshipReviewRepository.saveAndFlush(hardshipReview);
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/mapper/HardshipReviewMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/mapper/HardshipReviewMapper.java
@@ -31,6 +31,10 @@ public interface HardshipReviewMapper {
     @Mapping(source = "status", target = "status", qualifiedByName = "mapStatusToHardshipReviewStatusEnum")
     HardshipReviewDTO hardshipReviewEntityToHardshipReviewDTO(final HardshipReviewEntity hardshipReview);
 
+    @InheritInverseConfiguration
+    @Mapping(source = "status", target = "status", qualifiedByName = "mapHardshipReviewStatusEnumToStatus")
+    HardshipReviewEntity hardshipReviewDTOToHardshipReviewEntity(final HardshipReviewDTO hardshipReviewDTO);
+
     @Mapping(source = "detailType", target = "detailType", qualifiedByName = "mapDetailTypeToHardshipReviewDetailTypeEnum")
     HardshipReviewDetail hardshipReviewDetailEntityToHardshipReviewDetail(
             final HardshipReviewDetailEntity reviewDetailEntity
@@ -59,13 +63,18 @@ public interface HardshipReviewMapper {
     @Mapping(target = "valid", source = "valid", defaultValue = "Y")
     HardshipReviewDTO updateHardshipReviewToHardshipReviewDTO(final UpdateHardshipReview hardshipReview);
 
-    @InheritInverseConfiguration
-    HardshipReviewEntity hardshipReviewDTOToHardshipReviewEntity(final HardshipReviewDTO hardshipReviewDTO);
-
     @Named("mapStatusToHardshipReviewStatusEnum")
     default HardshipReviewStatus mapStatusToHardshipReviewStatusEnum(String status) {
         if (status != null) {
             return HardshipReviewStatus.getFrom(status);
+        }
+        return null;
+    }
+
+    @Named("mapHardshipReviewStatusEnumToStatus")
+    default String mapHardshipReviewStatusEnumToStatus(HardshipReviewStatus status) {
+        if (status != null) {
+            return status.getValue();
         }
         return null;
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1526)

- @InheritInverseConfiguration annotation wasn't enough to map hardship status when mapping from DTO to Entity for a Hardship Review so added a custom mapper to help Mapstruct along.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
