### PR TITLE
LCAM 1527 Null Pointer Exception When Building Means Assessor Name in Orchestrator

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/FinancialAssessmentDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/FinancialAssessmentDTO.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.justice.laa.crime.dto.maat.UserDTO;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -62,6 +63,7 @@ public class FinancialAssessmentDTO {
     private LocalDateTime firstReminderDate;
     private LocalDateTime secondReminderDate;
     private LocalDateTime evidenceReceivedDate;
+    private UserDTO userCreatedEntity;
     @Builder.Default
     private List<FinancialAssessmentDetails> assessmentDetails = new ArrayList<>();
     @Builder.Default


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1527)

- UserCreatedEntity was being reference in orchestrator to construct meansAssessorName for the request to CAT service. However whilst this variable is present in the MeansAssessmentDTO object in orchestrator, it isn't in maat-api and so wasn't being returned cause a NPE. I've added this variable to the MeansAssessmentDTO to ensure it is returned.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
