### PR TITLE
LCAM 1528 Hardship Details Not Being Set to Active on Database

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewDetailEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewDetailEntity.java
@@ -78,7 +78,7 @@ public class HardshipReviewDetailEntity {
 
     @Builder.Default
     @Column(name = "ACTIVE")
-    private String active = "N";
+    private String active = "Y";
 
     @Column(name = "REMOVED_DATE")
     private LocalDateTime removedDate;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/model/hardship/HardshipReviewDetail.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/model/hardship/HardshipReviewDetail.java
@@ -1,6 +1,7 @@
 package gov.uk.courtdata.model.hardship;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.uk.courtdata.enums.Frequency;
 import gov.uk.courtdata.enums.HardshipReviewDetailCode;
 import gov.uk.courtdata.enums.HardshipReviewDetailReason;
@@ -32,6 +33,7 @@ public class HardshipReviewDetail {
     private HardshipReviewDetailReason detailReason;
     private LocalDateTime timestamp;
     private String userCreated;
+    private Boolean active;
 
     @JsonIgnore()
     private LocalDateTime dateCreated;
@@ -43,8 +45,6 @@ public class HardshipReviewDetail {
     private String reasonResponse;
     @JsonIgnore
     private String userModified;
-    @JsonIgnore
-    private Boolean active;
     @JsonIgnore
     private LocalDateTime removedDate;
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1528)

- Allowed active for HardshipReviewDetail to be deserialised so that we can pass a value of Y through from the hardship service when creating a hardship review.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
