### PR TITLE
LCAM-1514

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/impl/FinancialAssessmentImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/impl/FinancialAssessmentImpl.java
@@ -162,7 +162,7 @@ public class FinancialAssessmentImpl {
         passportAssessmentRepository.updateAllPreviousPassportAssessmentsAsReplaced(
                 financialAssessment.getRepOrder().getId()
         );
-        hardshipReviewRepository.updateOldHardshipReviews(
+        hardshipReviewRepository.replaceOldHardshipReviews(
                 financialAssessment.getRepOrder().getId(), financialAssessment.getId()
         );
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/impl/PassportAssessmentImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/impl/PassportAssessmentImpl.java
@@ -78,7 +78,7 @@ public class PassportAssessmentImpl {
         financialAssessmentRepository.updateAllPreviousFinancialAssessmentsAsReplaced(
                 passportAssessment.getRepOrder().getId()
         );
-        hardshipReviewRepository.updateOldHardshipReviews(
+        hardshipReviewRepository.replaceOldHardshipReviews(
                 passportAssessment.getRepOrder().getId(), financialAssessmentId
         );
     }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/impl/HardshipReviewImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/impl/HardshipReviewImpl.java
@@ -36,6 +36,9 @@ public class HardshipReviewImpl {
     public HardshipReviewEntity create(final HardshipReviewDTO hardshipReviewDTO) {
         HardshipReviewEntity hardshipReview =
                 hardshipReviewMapper.hardshipReviewDTOToHardshipReviewEntity(hardshipReviewDTO);
+
+        hardshipReviewRepository.replaceOldHardshipReviews(hardshipReview.getRepId(), hardshipReview.getCourtType());
+
         return hardshipReviewRepository.saveAndFlush(hardshipReview);
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/HardshipReviewRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/HardshipReviewRepository.java
@@ -15,6 +15,10 @@ public interface HardshipReviewRepository extends JpaRepository<HardshipReviewEn
     @Query(value = "UPDATE HardshipReviewEntity hr set hr.replaced = 'Y' WHERE hr.repId = :repId and hr.financialAssessmentId <> :financialAssessmentId")
     void replaceOldHardshipReviews(@Param("repId") Integer repId, @Param("financialAssessmentId") Integer financialAssessmentId);
 
+    @Modifying
+    @Query(value = "UPDATE HardshipReviewEntity hr set hr.replaced = 'Y' WHERE hr.repId = :repId and hr.courtType = :courtType")
+    void replaceOldHardshipReviews(@Param("repId") Integer repId, @Param("courtType") String courtType);
+
     @Query(value = "SELECT hr FROM HardshipReviewEntity hr WHERE hr.repId = :repId AND hr.replaced = 'N'")
     HardshipReviewEntity findByRepId(@Param("repId") Integer repId);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/HardshipReviewRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/HardshipReviewRepository.java
@@ -10,9 +10,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HardshipReviewRepository extends JpaRepository<HardshipReviewEntity, Integer>, JpaSpecificationExecutor<HardshipReviewEntity> {
+
     @Modifying
     @Query(value = "UPDATE HardshipReviewEntity hr set hr.replaced = 'Y' WHERE hr.repId = :repId and hr.financialAssessmentId <> :financialAssessmentId")
-    void updateOldHardshipReviews(@Param("repId") Integer repId, @Param("financialAssessmentId") Integer financialAssessmentId);
+    void replaceOldHardshipReviews(@Param("repId") Integer repId, @Param("financialAssessmentId") Integer financialAssessmentId);
 
     @Query(value = "SELECT hr FROM HardshipReviewEntity hr WHERE hr.repId = :repId AND hr.replaced = 'N'")
     HardshipReviewEntity findByRepId(@Param("repId") Integer repId);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/impl/FinancialAssessmentImplTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/impl/FinancialAssessmentImplTest.java
@@ -166,7 +166,7 @@ class FinancialAssessmentImplTest {
 
         Integer repId = financialAssessment.getRepOrder().getId();
 
-        verify(hardshipReviewRepository).updateOldHardshipReviews(repId, MOCK_FINANCIAL_ASSESSMENT_ID);
+        verify(hardshipReviewRepository).replaceOldHardshipReviews(repId, MOCK_FINANCIAL_ASSESSMENT_ID);
         verify(passportAssessmentRepository).updateAllPreviousPassportAssessmentsAsReplaced(repId);
         verify(financialAssessmentRepository).updatePreviousFinancialAssessmentsAsReplaced(repId, MOCK_FINANCIAL_ASSESSMENT_ID);
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/impl/HardshipReviewImplTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/impl/HardshipReviewImplTest.java
@@ -88,6 +88,9 @@ class HardshipReviewImplTest {
 
         hardshipReviewImpl.create(hardshipReviewDTO);
         verify(hardshipReviewRepository).saveAndFlush(hardshipReviewEntityArgumentCaptor.capture());
+        verify(hardshipReviewRepository).replaceOldHardshipReviews(
+                TestEntityDataBuilder.REP_ID, hardshipReviewDTO.getCourtType()
+        );
         assertThat(hardshipReviewEntityArgumentCaptor.getValue().getId())
                 .isEqualTo(hardshipReviewDTO.getId());
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1514)

- Introduced a new method `replaceOldHardshipReviews` in the `HardshipReviewRepository` which marks existing Hardship Reviews as replaced in the DB when creating a fresh review.
  - This will prevent the reoccurrence of an issue preventing applications from being opened in MAAT because there are multiple active Hardships stored against the record in the DB.
  - This mimics the behaviour already in place for replacing existing financial assessments.
- Updated test case to verify the new method is invoked as expected.
- Renamed existing method `updateOldHardshipReviews` to better reflect it's purpose.
