### PR TITLE
LCAM 1536 Null Pointer Exception Updating Hardship With No Solicitors Costs

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/impl/HardshipReviewImpl.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/hardship/impl/HardshipReviewImpl.java
@@ -52,17 +52,26 @@ public class HardshipReviewImpl {
         existing.setReviewDate(hardshipReviewDTO.getReviewDate());
         existing.setNotes(hardshipReviewDTO.getNotes());
         existing.setDecisionNotes(hardshipReviewDTO.getDecisionNotes());
-        existing.setSolicitorRate(hardshipReviewDTO.getSolicitorCosts().getRate());
-        existing.setSolicitorHours(hardshipReviewDTO.getSolicitorCosts().getHours());
-        existing.setSolicitorVat(hardshipReviewDTO.getSolicitorCosts().getVat());
-        existing.setSolicitorDisb(hardshipReviewDTO.getSolicitorCosts().getDisbursements());
-        existing.setSolicitorEstTotalCost(hardshipReviewDTO.getSolicitorCosts().getEstimatedTotal());
         existing.setDisposableIncome(hardshipReviewDTO.getDisposableIncome());
         existing.setDisposableIncomeAfterHardship(hardshipReviewDTO.getDisposableIncomeAfterHardship());
         existing.setStatus(hardshipReviewDTO.getStatus().getStatus());
         existing.setUserModified(hardshipReviewDTO.getUserModified());
         existing.setNewWorkReason(
                 hardshipReviewMapper.newWorkReasonToNewWorkReasonEntity(hardshipReviewDTO.getNewWorkReason()));
+
+        if (hardshipReviewDTO.getSolicitorCosts() == null) {
+            existing.setSolicitorRate(null);
+            existing.setSolicitorHours(null);
+            existing.setSolicitorVat(null);
+            existing.setSolicitorDisb(null);
+            existing.setSolicitorEstTotalCost(null);
+        } else {
+            existing.setSolicitorRate(hardshipReviewDTO.getSolicitorCosts().getRate());
+            existing.setSolicitorHours(hardshipReviewDTO.getSolicitorCosts().getHours());
+            existing.setSolicitorVat(hardshipReviewDTO.getSolicitorCosts().getVat());
+            existing.setSolicitorDisb(hardshipReviewDTO.getSolicitorCosts().getDisbursements());
+            existing.setSolicitorEstTotalCost(hardshipReviewDTO.getSolicitorCosts().getEstimatedTotal());
+        }
 
         List<HardshipReviewDetail> detailItems = hardshipReviewDTO.getReviewDetails();
         existing.getReviewDetails().clear();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/impl/HardshipReviewImplTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/impl/HardshipReviewImplTest.java
@@ -149,4 +149,55 @@ class HardshipReviewImplTest {
         softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getNewWorkReason().getCode())
                 .isEqualTo(hardshipReviewDTO.getNewWorkReason().getCode());
     }
+
+    @Test
+    void givenHardshipDTOWithoutSolicitorsCosts_whenUpdateIsInvoked_thenHardshipIsUpdated() {
+        HardshipReviewDTO hardshipReviewDTO = TestModelDataBuilder.getHardshipReviewDTOWithRelationships();
+        hardshipReviewDTO.setSolicitorCosts(null);
+        HardshipReviewEntity mockHardshipEntity = TestEntityDataBuilder.getHardshipReviewEntityWithRelationships();
+        when(hardshipReviewRepository.getReferenceById(any(Integer.class)))
+                .thenReturn(mockHardshipEntity);
+
+        when(hardshipReviewMapper.hardshipReviewDetailToHardshipReviewDetailEntity(any(HardshipReviewDetail.class)))
+                .thenReturn(TestEntityDataBuilder.getHardshipReviewDetailsEntity());
+
+        when(hardshipReviewMapper.hardshipReviewProgressToHardshipReviewProgressEntity(
+                any(HardshipReviewProgress.class)))
+                .thenReturn(TestEntityDataBuilder.getHardshipReviewProgressEntity());
+
+        when(hardshipReviewMapper.newWorkReasonToNewWorkReasonEntity(any(NewWorkReason.class)))
+                .thenReturn(TestEntityDataBuilder.getNewWorkReasonEntity());
+
+        hardshipReviewImpl.update(hardshipReviewDTO);
+
+        verify(hardshipReviewRepository).saveAndFlush(hardshipReviewEntityArgumentCaptor.capture());
+
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getId())
+                .isEqualTo(hardshipReviewDTO.getId());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getCmuId())
+                .isEqualTo(hardshipReviewDTO.getCmuId());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getReviewResult())
+                .isEqualTo(hardshipReviewDTO.getReviewResult());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getResultDate())
+                .isEqualTo(hardshipReviewDTO.getResultDate());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getNotes())
+                .isEqualTo(hardshipReviewDTO.getNotes());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getDecisionNotes())
+                .isEqualTo(hardshipReviewDTO.getDecisionNotes());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getSolicitorRate()).isNull();
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getSolicitorHours()).isNull();
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getSolicitorVat()).isNull();
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getSolicitorDisb()).isNull();
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getSolicitorEstTotalCost()).isNull();
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getDisposableIncome())
+                .isEqualTo(hardshipReviewDTO.getDisposableIncome());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getDisposableIncomeAfterHardship())
+                .isEqualTo(hardshipReviewDTO.getDisposableIncomeAfterHardship());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getStatus())
+                .isEqualTo(hardshipReviewDTO.getStatus().getStatus());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getUserModified())
+                .isEqualTo(hardshipReviewDTO.getUserModified());
+        softly.assertThat(hardshipReviewEntityArgumentCaptor.getValue().getNewWorkReason().getCode())
+                .isEqualTo(hardshipReviewDTO.getNewWorkReason().getCode());
+    }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1536)

- Added a null check to the update hardship review logic to set the appropriate solicitors costs fields in the hardship review entity to null if no solicitors costs have been entered.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
