### PR TITLE
LCAM-1539

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewProgressEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/HardshipReviewProgressEntity.java
@@ -56,7 +56,7 @@ public class HardshipReviewProgressEntity {
 
     @Builder.Default
     @Column(name = "ACTIVE")
-    private String active = "N";
+    private String active = "Y";
 
     @Column(name = "REMOVED_DATE")
     private LocalDateTime removedDate;


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1539)

- Update default value for `active` field in the `HardshipReviewProgressEntity` to `'Y'`
  - Previously, the active field would default to `'N'`, however, this meant progress items were not being displayed in the UI after creation. New records should always be marked as `active` and when performing an update old progress items are deleted and recreated rather than updating the existing rows.
