### PR TITLE
Add feature flag memberships to user summary information

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/FeatureToggleDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/FeatureToggleDTO.java
@@ -1,0 +1,18 @@
+package gov.uk.courtdata.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeatureToggleDTO {
+
+  private Integer id;
+  private String username;
+  private String featureName;
+  private String action;
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/UserSummaryDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/UserSummaryDTO.java
@@ -18,4 +18,5 @@ public class UserSummaryDTO {
     private ReservationsDTO reservationsDTO;
     private String currentUserSession;
     private List<RoleDataItemDTO> roleDataItem;
+    private List<FeatureToggleDTO> featureToggle;
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FeatureToggleEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FeatureToggleEntity.java
@@ -1,0 +1,32 @@
+package gov.uk.courtdata.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Data
+@Table(name = "FEATURE_TOGGLE", schema = "TOGDATA")
+public class FeatureToggleEntity {
+
+  @Id
+  @Column(name = "ID", nullable = false)
+  private Integer id;
+
+  @Column(name = "USER_NAME")
+  private String username;
+
+  @Column(name = "FEATURE")
+  private String featureName;
+
+  @Column(name = "ACTION")
+  private String action;
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FeatureToggleEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FeatureToggleEntity.java
@@ -2,7 +2,10 @@ package gov.uk.courtdata.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +21,8 @@ import lombok.NoArgsConstructor;
 public class FeatureToggleEntity {
 
   @Id
+  @SequenceGenerator(name = "feature_toggle_seq", sequenceName = "ISEQ$$_316195", allocationSize = 1, schema = "TOGDATA")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "feature_toggle_seq")
   @Column(name = "ID", nullable = false)
   private Integer id;
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/mapper/FeatureToggleMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/mapper/FeatureToggleMapper.java
@@ -1,0 +1,22 @@
+package gov.uk.courtdata.mapper;
+
+import gov.uk.courtdata.dto.FeatureToggleDTO;
+import gov.uk.courtdata.entity.FeatureToggleEntity;
+import java.util.List;
+import org.mapstruct.Builder;
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+    componentModel = "spring",
+    unmappedTargetPolicy = ReportingPolicy.IGNORE,
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+    collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED,
+    builder = @Builder(disableBuilder = true)
+)
+public interface FeatureToggleMapper {
+
+  List<FeatureToggleDTO> featureToggleToFeatureToggleDto(final List<FeatureToggleEntity> featureToggleEntity);
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/FeatureToggleRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/FeatureToggleRepository.java
@@ -1,0 +1,15 @@
+package gov.uk.courtdata.repository;
+
+import gov.uk.courtdata.entity.FeatureToggleEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeatureToggleRepository extends JpaRepository<FeatureToggleEntity, Integer> {
+
+  @Query(value = "select ID, USER_NAME, FEATURE, ACTION from TOGDATA.FEATURE_TOGGLE where USER_NAME = :username or USER_NAME is null", nativeQuery = true)
+  List<FeatureToggleEntity> getFeatureTogglesForUser(@Param("username") String username);
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/FeatureToggleRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/FeatureToggleRepository.java
@@ -10,9 +10,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FeatureToggleRepository extends JpaRepository<FeatureToggleEntity, Integer> {
 
-  @Query(value = "select ID, USER_NAME, FEATURE, ACTION from TOGDATA.FEATURE_TOGGLE where USER_NAME = :username", nativeQuery = true)
-  List<FeatureToggleEntity> getFeatureTogglesForUser(@Param("username") String username);
-
-  @Query(value = "select ID, USER_NAME, FEATURE, ACTION from TOGDATA.FEATURE_TOGGLE where USER_NAME is null", nativeQuery = true)
-  List<FeatureToggleEntity> getFeatureTogglesForAllUsers();
+  /**
+   * Gets the feature toggles for a user, which is a combination of user-specific feature toggles,
+   * in addition to those which are applicable to all users through a null username.
+   * @param username The username to get feature toggles for.
+   * @return A list of feature toggles applicable to the user.
+   */
+  @Query(value = "select ID, USER_NAME, FEATURE, ACTION from TOGDATA.FEATURE_TOGGLE where USER_NAME = :username or USER_NAME is null", nativeQuery = true)
+  List<FeatureToggleEntity> getAllFeatureTogglesForUser(@Param("username") String username);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/FeatureToggleRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/FeatureToggleRepository.java
@@ -10,6 +10,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FeatureToggleRepository extends JpaRepository<FeatureToggleEntity, Integer> {
 
-  @Query(value = "select ID, USER_NAME, FEATURE, ACTION from TOGDATA.FEATURE_TOGGLE where USER_NAME = :username or USER_NAME is null", nativeQuery = true)
+  @Query(value = "select ID, USER_NAME, FEATURE, ACTION from TOGDATA.FEATURE_TOGGLE where USER_NAME = :username", nativeQuery = true)
   List<FeatureToggleEntity> getFeatureTogglesForUser(@Param("username") String username);
+
+  @Query(value = "select ID, USER_NAME, FEATURE, ACTION from TOGDATA.FEATURE_TOGGLE where USER_NAME is null", nativeQuery = true)
+  List<FeatureToggleEntity> getFeatureTogglesForAllUsers();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/service/FeatureToggleService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/service/FeatureToggleService.java
@@ -4,7 +4,6 @@ import gov.uk.courtdata.dto.FeatureToggleDTO;
 import gov.uk.courtdata.entity.FeatureToggleEntity;
 import gov.uk.courtdata.mapper.FeatureToggleMapper;
 import gov.uk.courtdata.repository.FeatureToggleRepository;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -18,18 +17,20 @@ public class FeatureToggleService {
   private final FeatureToggleMapper featureToggleMapper;
 
   public List<FeatureToggleDTO> getFeatureTogglesForUser(String username) {
-    List<FeatureToggleEntity> featureToggleEntitiesForUser = featureToggleRepository.getFeatureTogglesForUser(username);
-    List<FeatureToggleEntity> nonOverlappingPublicFeatureToggles = this.getNonOverlappingPublicFeatureToggleEntities(featureToggleEntitiesForUser, username);
+    List<FeatureToggleEntity> allFeatureToggleEntitiesForUser = featureToggleRepository.getAllFeatureTogglesForUser(username);
+    List<FeatureToggleEntity> featureToggleEntitiesForUser = allFeatureToggleEntitiesForUser.stream().filter(e -> username.equals(e.getUsername())).toList();
+
+    List<FeatureToggleEntity> nonOverlappingPublicFeatureToggles = this.getNonOverlappingPublicFeatureToggleEntities(allFeatureToggleEntitiesForUser, featureToggleEntitiesForUser);
 
     return (featureToggleEntitiesForUser.isEmpty() && nonOverlappingPublicFeatureToggles.isEmpty())
         ? null
         : featureToggleMapper.featureToggleToFeatureToggleDto(Stream.concat(featureToggleEntitiesForUser.stream(), nonOverlappingPublicFeatureToggles.stream()).toList());
   }
 
-  private List<FeatureToggleEntity> getNonOverlappingPublicFeatureToggleEntities(List<FeatureToggleEntity> featureToggleEntitiesForUser, String username) {
-    List<FeatureToggleEntity> toggles = featureToggleRepository.getFeatureTogglesForAllUsers();
+  private List<FeatureToggleEntity> getNonOverlappingPublicFeatureToggleEntities(List<FeatureToggleEntity> allFeatureToggleEntitiesForUser, List<FeatureToggleEntity> featureToggleEntitiesForUser) {
+    List<FeatureToggleEntity> publicFeatureToggleEntities = allFeatureToggleEntitiesForUser.stream().filter(t -> t.getUsername() == null).toList();
 
-    return featureToggleRepository.getFeatureTogglesForAllUsers()
+    return publicFeatureToggleEntities
         .stream()
         .filter(e -> featureToggleEntitiesForUser.stream().noneMatch(
             userEntity -> userEntity.getFeatureName().equals(e.getFeatureName()) && userEntity.getAction().equals(e.getAction())))

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/service/FeatureToggleService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/service/FeatureToggleService.java
@@ -1,0 +1,38 @@
+package gov.uk.courtdata.service;
+
+import gov.uk.courtdata.dto.FeatureToggleDTO;
+import gov.uk.courtdata.entity.FeatureToggleEntity;
+import gov.uk.courtdata.mapper.FeatureToggleMapper;
+import gov.uk.courtdata.repository.FeatureToggleRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeatureToggleService {
+
+  private final FeatureToggleRepository featureToggleRepository;
+  private final FeatureToggleMapper featureToggleMapper;
+
+  public List<FeatureToggleDTO> getFeatureTogglesForUser(String username) {
+    List<FeatureToggleEntity> featureToggleEntitiesForUser = featureToggleRepository.getFeatureTogglesForUser(username);
+    List<FeatureToggleEntity> nonOverlappingPublicFeatureToggles = this.getNonOverlappingPublicFeatureToggleEntities(featureToggleEntitiesForUser, username);
+
+    return (featureToggleEntitiesForUser.isEmpty() && nonOverlappingPublicFeatureToggles.isEmpty())
+        ? null
+        : featureToggleMapper.featureToggleToFeatureToggleDto(Stream.concat(featureToggleEntitiesForUser.stream(), nonOverlappingPublicFeatureToggles.stream()).toList());
+  }
+
+  private List<FeatureToggleEntity> getNonOverlappingPublicFeatureToggleEntities(List<FeatureToggleEntity> featureToggleEntitiesForUser, String username) {
+    List<FeatureToggleEntity> toggles = featureToggleRepository.getFeatureTogglesForAllUsers();
+
+    return featureToggleRepository.getFeatureTogglesForAllUsers()
+        .stream()
+        .filter(e -> featureToggleEntitiesForUser.stream().noneMatch(
+            userEntity -> userEntity.getFeatureName().equals(e.getFeatureName()) && userEntity.getAction().equals(e.getAction())))
+        .toList();
+  }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/users/mapper/UserSummaryMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/users/mapper/UserSummaryMapper.java
@@ -1,5 +1,6 @@
 package gov.uk.courtdata.users.mapper;
 
+import gov.uk.courtdata.dto.FeatureToggleDTO;
 import gov.uk.courtdata.dto.ReservationsDTO;
 import gov.uk.courtdata.dto.RoleDataItemDTO;
 import gov.uk.courtdata.dto.UserSummaryDTO;
@@ -19,10 +20,12 @@ public interface UserSummaryMapper {
     @Mapping(target = "username", source = "username")
     @Mapping(target = "reservationsDTO", source = "reservationsDTO")
     @Mapping(target = "roleDataItem", source = "roleDataItem")
+    @Mapping(target = "featureToggle", source = "featureToggle")
     UserSummaryDTO userToUserSummaryDTO(final String username,
                                         final List<String> newWorkReasons,
                                         final List<String> roleActions,
                                         final ReservationsDTO reservationsDTO,
                                         final String currentUserSession,
-                                        final List<RoleDataItemDTO> roleDataItem);
+                                        final List<RoleDataItemDTO> roleDataItem,
+                                        final List<FeatureToggleDTO> featureToggle);
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/users/service/UserSummaryService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/users/service/UserSummaryService.java
@@ -1,15 +1,19 @@
 package gov.uk.courtdata.users.service;
 
+import gov.uk.courtdata.dto.FeatureToggleDTO;
 import gov.uk.courtdata.dto.ReservationsDTO;
 import gov.uk.courtdata.dto.RoleDataItemDTO;
 import gov.uk.courtdata.dto.UserSummaryDTO;
+import gov.uk.courtdata.entity.FeatureToggleEntity;
 import gov.uk.courtdata.entity.ReservationsEntity;
 import gov.uk.courtdata.entity.RoleDataItemEntity;
 import gov.uk.courtdata.entity.UserEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
+import gov.uk.courtdata.mapper.FeatureToggleMapper;
 import gov.uk.courtdata.mapper.ReservationsMapper;
 import gov.uk.courtdata.mapper.RoleDataItemsMapper;
 import gov.uk.courtdata.helper.ReservationsRepositoryHelper;
+import gov.uk.courtdata.repository.FeatureToggleRepository;
 import gov.uk.courtdata.repository.RoleActionsRepository;
 import gov.uk.courtdata.repository.RoleDataItemsRepository;
 import gov.uk.courtdata.repository.RoleWorkReasonsRepository;
@@ -37,7 +41,8 @@ public class UserSummaryService {
     private final RoleDataItemsRepository roleDataItemsRepository;
     private final RoleDataItemsMapper roleDataItemsMapper;
     private final ReservationsMapper reservationsMapper;
-
+    private final FeatureToggleRepository featureToggleRepository;
+    private final FeatureToggleMapper featureToggleMapper;
 
     public UserSummaryDTO getUserSummary(String username) {
 
@@ -54,9 +59,12 @@ public class UserSummaryService {
         Optional<ReservationsEntity> reservations = reservationsRepositoryHelper.getReservationByUserName(username);
         ReservationsDTO reservationsDTO = reservations.isEmpty() ? null : reservationsMapper.reservationsEntitytoDTO(reservations.get());
 
+        List<FeatureToggleEntity> featureToggleEntities = featureToggleRepository.getFeatureTogglesForUser(username);
+        List<FeatureToggleDTO> featureToggleDtos = featureToggleEntities.isEmpty() ? null: featureToggleMapper.featureToggleToFeatureToggleDto(featureToggleEntities);
+
         Optional<UserEntity> userEntity = userRepository.findById(username);
         String currentUserSession = userEntity.isEmpty() ? null : userEntity.get().getCurrentSession();
-        return userSummaryMapper.userToUserSummaryDTO(username, newWorkReasonForUser, userRoleActions, reservationsDTO, currentUserSession, roleDataItemDTOList);
+        return userSummaryMapper.userToUserSummaryDTO(username, newWorkReasonForUser, userRoleActions, reservationsDTO, currentUserSession, roleDataItemDTOList, featureToggleDtos);
     }
 
     public UserEntity getUser(String username) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/users/service/UserSummaryService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/users/service/UserSummaryService.java
@@ -4,20 +4,18 @@ import gov.uk.courtdata.dto.FeatureToggleDTO;
 import gov.uk.courtdata.dto.ReservationsDTO;
 import gov.uk.courtdata.dto.RoleDataItemDTO;
 import gov.uk.courtdata.dto.UserSummaryDTO;
-import gov.uk.courtdata.entity.FeatureToggleEntity;
 import gov.uk.courtdata.entity.ReservationsEntity;
 import gov.uk.courtdata.entity.RoleDataItemEntity;
 import gov.uk.courtdata.entity.UserEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
-import gov.uk.courtdata.mapper.FeatureToggleMapper;
 import gov.uk.courtdata.mapper.ReservationsMapper;
 import gov.uk.courtdata.mapper.RoleDataItemsMapper;
 import gov.uk.courtdata.helper.ReservationsRepositoryHelper;
-import gov.uk.courtdata.repository.FeatureToggleRepository;
 import gov.uk.courtdata.repository.RoleActionsRepository;
 import gov.uk.courtdata.repository.RoleDataItemsRepository;
 import gov.uk.courtdata.repository.RoleWorkReasonsRepository;
 import gov.uk.courtdata.repository.UserRepository;
+import gov.uk.courtdata.service.FeatureToggleService;
 import gov.uk.courtdata.users.mapper.UserSummaryMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,8 +39,7 @@ public class UserSummaryService {
     private final RoleDataItemsRepository roleDataItemsRepository;
     private final RoleDataItemsMapper roleDataItemsMapper;
     private final ReservationsMapper reservationsMapper;
-    private final FeatureToggleRepository featureToggleRepository;
-    private final FeatureToggleMapper featureToggleMapper;
+    private final FeatureToggleService featureToggleService;
 
     public UserSummaryDTO getUserSummary(String username) {
 
@@ -59,8 +56,7 @@ public class UserSummaryService {
         Optional<ReservationsEntity> reservations = reservationsRepositoryHelper.getReservationByUserName(username);
         ReservationsDTO reservationsDTO = reservations.isEmpty() ? null : reservationsMapper.reservationsEntitytoDTO(reservations.get());
 
-        List<FeatureToggleEntity> featureToggleEntities = featureToggleRepository.getFeatureTogglesForUser(username);
-        List<FeatureToggleDTO> featureToggleDtos = featureToggleEntities.isEmpty() ? null: featureToggleMapper.featureToggleToFeatureToggleDto(featureToggleEntities);
+        List<FeatureToggleDTO> featureToggleDtos = featureToggleService.getFeatureTogglesForUser(username);
 
         Optional<UserEntity> userEntity = userRepository.findById(username);
         String currentUserSession = userEntity.isEmpty() ? null : userEntity.get().getCurrentSession();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/users/UserSummaryControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/users/UserSummaryControllerIntegrationTest.java
@@ -104,7 +104,7 @@ public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest
     repos.featureToggleRepository.save(FeatureToggleEntity.builder()
         .id(1)
         .username(VALID_TEST_USER)
-        .featureName("Test feature")
+        .featureName("Test feature 1")
         .action("Create")
         .build());
 
@@ -148,6 +148,54 @@ public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest
         .andExpect(jsonPath("$.reservationsDTO").doesNotExist())
         .andExpect(jsonPath("$.featureToggle").doesNotExist())
         .andExpect(jsonPath("$.username").value(INVALID_TEST_USER));
+  }
 
+  @Test
+  public void givenMultipleMatchingFeatureToggles_whenGetUserSummaryIsInvoked_thenPrioritisesUserSpecificToggles()
+      throws Exception {
+    repos.featureToggleRepository.save(FeatureToggleEntity.builder()
+        .id(0)
+        .username(VALID_TEST_USER)
+        .featureName("Test feature 0")
+        .action("Create")
+        .build());
+    // Public version of the same feature flag already specified for the user, should be ignored.
+    repos.featureToggleRepository.save(FeatureToggleEntity.builder()
+        .id(2)
+        .featureName("Test feature 1")
+        .action("Create")
+        .build());
+    repos.featureToggleRepository.save(FeatureToggleEntity.builder()
+        .id(3)
+        .featureName("Test feature 1")
+        .action("Update")
+        .build());
+    repos.featureToggleRepository.save(FeatureToggleEntity.builder()
+        .id(4)
+        .featureName("Test feature 2")
+        .action("Create")
+        .build());
+
+    mvc.perform(MockMvcRequestBuilders.get(GET_USER_SUMMARY_URL, VALID_TEST_USER))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.roleActions[0]").value(DISABLED_ACTION))
+        .andExpect(jsonPath("$.newWorkReasons[0]").value(VALID_NWORCODE))
+        .andExpect(jsonPath("$.reservationsDTO.recordId").value(VALID_RESERVATION_ID))
+        .andExpect(jsonPath("$.roleDataItem[0].roleName").value(AUTHORISED_ROLE))
+        .andExpect(jsonPath("$.featureToggle.length()").value(4))
+        .andExpect(jsonPath("$.featureToggle[0].username").value(VALID_TEST_USER))
+        .andExpect(jsonPath("$.featureToggle[0].featureName").value("Test feature 0"))
+        .andExpect(jsonPath("$.featureToggle[0].action").value("Create"))
+        .andExpect(jsonPath("$.featureToggle[1].username").value(VALID_TEST_USER))
+        .andExpect(jsonPath("$.featureToggle[1].featureName").value("Test feature 1"))
+        .andExpect(jsonPath("$.featureToggle[1].action").value("Create"))
+        .andExpect(jsonPath("$.featureToggle[2].username").doesNotExist())
+        .andExpect(jsonPath("$.featureToggle[2].featureName").value("Test feature 1"))
+        .andExpect(jsonPath("$.featureToggle[2].action").value("Update"))
+        .andExpect(jsonPath("$.featureToggle[3].username").doesNotExist())
+        .andExpect(jsonPath("$.featureToggle[3].featureName").value("Test feature 2"))
+        .andExpect(jsonPath("$.featureToggle[3].action").value("Create"))
+        .andExpect(jsonPath("$.username").value(VALID_TEST_USER));
   }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/users/UserSummaryControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/users/UserSummaryControllerIntegrationTest.java
@@ -5,6 +5,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import gov.uk.MAATCourtDataApplication;
+import gov.uk.courtdata.builder.TestModelDataBuilder;
+import gov.uk.courtdata.entity.FeatureToggleEntity;
 import gov.uk.courtdata.entity.ReservationsEntity;
 import gov.uk.courtdata.entity.RoleActionEntity;
 import gov.uk.courtdata.entity.RoleDataItemEntity;
@@ -99,6 +101,13 @@ public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest
         .expiryDate(expiryDate)
         .build());
 
+    repos.featureToggleRepository.save(FeatureToggleEntity.builder()
+        .id(1)
+        .username(VALID_TEST_USER)
+        .featureName("Test feature")
+        .action("Create")
+        .build());
+
     repos.user.save(UserEntity.builder()
         .username(VALID_TEST_USER)
         .currentSession(VALID_SESSION_ID)
@@ -124,6 +133,7 @@ public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest
         .andExpect(jsonPath("$.newWorkReasons[0]").value(VALID_NWORCODE))
         .andExpect(jsonPath("$.reservationsDTO.recordId").value(VALID_RESERVATION_ID))
         .andExpect(jsonPath("$.roleDataItem[0].roleName").value(AUTHORISED_ROLE))
+        .andExpect(jsonPath("$.featureToggle[0].username").value(VALID_TEST_USER))
         .andExpect(jsonPath("$.username").value(VALID_TEST_USER));
   }
 
@@ -136,6 +146,7 @@ public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest
         .andExpect(jsonPath("$.roleActions").isEmpty())
         .andExpect(jsonPath("$.newWorkReasons").isEmpty())
         .andExpect(jsonPath("$.reservationsDTO").doesNotExist())
+        .andExpect(jsonPath("$.featureToggle").doesNotExist())
         .andExpect(jsonPath("$.username").value(INVALID_TEST_USER));
 
   }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/users/UserSummaryControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/users/UserSummaryControllerIntegrationTest.java
@@ -102,7 +102,6 @@ public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest
         .build());
 
     repos.featureToggleRepository.save(FeatureToggleEntity.builder()
-        .id(1)
         .username(VALID_TEST_USER)
         .featureName("Test feature 1")
         .action("Create")
@@ -154,25 +153,21 @@ public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest
   public void givenMultipleMatchingFeatureToggles_whenGetUserSummaryIsInvoked_thenPrioritisesUserSpecificToggles()
       throws Exception {
     repos.featureToggleRepository.save(FeatureToggleEntity.builder()
-        .id(0)
         .username(VALID_TEST_USER)
-        .featureName("Test feature 0")
+        .featureName("Test feature 2")
         .action("Create")
         .build());
     // Public version of the same feature flag already specified for the user, should be ignored.
     repos.featureToggleRepository.save(FeatureToggleEntity.builder()
-        .id(2)
         .featureName("Test feature 1")
         .action("Create")
         .build());
     repos.featureToggleRepository.save(FeatureToggleEntity.builder()
-        .id(3)
         .featureName("Test feature 1")
         .action("Update")
         .build());
     repos.featureToggleRepository.save(FeatureToggleEntity.builder()
-        .id(4)
-        .featureName("Test feature 2")
+        .featureName("Test feature 3")
         .action("Create")
         .build());
 
@@ -185,16 +180,16 @@ public class UserSummaryControllerIntegrationTest extends MockMvcIntegrationTest
         .andExpect(jsonPath("$.roleDataItem[0].roleName").value(AUTHORISED_ROLE))
         .andExpect(jsonPath("$.featureToggle.length()").value(4))
         .andExpect(jsonPath("$.featureToggle[0].username").value(VALID_TEST_USER))
-        .andExpect(jsonPath("$.featureToggle[0].featureName").value("Test feature 0"))
+        .andExpect(jsonPath("$.featureToggle[0].featureName").value("Test feature 1"))
         .andExpect(jsonPath("$.featureToggle[0].action").value("Create"))
         .andExpect(jsonPath("$.featureToggle[1].username").value(VALID_TEST_USER))
-        .andExpect(jsonPath("$.featureToggle[1].featureName").value("Test feature 1"))
+        .andExpect(jsonPath("$.featureToggle[1].featureName").value("Test feature 2"))
         .andExpect(jsonPath("$.featureToggle[1].action").value("Create"))
         .andExpect(jsonPath("$.featureToggle[2].username").doesNotExist())
         .andExpect(jsonPath("$.featureToggle[2].featureName").value("Test feature 1"))
         .andExpect(jsonPath("$.featureToggle[2].action").value("Update"))
         .andExpect(jsonPath("$.featureToggle[3].username").doesNotExist())
-        .andExpect(jsonPath("$.featureToggle[3].featureName").value("Test feature 2"))
+        .andExpect(jsonPath("$.featureToggle[3].featureName").value("Test feature 3"))
         .andExpect(jsonPath("$.featureToggle[3].action").value("Create"))
         .andExpect(jsonPath("$.username").value(VALID_TEST_USER));
   }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
@@ -26,6 +26,7 @@ import gov.uk.courtdata.repository.DefendantMAATDataRepository;
 import gov.uk.courtdata.repository.DefendantRepository;
 import gov.uk.courtdata.repository.FdcContributionsRepository;
 import gov.uk.courtdata.repository.FdcItemsRepository;
+import gov.uk.courtdata.repository.FeatureToggleRepository;
 import gov.uk.courtdata.repository.FinancialAssessmentDetailsHistoryRepository;
 import gov.uk.courtdata.repository.FinancialAssessmentDetailsRepository;
 import gov.uk.courtdata.repository.FinancialAssessmentRepository;
@@ -140,6 +141,9 @@ public class Repositories {
 
   @Autowired
   public FdcItemsRepository fdcItemsRepository;
+
+  @Autowired
+  public FeatureToggleRepository featureToggleRepository;
 
   @Autowired
   public FinancialAssessmentDetailsHistoryRepository financialAssessmentDetailsHistory;
@@ -297,6 +301,7 @@ public class Repositories {
         defendant,
         eformStaging,
         fdcContributions,
+        featureToggleRepository,
         financialAssessmentDetailsHistory,
         financialAssessmentDetails,
         financialAssessment,

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/users/service/UserSummaryServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/users/service/UserSummaryServiceTest.java
@@ -11,6 +11,7 @@ import gov.uk.courtdata.repository.RoleActionsRepository;
 import gov.uk.courtdata.repository.RoleDataItemsRepository;
 import gov.uk.courtdata.repository.RoleWorkReasonsRepository;
 import gov.uk.courtdata.repository.UserRepository;
+import gov.uk.courtdata.service.FeatureToggleService;
 import gov.uk.courtdata.users.mapper.UserSummaryMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,7 +47,7 @@ class UserSummaryServiceTest {
     @Mock
     private RoleDataItemsRepository roleDataItemsRepository;
     @Mock
-    private FeatureToggleRepository featureToggleRepository;
+    private FeatureToggleService featureToggleService;
 
     @Test
     void whenGetUserSummaryIsInvoked_thenUserSummaryDTOIsReturned() {
@@ -54,7 +55,7 @@ class UserSummaryServiceTest {
         verify(roleActionsRepository).getRoleActionsForUser(any());
         verify(roleWorkReasonsRepository).getNewWorkReasonForUser(any());
         verify(roleDataItemsRepository).getRoleDataItemsForUser(any());
-        verify(featureToggleRepository).getFeatureTogglesForUser(any());
+        verify(featureToggleService).getFeatureTogglesForUser(any());
         verify(reservationsRepositoryHelper).getReservationByUserName(any());
         verify(userRepository).findById(any());
         verify(userSummaryMapper).userToUserSummaryDTO(any(), any(), any(), any(), any(), any(), any());

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/users/service/UserSummaryServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/users/service/UserSummaryServiceTest.java
@@ -6,6 +6,7 @@ import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.entity.UserEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.helper.ReservationsRepositoryHelper;
+import gov.uk.courtdata.repository.FeatureToggleRepository;
 import gov.uk.courtdata.repository.RoleActionsRepository;
 import gov.uk.courtdata.repository.RoleDataItemsRepository;
 import gov.uk.courtdata.repository.RoleWorkReasonsRepository;
@@ -44,7 +45,8 @@ class UserSummaryServiceTest {
     private UserRepository userRepository;
     @Mock
     private RoleDataItemsRepository roleDataItemsRepository;
-
+    @Mock
+    private FeatureToggleRepository featureToggleRepository;
 
     @Test
     void whenGetUserSummaryIsInvoked_thenUserSummaryDTOIsReturned() {
@@ -52,9 +54,10 @@ class UserSummaryServiceTest {
         verify(roleActionsRepository).getRoleActionsForUser(any());
         verify(roleWorkReasonsRepository).getNewWorkReasonForUser(any());
         verify(roleDataItemsRepository).getRoleDataItemsForUser(any());
+        verify(featureToggleRepository).getFeatureTogglesForUser(any());
         verify(reservationsRepositoryHelper).getReservationByUserName(any());
         verify(userRepository).findById(any());
-        verify(userSummaryMapper).userToUserSummaryDTO(any(), any(), any(), any(), any(), any());
+        verify(userSummaryMapper).userToUserSummaryDTO(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
This PR adds feature flag memberships to the user summary information, both for user-specific memberships and for those which apply to all users.

This update is made to allow for changes in services which use feature flags to control logic and specifically, to remove the need to pass feature flag information between services (such as between MAAT and the Orchestration Service). The feature flag information is added specifically to the `UserSummaryDTO` as this is the most appropriate place to hold this information, similar to that held already for role data items.

[Part of LCAM-1342](https://dsdmoj.atlassian.net/browse/LCAM-1342)
