### PR TITLE
LCAM-1585|Fix the Applicant create functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If the command is not found, [follow the steps on the 1Password developer docs t
 Once you're ready to run the application:
 
 ```sh
-./startup-local.sh
+./start-local.sh
 ```
 
 ### DB Configuration

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/applicant/controller/ApplicantController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/applicant/controller/ApplicantController.java
@@ -1,6 +1,7 @@
 package gov.uk.courtdata.applicant.controller;
 
 import gov.uk.courtdata.annotation.NotFoundApiResponse;
+import gov.uk.courtdata.annotation.StandardApiResponse;
 import gov.uk.courtdata.annotation.StandardApiResponseCodes;
 import gov.uk.courtdata.applicant.dto.ApplicantHistoryDTO;
 import gov.uk.courtdata.applicant.dto.RepOrderApplicantLinksDTO;
@@ -13,10 +14,12 @@ import gov.uk.courtdata.applicant.validator.ApplicantValidationProcessor;
 import gov.uk.courtdata.entity.Applicant;
 import gov.uk.courtdata.enums.LoggingData;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -30,6 +33,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -130,11 +136,17 @@ public class ApplicantController {
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Create a Applicant record")
-    @StandardApiResponseCodes
+    @StandardApiResponse
+    @NotFoundApiResponse
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Created Applicant record",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Applicant.class)))
+    })
     public ResponseEntity<Applicant> createApplicant(@RequestBody @Valid Applicant applicant) {
         log.info("Create Applicant Request Received");
-        applicantService.create(applicant);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(applicantService.create(applicant));
     }
 
     @PutMapping(value = "/update-cclf", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/applicant/service/ApplicantService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/applicant/service/ApplicantService.java
@@ -51,9 +51,9 @@ public class ApplicantService {
         applicantRepository.deleteById(id);
     }
 
-    public void create(Applicant applicant) {
+    public Applicant create(Applicant applicant) {
         log.info("ApplicantService::create - Start");
-        applicantRepository.saveAndFlush(applicant);
+        return applicantRepository.saveAndFlush(applicant);
     }
 
     public void updateSendToCCLF(SendToCCLFDTO sendToCCLFDTO) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/Applicant.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/Applicant.java
@@ -2,9 +2,13 @@ package gov.uk.courtdata.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,6 +22,8 @@ import java.time.LocalDateTime;
 @Table(name = "APPLICANTS", schema = "TOGDATA")
 public class Applicant {
     @Id
+    @SequenceGenerator(name = "applicants_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "applicants_gen_seq")
     @Column(name = "ID", nullable = false)
     private Integer id;
 
@@ -66,6 +72,7 @@ public class Applicant {
     @Column(name = "SEND_TO_CCLF", length = 1)
     private String sendToCclf;
 
+    @CreationTimestamp
     @Column(name = "DATE_CREATED", nullable = false)
     private LocalDateTime dateCreated;
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/controller/ApplicantControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/controller/ApplicantControllerTest.java
@@ -20,11 +20,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.MediaType;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.util.HashMap;
 import java.util.List;
 
 import static gov.uk.courtdata.builder.TestModelDataBuilder.REP_ID;
@@ -199,7 +197,6 @@ public class ApplicantControllerTest {
                 .andExpect(jsonPath("$.code").value(ErrorCodes.DB_ERROR));
     }
 
-
     @Test
     void givenValidRequest_whenUpdateApplicantIsInvoked_thenUpdateIsSuccess() throws Exception {
         mvc.perform(MockMvcRequestBuilders.patch(ENDPOINT_URL + "/" + ID)
@@ -343,7 +340,6 @@ public class ApplicantControllerTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value(ErrorCodes.DB_ERROR));
     }
-
 
     @Test
     void givenValidRequest_whenUpdateSendToCCLFIsInvoked_thenUpdateIsSuccess() throws Exception {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/service/ApplicantServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/service/ApplicantServiceTest.java
@@ -40,25 +40,23 @@ public class ApplicantServiceTest {
 
     @Test
     void givenAValidInput_whenFindIsInvoked_thenShouldReturnApplicantDTO() {
-        when(applicantRepository.findById(anyInt())).thenReturn(Optional.of(Applicant.builder().id(1).build()));
-        applicantService.find(1);
-        verify(applicantRepository, atLeastOnce()).findById(1);
+        when(applicantRepository.findById(anyInt())).thenReturn(Optional.of(Applicant.builder().id(ID).build()));
+        applicantService.find(ID);
+        verify(applicantRepository, atLeastOnce()).findById(ID);
     }
 
     @Test
     void givenApplicantNotFound_whenFindIsInvoked_thenExceptionIsRaised() {
-        assertThatThrownBy(() -> {
-            applicantService.find(1);
-        }).isInstanceOf(RequestedObjectNotFoundException.class)
+        assertThatThrownBy(() -> applicantService.find(ID)).isInstanceOf(RequestedObjectNotFoundException.class)
                 .hasMessageContaining("Applicant not found for id ");
     }
 
     @Test
     void givenAValidInput_whenUpdateIsInvoked_thenUpdateIsSuccess() {
-        when(applicantRepository.findById(anyInt())).thenReturn(Optional.of(Applicant.builder().id(1).build()));
+        when(applicantRepository.findById(anyInt())).thenReturn(Optional.of(Applicant.builder().id(ID).build()));
         HashMap<String, Object> inputMap = new HashMap<>();
         inputMap.put("email", "test@test.co");
-        applicantService.update(1, inputMap);
+        applicantService.update(ID, inputMap);
         verify(applicantRepository, atLeastOnce()).findById(any());
         verify(applicantRepository, atLeastOnce()).save(any());
     }
@@ -66,13 +64,13 @@ public class ApplicantServiceTest {
 
     @Test
     void givenAValidInput_whenCreateIsInvoked_thenCreateIsSuccess() {
-        applicantService.create(Applicant.builder().id(1).build());
+        applicantService.create(Applicant.builder().build());
         verify(applicantRepository, atLeastOnce()).saveAndFlush(any());
     }
 
     @Test
     void givenAValidInput_whenDeleteIsInvoked_thenDeleteIsSuccess() {
-        applicantService.delete(1);
+        applicantService.delete(ID);
         verify(applicantRepository, atLeastOnce()).deleteById(any());
     }
 
@@ -80,8 +78,8 @@ public class ApplicantServiceTest {
     void givenAValidInput_whenUpdateSendToCCLFIsInvoked_thenUpdateIsSuccess() {
         doNothing().when(repOrderService).update(any(), any());
         doNothing().when(applicantHistoryService).update(any(), any());
-        when(applicantRepository.findById(anyInt())).thenReturn(Optional.of(Applicant.builder().id(1).build()));
-        SendToCCLFDTO sendToCCLFDTO = SendToCCLFDTO.builder().applId(1).repId(1).applHistoryId(1).build();
+        when(applicantRepository.findById(anyInt())).thenReturn(Optional.of(Applicant.builder().id(ID).build()));
+        SendToCCLFDTO sendToCCLFDTO = SendToCCLFDTO.builder().applId(ID).repId(ID).applHistoryId(ID).build();
         applicantService.updateSendToCCLF(sendToCCLFDTO);
         verify(repOrderService, atLeastOnce()).update(any(), any());
         verify(applicantHistoryService, atLeastOnce()).update(any(), any());


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1585)

Update the Applicant create end point to ensure that an applicant is created using the correct sequence as per the current DB and returning the created applicant to the client so that the client will have the generated Applicant ID.

Tidied up the tests; and updated README with the correct script used to run the application locally.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.