### PR TITLE
LCAM-1612|Do not update 'Mandatory' field on Income Evidence

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/mapper/FinancialAssessmentMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/assessment/mapper/FinancialAssessmentMapper.java
@@ -56,6 +56,7 @@ public interface FinancialAssessmentMapper {
     ChildWeightings childWeightingsEntityToChildWeightings(final ChildWeightingsEntity childWeightingsEntity);
 
     @Mapping(target = "active", defaultValue = "Y")
+    @Mapping(target = "mandatory", ignore = true)
     FinAssIncomeEvidenceEntity finAssIncomeEvidenceDTOToFinAssIncomeEvidenceEntity(final FinAssIncomeEvidenceDTO finAssIncomeEvidenceDTO);
 
     FinAssIncomeEvidenceDTO finAssIncomeEvidenceEntityToFinAssIncomeEvidenceDTO(final FinAssIncomeEvidenceEntity finAssIncomeEvidenceEntity);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/mapper/FinancialAssessmentMapperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/mapper/FinancialAssessmentMapperTest.java
@@ -2,11 +2,13 @@ package gov.uk.courtdata.assessment.mapper;
 
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.dto.AssessorDetails;
+import gov.uk.courtdata.entity.FinAssIncomeEvidenceEntity;
 import gov.uk.courtdata.entity.FinancialAssessmentEntity;
 import gov.uk.courtdata.entity.UserEntity;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FinancialAssessmentMapperTest {
@@ -24,5 +26,12 @@ class FinancialAssessmentMapperTest {
 
         assertEquals("Karen Greaves", meansAssessorDetails.getFullName());
         assertEquals(userName, meansAssessorDetails.getUserName());
+    }
+
+    @Test
+    void shouldRetainMandatoryField() {
+        FinAssIncomeEvidenceEntity finAssIncomeEvidenceEntity =
+                financialAssessmentMapper.finAssIncomeEvidenceDTOToFinAssIncomeEvidenceEntity(TestEntityDataBuilder.getFinAssIncomeEvidenceDTO());
+        assertThat(finAssIncomeEvidenceEntity.getMandatory()).isNull();
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -3,6 +3,7 @@ package gov.uk.courtdata.builder;
 import gov.uk.courtdata.applicant.entity.ApplicantDisabilitiesEntity;
 import gov.uk.courtdata.applicant.entity.ApplicantHistoryEntity;
 import gov.uk.courtdata.applicant.entity.RepOrderApplicantLinksEntity;
+import gov.uk.courtdata.dto.FinAssIncomeEvidenceDTO;
 import gov.uk.courtdata.entity.*;
 import gov.uk.courtdata.enums.ConcorContributionStatus;
 import gov.uk.courtdata.enums.Frequency;
@@ -507,6 +508,18 @@ public class TestEntityDataBuilder {
                 .dateCreated(LocalDateTime.parse("2021-10-09T15:01:25"))
                 .userCreated(TEST_USER)
                 .userModified(TEST_USER)
+                .active("Y")
+                .incomeEvidence("INE")
+                .build();
+    }
+
+    public static FinAssIncomeEvidenceDTO getFinAssIncomeEvidenceDTO() {
+        return FinAssIncomeEvidenceDTO.builder()
+                .dateReceived(LocalDateTime.parse("2021-10-09T15:01:25"))
+                .dateCreated(LocalDateTime.parse("2021-10-09T15:01:25"))
+                .userCreated(TEST_USER)
+                .userModified(TEST_USER)
+                .mandatory("Y")
                 .active("Y")
                 .incomeEvidence("INE")
                 .build();


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1612)

Ignoring the 'Mandatory' field on Income Evidence updates as this field is not passed from MAAT application.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.