### PR TITLE
DCES-592 Predictable error code on missing contribution_file

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -92,6 +92,11 @@ public class ConcorContributionsService {
                 .orElseThrow(() -> new RequestedObjectNotFoundException("log concor_contribution ID " + request.getConcorId() + ": not found"));
         log.info("log concor_contribution ID {}: found OK", concorEntity.getId());
         if (!StringUtils.isEmpty(request.getErrorText())) {
+            if (concorEntity.getContribFileId() == null) {
+                // returns HTTP status 400 with error code "Object Not Found" (rather than "DB error" as it would without this check).
+                throw new NoSuchElementException("log contribution_file (associated with concur_contribution ID "
+                        + request.getConcorId() + "): not found");
+            }
             saveErrorMessage(request, concorEntity);
         } else if (!debtCollectionService.updateContributionFileReceivedCount(concorEntity.getContribFileId())) {
             throw new NoSuchElementException("log contribution_file ID " + concorEntity.getContribFileId()

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -1,7 +1,7 @@
 package gov.uk.courtdata.dces.service;
 
-import gov.uk.courtdata.dces.mapper.FdcContributionMapper;
 import gov.uk.courtdata.dces.mapper.ContributionFileMapper;
+import gov.uk.courtdata.dces.mapper.FdcContributionMapper;
 import gov.uk.courtdata.dces.request.CreateFdcContributionRequest;
 import gov.uk.courtdata.dces.request.CreateFdcFileRequest;
 import gov.uk.courtdata.dces.request.CreateFdcItemRequest;
@@ -146,6 +146,11 @@ public class FdcContributionsService {
                 .orElseThrow(() -> new RequestedObjectNotFoundException("log fdc_contribution ID " + request.getFdcId() + ": not found"));
         log.info("log fdc_contribution ID {}: found OK", fdcEntity.getId());
         if (!StringUtils.isEmpty(request.getErrorText())) {
+            if (fdcEntity.getContFileId() == null) {
+                // returns HTTP status 400 with error code "Object Not Found" (rather than "DB error" as it would without this check).
+                throw new NoSuchElementException("log contribution_file (associated with fd_contribution ID "
+                        + request.getFdcId() + "): not found");
+            }
             saveErrorMessage(request, fdcEntity);
         } else if (!debtCollectionService.updateContributionFileReceivedCount(fdcEntity.getContFileId())) {
             throw new NoSuchElementException("log contribution_file ID " + fdcEntity.getContFileId()


### PR DESCRIPTION
## What

[DCES-52](https://dsdmoj.atlassian.net/browse/DCES-592) Handle acknowledgement for unSENT or missing contributions
- MAAT court data API to produce predictable error code when contribution_file is missing.

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.