### PR TITLE
LASB-3651 - disabled the JMS health indicators as MAAT API uses SQS i…

### DIFF
--- a/maat-court-data-api/src/main/resources/application.yaml
+++ b/maat-court-data-api/src/main/resources/application.yaml
@@ -128,6 +128,9 @@ feature:
 version: 0.0.1
 
 management:
+  health:
+    jms:
+      enabled: false
   tracing:
     propagation:
       type: w3c,b3


### PR DESCRIPTION
…nstead

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3651)

Disabled the JMS health check as we use SQS instead.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.