### PR TITLE
DCES-665: Added new get endpoint to get a single concor-contribution-file

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
@@ -52,6 +52,19 @@ public class ConcorContributionsRestController {
 
     @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
     @StandardApiResponse
+    @GetMapping(value = "/concor-contribution-file/{concorContributionId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(description = "Get the Contributions file for given concorContributionId")
+    public ResponseEntity<ConcorContributionResponse> concorContributionFile(
+        @PathVariable final Integer concorContributionId
+    ) {
+        log.info("Get Concor contribution file for concorContributionId {}", concorContributionId);
+        ConcorContributionResponse contributionResponse = concorContributionsService.getConcorContributionFile(concorContributionId);
+
+        return ResponseEntity.ok(contributionResponse);
+    }
+
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    @StandardApiResponse
     @PostMapping(value = "/create-contribution-file", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Creating a contribution file and updating the status to Sent in the concor contribution")
     public ResponseEntity<Integer> updateContributionFileStatus(@RequestBody final CreateContributionFileRequest request) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
@@ -52,9 +52,10 @@ public class ConcorContributionsRestController {
 
     @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
     @StandardApiResponse
+    @NotFoundApiResponse
     @GetMapping(value = "/concor-contribution-file/{concorContributionId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Get the Concor Contribution ID and associated XML for given concorContributionId")
-    public ResponseEntity<ConcorContributionResponse> concorContributionFile(
+    public ResponseEntity<ConcorContributionResponse> findConcorContributionFile(
         @PathVariable final Integer concorContributionId
     ) {
         log.info("Get Concor Contribution ID and associated XML for concorContributionId {}", concorContributionId);

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
@@ -53,11 +53,11 @@ public class ConcorContributionsRestController {
     @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
     @StandardApiResponse
     @GetMapping(value = "/concor-contribution-file/{concorContributionId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(description = "Get the Contributions file for given concorContributionId")
+    @Operation(description = "Get the Concor Contribution ID and associated XML for given concorContributionId")
     public ResponseEntity<ConcorContributionResponse> concorContributionFile(
         @PathVariable final Integer concorContributionId
     ) {
-        log.info("Get Concor contribution file for concorContributionId {}", concorContributionId);
+        log.info("Get Concor Contribution ID and associated XML for concorContributionId {}", concorContributionId);
         ConcorContributionResponse contributionResponse = concorContributionsService.getConcorContributionFile(concorContributionId);
 
         return ResponseEntity.ok(contributionResponse);

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -70,6 +70,17 @@ public class ConcorContributionsService {
                         .build()).toList();
     }
 
+    public ConcorContributionResponse getConcorContributionFile(Integer concorContributionId) {
+
+        log.info("Getting concor contribution file for concorContributionId {}", concorContributionId);
+        final Optional<ConcorContributionsEntity> concorFile = concorRepository.findById(concorContributionId);
+
+        return concorFile.map(cc -> ConcorContributionResponse.builder().concorContributionId(cc.getId())
+                .xmlContent(cc.getCurrentXml())
+                .build()).orElse(null);
+    }
+
+
     @Transactional(rollbackFor = MAATCourtDataException.class)
     @NotNull
     public Integer createContributionAndUpdateConcorStatus(CreateContributionFileRequest contributionRequest){

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -77,7 +77,7 @@ public class ConcorContributionsService {
 
         return concorFile.map(cc -> ConcorContributionResponse.builder().concorContributionId(cc.getId())
                 .xmlContent(cc.getCurrentXml())
-                .build()).orElse(null);
+                .build()).orElseThrow(() -> new RequestedObjectNotFoundException("Concor Contribution ID " + concorContributionId + " not found"));
     }
 
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
@@ -148,6 +148,22 @@ class ConcorContributionsServiceTest {
     }
 
     @Test
+    void getConcorContributionFileThrowsNotFoundExceptionWhenConcorContributionIdIsInvalid() {
+        when(concorRepository.findById(0)).thenReturn(Optional.empty());
+        Assertions.assertThrows(RequestedObjectNotFoundException.class,
+            () -> concorService.getConcorContributionFile(0));
+    }
+
+    @Test
+    void getConcorContributionFileReturnsResponseWhenConcorContributionIdIsValid() {
+        when(concorRepository.findById(110)).thenReturn(Optional.of(ConcorContributionsEntity.builder().id(110).currentXml("XmlContent").build()));
+        ConcorContributionResponse response = concorService.getConcorContributionFile(110);
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(110, response.getConcorContributionId());
+        Assertions.assertEquals("XmlContent", response.getXmlContent());
+    }
+
+    @Test
     void testWhenContributionRequestIsNullAndThrowException() {
         Assertions.assertThrows(ValidationException.class,
                 () -> concorService.createContributionAndUpdateConcorStatus(null));


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-665)

DCES-665: Added new get endpoint to get a single concor-contribution-file for the given concor-contribution-id.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.