### PR TITLE
DCES-667: Added new endpoints to get FDC and Concor contributions for a given set of IDs.

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
@@ -58,7 +58,7 @@ public class ConcorContributionsRestController {
     @StandardApiResponseCodes
     @GetMapping(value = "/concor-contribution-xml")
     @Operation(description = "Get a list of Concor Contribution ID and related XML when give a list of Concor Contribution IDs")
-    public ResponseEntity<List<ConcorContributionResponse>> getConcorContributionFiles(@RequestBody List<Integer> idList) {
+    public ResponseEntity<List<ConcorContributionResponse>> getConcorContributionXml(@RequestBody List<Integer> idList) {
 
         log.info("Request received to get the XML for {} IDs", idList.size());
         if (idList.isEmpty()) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
@@ -56,7 +56,7 @@ public class ConcorContributionsRestController {
     }
 
     @StandardApiResponseCodes
-    @GetMapping(value = "/concor-contribution-xml")
+    @PostMapping(value = "/concor-contribution-xml")
     @Operation(description = "Get a list of Concor Contribution ID and related XML when give a list of Concor Contribution IDs")
     public ResponseEntity<List<ConcorContributionResponse>> getConcorContributionXml(@RequestBody List<Integer> idList) {
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestController.java
@@ -55,7 +55,9 @@ public class ConcorContributionsRestController {
         return ResponseEntity.ok(contributionResponses);
     }
 
-    @StandardApiResponseCodes
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    @StandardApiResponse
+    @NotFoundApiResponse
     @PostMapping(value = "/concor-contribution-xml")
     @Operation(description = "Get a list of Concor Contribution ID and related XML when give a list of Concor Contribution IDs")
     public ResponseEntity<List<ConcorContributionResponse>> getConcorContributionXml(@RequestBody List<Integer> idList) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/FdcContributionsController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/FdcContributionsController.java
@@ -122,7 +122,7 @@ public class FdcContributionsController {
     }
 
     @StandardApiResponseCodes
-    @GetMapping(value = "/fdc-contributions", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/fdc-contributions", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Get a list of FCD Contributions when given a list of fdc-contribution-ids")
     public ResponseEntity<FdcContributionsResponse> getFdcContributions(@RequestBody final List<Integer> fdcContributionIdList) {
         log.info("Request received to get the XML for {} IDs", fdcContributionIdList.size());

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/FdcContributionsController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/controller/FdcContributionsController.java
@@ -55,6 +55,20 @@ public class FdcContributionsController {
         return ResponseEntity.ok(contributionResponses);
     }
 
+    @StandardApiResponseCodes
+    @PostMapping(value = "/fdc-contributions", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(description = "Get a list of FCD Contributions when given a list of fdc-contribution-ids")
+    public ResponseEntity<FdcContributionsResponse> getFdcContributions(@RequestBody final List<Integer> fdcContributionIdList) {
+        log.info("Request received to get the XML for {} IDs", fdcContributionIdList.size());
+        if (fdcContributionIdList.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ID List Empty");
+        } else if (fdcContributionIdList.size() > REQUEST_ID_LIST_SIZE_LIMIT) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Too many IDs provided, max is " + REQUEST_ID_LIST_SIZE_LIMIT);
+        } else {
+            return ResponseEntity.ok(fdcContributionsService.getFdcContributions(fdcContributionIdList));
+        }
+    }
+
     @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
     @StandardApiResponse
     @PostMapping(value = "/prepare-fdc-contributions-files", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -119,20 +133,6 @@ public class FdcContributionsController {
     public ResponseEntity<FdcContributionEntry> getFdcContribution(@PathVariable(name = "fdc-contribution-id") final Integer fdcContributionId) {
         log.info("Get FDC Contribution by Id {}", fdcContributionId);
         return ResponseEntity.ok(fdcContributionsService.getFdcContribution(fdcContributionId));
-    }
-
-    @StandardApiResponseCodes
-    @PostMapping(value = "/fdc-contributions", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(description = "Get a list of FCD Contributions when given a list of fdc-contribution-ids")
-    public ResponseEntity<FdcContributionsResponse> getFdcContributions(@RequestBody final List<Integer> fdcContributionIdList) {
-        log.info("Request received to get the XML for {} IDs", fdcContributionIdList.size());
-        if (fdcContributionIdList.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ID List Empty");
-        } else if (fdcContributionIdList.size() > REQUEST_ID_LIST_SIZE_LIMIT) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Too many IDs provided, max is " + REQUEST_ID_LIST_SIZE_LIMIT);
-        } else {
-            return ResponseEntity.ok(fdcContributionsService.getFdcContributions(fdcContributionIdList));
-        }
     }
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -16,6 +16,7 @@ import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.repository.ConcorContributionsRepository;
 import gov.uk.courtdata.util.ValidationUtils;
 import jakarta.validation.constraints.NotNull;
+import java.util.HashSet;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -63,11 +64,20 @@ public class ConcorContributionsService {
         log.info("Searching concor contribution file with status {}, startId {} and count {}", status, concorContributionId, noOfRecords);
         Pageable pageable = PageRequest.of(0, noOfRecords, Sort.by("id"));
         final List<ConcorContributionsEntity> concorFileList = concorRepository.findByStatusAndIdGreaterThan(status, concorContributionId, pageable);
+        return getConcorContributionResponses(concorFileList);
+    }
 
+    public List<ConcorContributionResponse> getConcorContributionXml(List<Integer> idList) {
+        List<ConcorContributionsEntity> concorFileList = concorRepository.findByIdIn(new HashSet(idList));
+        return getConcorContributionResponses(concorFileList);
+    }
+
+    private static List<ConcorContributionResponse> getConcorContributionResponses(
+        List<ConcorContributionsEntity> concorFileList) {
         return concorFileList.stream().map(cc -> ConcorContributionResponse.builder()
-                        .concorContributionId(cc.getId())
-                        .xmlContent(cc.getCurrentXml())
-                        .build()).toList();
+            .concorContributionId(cc.getId())
+            .xmlContent(cc.getCurrentXml())
+            .build()).toList();
     }
 
     @Transactional(rollbackFor = MAATCourtDataException.class)
@@ -153,4 +163,5 @@ public class ConcorContributionsService {
             return false;
         }
     }
+
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -17,6 +17,7 @@ import gov.uk.courtdata.repository.ConcorContributionsRepository;
 import gov.uk.courtdata.util.ValidationUtils;
 import jakarta.validation.constraints.NotNull;
 import java.util.HashSet;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -58,23 +59,22 @@ public class ConcorContributionsService {
 
     public List<ConcorContributionResponse> getConcorContributionFiles(ConcorContributionStatus status, Integer noOfRecords, Integer concorContributionId) {
 
-        concorContributionId = Optional.ofNullable(concorContributionId).orElse(0);
+        Integer finalConcorContributionId = Optional.ofNullable(concorContributionId).orElse(0);
         noOfRecords = Optional.ofNullable(noOfRecords).orElse(DEFAULT_RECORD_COUNT);
 
         log.info("Searching concor contribution file with status {}, startId {} and count {}", status, concorContributionId, noOfRecords);
         Pageable pageable = PageRequest.of(0, noOfRecords, Sort.by("id"));
-        final List<ConcorContributionsEntity> concorFileList = concorRepository.findByStatusAndIdGreaterThan(status, concorContributionId, pageable);
-        return getConcorContributionResponses(concorFileList);
+        return buildConcorContributionResponseList(() -> concorRepository.findByStatusAndIdGreaterThan(status,
+            finalConcorContributionId, pageable));
     }
 
     public List<ConcorContributionResponse> getConcorContributionXml(List<Integer> idList) {
-        List<ConcorContributionsEntity> concorFileList = concorRepository.findByIdIn(new HashSet(idList));
-        return getConcorContributionResponses(concorFileList);
+        return buildConcorContributionResponseList(() -> concorRepository.findByIdIn(new HashSet<>(idList)));
     }
 
-    private static List<ConcorContributionResponse> getConcorContributionResponses(
-        List<ConcorContributionsEntity> concorFileList) {
-        return concorFileList.stream().map(cc -> ConcorContributionResponse.builder()
+    private static List<ConcorContributionResponse> buildConcorContributionResponseList(
+        Supplier<List<ConcorContributionsEntity>> repositoryCall) {
+        return repositoryCall.get().stream().map(cc -> ConcorContributionResponse.builder()
             .concorContributionId(cc.getId())
             .xmlContent(cc.getCurrentXml())
             .build()).toList();

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -38,7 +38,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 
 import static gov.uk.courtdata.enums.FdcContributionsStatus.SENT;
 
@@ -54,22 +53,22 @@ public class FdcContributionsService {
     private final DebtCollectionService debtCollectionService;
     private final FdcContributionMapper fdcContributionMapper;
 
-    private FdcContributionsResponse getFdcContributionsResponse(Supplier<List<FdcContributionsEntity>> repositoryCall) {
-        List<FdcContributionsEntity> fdcContributionsList = repositoryCall.get();
-        List<FdcContributionEntry> fdcContributionEntries = fdcContributionsList.stream()
-            .map(fdcContributionMapper::mapFdcContribution)
-            .toList();
-        return FdcContributionsResponse.builder().fdcContributions(fdcContributionEntries).build();
+    private FdcContributionsResponse buildFdcContributionsResponse(Supplier<List<FdcContributionsEntity>> repositoryCall) {
+        return FdcContributionsResponse.builder()
+            .fdcContributions(repositoryCall.get().stream()
+                .map(fdcContributionMapper::mapFdcContribution)
+            .toList())
+            .build();
     }
 
     public FdcContributionsResponse getFdcContributions(FdcContributionsStatus status) {
         log.info("Getting fdc contributions with status -> {}", status);
-        return getFdcContributionsResponse(() -> fdcContributionsRepository.findByStatus(status));
+        return buildFdcContributionsResponse(() -> fdcContributionsRepository.findByStatus(status));
     }
 
     public FdcContributionsResponse getFdcContributions(List<Integer> fdcContributionIdList) {
         log.info("Getting fdc contributions for IDs in a list of size {}", fdcContributionIdList.size());
-        return getFdcContributionsResponse(() -> fdcContributionsRepository.findByIdIn(new HashSet<>(fdcContributionIdList)));
+        return buildFdcContributionsResponse(() -> fdcContributionsRepository.findByIdIn(new HashSet<>(fdcContributionIdList)));
     }
 
     public FdcContributionsGlobalUpdateResponse fdcContributionGlobalUpdate() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
@@ -350,6 +350,17 @@ class ConcorContributionsRestControllerTest {
     }
 
     @Test
+    void givenEmptyRequestBody_whenXmlIsRequested_thenBadRequestError() throws Exception {
+
+        mvc.perform(MockMvcRequestBuilders.post(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_XML_URL))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(""))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.detail").value("Failed to read request"));
+    }
+
+
+    @Test
     void givenLongListOfIds_whenXmlIsRequested_thenBadRequestError() throws Exception {
         String longList = IntStream.rangeClosed(1, 351)
             .mapToObj(Integer::toString)

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
@@ -306,7 +306,7 @@ class ConcorContributionsRestControllerTest {
     @Test
     void givenEmptyListOfIds_whenXmlIsRequested_thenBadRequestError() throws Exception {
 
-        mvc.perform(MockMvcRequestBuilders.get(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_XML_URL))
+        mvc.perform(MockMvcRequestBuilders.post(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_XML_URL))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("[]"))
             .andExpect(status().isBadRequest())
@@ -319,7 +319,7 @@ class ConcorContributionsRestControllerTest {
             .mapToObj(Integer::toString)
             .collect(Collectors.joining(","));
 
-        mvc.perform(MockMvcRequestBuilders.get(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_XML_URL))
+        mvc.perform(MockMvcRequestBuilders.post(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_XML_URL))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("["+longList+"]"))
             .andExpect(status().isBadRequest())
@@ -335,7 +335,7 @@ class ConcorContributionsRestControllerTest {
                 .xmlContent("FirstXMLFile")
                 .build()));
 
-        mvc.perform(MockMvcRequestBuilders.get(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_XML_URL))
+        mvc.perform(MockMvcRequestBuilders.post(String.format(ENDPOINT_URL  + CONCOR_CONTRIBUTION_XML_URL))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("[110, 120]"))
             .andExpect(status().isOk())

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/FdcContributionsControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/FdcContributionsControllerTest.java
@@ -49,7 +49,7 @@ class FdcContributionsControllerTest {
         BigDecimal expectedCost2= new BigDecimal("444.44");
         BigDecimal expectedCost3= new BigDecimal("999.99");
 
-        when(fdcContributionsService.getFdcContributionFiles(FdcContributionsStatus.REQUESTED))
+        when(fdcContributionsService.getFdcContributions(FdcContributionsStatus.REQUESTED))
                 .thenReturn(FdcContributionsResponse.builder()
                         .fdcContributions(List.of(
                                 FdcContributionEntry.builder().id(1).finalCost(expectedCost1).build(),
@@ -73,7 +73,7 @@ class FdcContributionsControllerTest {
     @Test
     void testContributionFileResponseWhenActiveFileNotAvailable() throws Exception {
 
-        when(fdcContributionsService.getFdcContributionFiles(FdcContributionsStatus.REQUESTED))
+        when(fdcContributionsService.getFdcContributions(FdcContributionsStatus.REQUESTED))
                 .thenReturn(FdcContributionsResponse.builder().fdcContributions(List.of()).build());
 
         mvc.perform(MockMvcRequestBuilders.get(String.format(ENDPOINT_URL  +"/fdc-contribution-files"))

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/FdcContributionsControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/FdcContributionsControllerTest.java
@@ -10,6 +10,8 @@ import gov.uk.courtdata.dces.service.FdcContributionsService;
 import gov.uk.courtdata.entity.FdcContributionsEntity;
 import gov.uk.courtdata.enums.FdcContributionsStatus;
 import gov.uk.courtdata.exception.MAATCourtDataException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -25,6 +27,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,6 +39,7 @@ class FdcContributionsControllerTest {
 
     private static final String ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement";
     private static final String DRC_UPDATE_URL = "/log-fdc-response";
+    private static final String FDC_CONTRIBUTIONS_URL = "/fdc-contributions";
 
     @Autowired
     private MockMvc mvc;
@@ -200,6 +204,50 @@ class FdcContributionsControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("code").value("Object Not Found"));
     }
+
+    @Test
+    void givenEmptyListOfIds_whenFdcContributionsAreRequested_thenBadRequestError() throws Exception {
+
+        mvc.perform(MockMvcRequestBuilders.post(String.format(ENDPOINT_URL  + FDC_CONTRIBUTIONS_URL))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("[]"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.detail").value("ID List Empty"));
+    }
+
+    @Test
+    void givenLongListOfIds_whenFdcContributionsAreRequested_thenBadRequestError() throws Exception {
+        String longList = IntStream.rangeClosed(1, 1001)
+            .mapToObj(Integer::toString)
+            .collect(Collectors.joining(","));
+
+        mvc.perform(MockMvcRequestBuilders.post(String.format(ENDPOINT_URL  + FDC_CONTRIBUTIONS_URL))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("["+longList+"]"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.detail").value("Too many IDs provided, max is 1000"));
+    }
+
+    @Test
+    void givenValidListOfIds_whenFdcContributionsAreRequested_thenValidResponse() throws Exception {
+
+        when(fdcContributionsService.getFdcContributions(anyList())).
+            thenReturn(FdcContributionsResponse.builder()
+                        .fdcContributions(List.of(FdcContributionEntry.builder()
+                                .id(1)
+                                .accelerate("True")
+                        .build()))
+                .build());
+
+        mvc.perform(MockMvcRequestBuilders.post(String.format(ENDPOINT_URL  + FDC_CONTRIBUTIONS_URL))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("[110, 120]"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.fdcContributions.[0].id").value("1"))
+            .andExpect(jsonPath("$.fdcContributions.[0].accelerate").value("True"));
+    }
+
+
 
     private static String createDrcUpdateJson(int fdcId, String errorText){
         return """

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
@@ -352,6 +352,25 @@ class ConcorContributionsServiceTest {
         assertNull(actualResponse);
     }
 
+    @Test
+    void testGetConcorContributionXmlWhenNotFound() {
+        when(concorRepository.findByIdIn(any())).thenReturn(new ArrayList<>());
+        List<ConcorContributionResponse> actualResponse = concorService.getConcorContributionXml(List.of(1));
+        assertEquals(actualResponse, new ArrayList<>());
+    }
+
+    @Test
+    void testGetConcorContributionXmlWhenFound() {
+        List<ConcorContributionResponse> expectedResponse = List.of(ConcorContributionResponse.builder()
+                .concorContributionId(1)
+                .xmlContent(getXmlDocContent())
+                .build());
+
+        when(concorRepository.findByIdIn(any())).thenReturn(List.of(populateConcorContributionsEntity(1)));
+        List<ConcorContributionResponse> actualResponse = concorService.getConcorContributionXml(List.of(1));
+        assertEquals(actualResponse, expectedResponse);
+    }
+
     private LogContributionProcessedRequest createLogContributionProcessedRequest(int id, String errorText) {
         return LogContributionProcessedRequest.builder()
                 .concorId(id)
@@ -404,4 +423,5 @@ class ConcorContributionsServiceTest {
         concorFile.setId(concorContribId);
         return concorFile;
     }
+
 }


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-667)

Added 2 new endpoints viz /debt-collection-enforcement/fdc-contributions and /debt-collection-enforcement/concor-contribution-xml to get the FDC and Concor contributions data for a given list of IDs.

Found and fixed an issue whereby some fields (e.g. STATUS, JUD_APPORTION_PERCENT etc), were not mapped and hence not returned by the endpoint /debt-collection-enforcement/fdc-contribution-files.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.