### PR TITLE
DCES - Refactor Contributions Fetch to reduce DB impact.

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -64,8 +64,8 @@ public class ConcorContributionsService {
 
         log.info("Searching concor contribution file with status {}, startId {} and count {}", status, concorContributionId, noOfRecords);
         Pageable pageable = PageRequest.of(0, noOfRecords, Sort.by("id"));
-        return buildConcorContributionResponseList(() -> concorRepository.findByStatusAndIdGreaterThan(status,
-            finalConcorContributionId, pageable));
+        Set<Integer> idList = new HashSet<>(concorRepository.findByStatusAndIdGreaterThan(status,finalConcorContributionId,pageable));
+        return buildConcorContributionResponseList(() -> concorRepository.findByIdIn(idList));
     }
 
     public List<ConcorContributionResponse> getConcorContributionXml(List<Integer> idList) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
@@ -18,15 +18,16 @@ public interface ConcorContributionsRepository extends JpaRepository<ConcorContr
     List<ConcorContributionsEntity> findByIdIn(Set<Integer> ids);
 
     @Query("""
-       SELECT cc
+       SELECT cc.id
        FROM ConcorContributionsEntity cc
        WHERE cc.status = :status
        AND cc.id > :startId
        ORDER BY cc.id ASC""")
-    List<ConcorContributionsEntity> findByStatusAndIdGreaterThan(
+    List<Integer> findByStatusAndIdGreaterThan(
             @Param("status") ConcorContributionStatus status,
             @Param("startId") Integer startId,
             Pageable pageable);
+
 
     @Query("""
            SELECT cc.id

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
@@ -34,6 +34,7 @@ import org.springframework.data.domain.Sort;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -100,16 +101,20 @@ class ConcorContributionsServiceTest {
     @Test
     void testGetContributionFilesWhenConcorFileStatusIsActive() {
 
+        List<Integer> entityIdList = List.of(344, 345);
+        Set<Integer> entitySetList = new HashSet<>(entityIdList);
         List<ConcorContributionsEntity> entities = List.of(
                 populateConcorContributionsEntity(344),
                 populateConcorContributionsEntity(345)
         );
         Pageable pageable = PageRequest.of(0, 3, Sort.by("id"));
-        when(concorRepository.findByStatusAndIdGreaterThan(ACTIVE, 343, pageable)).thenReturn(entities);
+        when(concorRepository.findByStatusAndIdGreaterThan(ACTIVE, 343, pageable)).thenReturn(entityIdList);
+        when(concorRepository.findByIdIn(entitySetList)).thenReturn(entities);
 
         List<ConcorContributionResponse> responseList = concorService.getConcorContributionFiles(ACTIVE, 3, 343);
 
         verify(concorRepository).findByStatusAndIdGreaterThan(any(), any(), any());
+        verify(concorRepository).findByIdIn(any());
         assertNotNull(responseList);
         Assertions.assertFalse(responseList.isEmpty());
         Assertions.assertEquals(344,responseList.get(0).getConcorContributionId());
@@ -118,7 +123,7 @@ class ConcorContributionsServiceTest {
 
     @Test
     void testGetContributionFilesWhenConcorFileStatusIsActiveAndConcorContribIdIsNull() {
-
+        List<Integer> entityIdList = List.of(343,344,345,346);
         List<ConcorContributionsEntity> entities = List.of(
                 populateConcorContributionsEntity(343),
                 populateConcorContributionsEntity(344),
@@ -126,11 +131,13 @@ class ConcorContributionsServiceTest {
                 populateConcorContributionsEntity(346)
 
         );
-        when(concorRepository.findByStatusAndIdGreaterThan(any(),any(), any())).thenReturn(entities);
+        when(concorRepository.findByStatusAndIdGreaterThan(any(),any(), any())).thenReturn(entityIdList);
+        when(concorRepository.findByIdIn(any())).thenReturn(entities);
 
         List<ConcorContributionResponse> responseList = concorService.getConcorContributionFiles(ACTIVE, null, null);
 
         verify(concorRepository).findByStatusAndIdGreaterThan(any(), any(), any());
+        verify(concorRepository).findByIdIn(any());
         assertNotNull(responseList);
         Assertions.assertFalse(responseList.isEmpty());
         Assertions.assertEquals(343,responseList.get(0).getConcorContributionId());
@@ -140,7 +147,7 @@ class ConcorContributionsServiceTest {
     void getConcorContributionFilesReturnsEmptyListWhenStartingIdIsInvalid() {
         Pageable pageable = PageRequest.of(0, 2, Sort.by("id"));
         when(concorRepository.findByStatusAndIdGreaterThan(ACTIVE, 999, pageable)).thenReturn(List.of());
-
+        when(concorRepository.findByIdIn(any())).thenReturn(List.of());
         List<ConcorContributionResponse> responseList = concorService.getConcorContributionFiles(ACTIVE, 2, 999);
 
         assertNotNull(responseList);


### PR DESCRIPTION
## What

Refactoring the main dces contribution fetch to a split call to reduce db impact.
The Dev environment had a major issue with performance, and we noticed due to the exaggerated performance issues, that this specific call could be improved.

Doing the fetch top x with an id sort was magnitudes faster when other columns were excluded. So the call was split into 2 parts. The original call, which now only fetches the ids of those matching entries, and a use of the findByIdIn which will return the full details, but in a much more efficient manner.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.