### PR TITLE
DCES-Fdc-Mapper-Rep-Order-Fix

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/mapper/FdcContributionMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/mapper/FdcContributionMapper.java
@@ -6,6 +6,9 @@ import org.mapstruct.Mapper;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 
+/***
+ * Note this does not map the RepOrderEntity fields to the FdcContributionEntry as might be expected.
+ */
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface FdcContributionMapper {
     FdcContributionEntry mapFdcContribution(FdcContributionsEntity entity);


### PR DESCRIPTION
## What

Fixing issue with mapper not mapping repOrder on the response objects.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.