### PR TITLE
DCES-694-Fdc-Fetch-Rework

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/mapper/FdcMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/mapper/FdcMapper.java
@@ -1,0 +1,33 @@
+package gov.uk.courtdata.dces.mapper;
+
+import gov.uk.courtdata.entity.FdcContributionsEntity;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+public class FdcMapper implements RowMapper<FdcContributionsEntity> {
+    @Override
+    public @NotNull FdcContributionsEntity mapRow(ResultSet rs, int rowNum) throws SQLException {
+        FdcContributionsEntity fdcEntity = new FdcContributionsEntity();
+        fdcEntity.setId(rs.getInt("ID"));
+        fdcEntity.setMaatId(rs.getInt("REP_ID"));
+        fdcEntity.setFinalCost(rs.getBigDecimal("FINAL_COST"));
+        fdcEntity.setLgfsCost(rs.getBigDecimal("LGFS_COST"));
+        fdcEntity.setAgfsCost(rs.getBigDecimal("AGFS_COST"));
+
+        Date dateCalculated = rs.getDate("DATE_CALCULATED");
+        if(Objects.nonNull(dateCalculated)){
+            fdcEntity.setDateCalculated(dateCalculated.toLocalDate());
+        }
+        Date sentenceOrderDate = rs.getDate("SENTENCE_ORDER_DATE");
+        if(Objects.nonNull(sentenceOrderDate)){
+            fdcEntity.setSentenceOrderDate(sentenceOrderDate.toLocalDate());
+        }
+        return fdcEntity;
+    }
+
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/mapper/FdcMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/mapper/FdcMapper.java
@@ -1,6 +1,7 @@
 package gov.uk.courtdata.dces.mapper;
 
 import gov.uk.courtdata.entity.FdcContributionsEntity;
+import gov.uk.courtdata.entity.RepOrderEntity;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.jdbc.core.RowMapper;
 
@@ -9,12 +10,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Objects;
 
+/***
+ * Mapper to map the basic needed fields for FDC processing.
+ * Note that this will only map the SentenceOrderDate, and Id fields on the RepOrderEntity.
+ */
 public class FdcMapper implements RowMapper<FdcContributionsEntity> {
     @Override
     public @NotNull FdcContributionsEntity mapRow(ResultSet rs, int rowNum) throws SQLException {
         FdcContributionsEntity fdcEntity = new FdcContributionsEntity();
         fdcEntity.setId(rs.getInt("ID"));
-        fdcEntity.setMaatId(rs.getInt("REP_ID"));
         fdcEntity.setFinalCost(rs.getBigDecimal("FINAL_COST"));
         fdcEntity.setLgfsCost(rs.getBigDecimal("LGFS_COST"));
         fdcEntity.setAgfsCost(rs.getBigDecimal("AGFS_COST"));
@@ -23,10 +27,15 @@ public class FdcMapper implements RowMapper<FdcContributionsEntity> {
         if(Objects.nonNull(dateCalculated)){
             fdcEntity.setDateCalculated(dateCalculated.toLocalDate());
         }
+        // create basic RepOrderEntity
+        RepOrderEntity repOrderEntity = new RepOrderEntity();
+        repOrderEntity.setId(rs.getInt("REP_ID"));
         Date sentenceOrderDate = rs.getDate("SENTENCE_ORDER_DATE");
         if(Objects.nonNull(sentenceOrderDate)){
-            fdcEntity.setSentenceOrderDate(sentenceOrderDate.toLocalDate());
+            repOrderEntity.setSentenceOrderDate(sentenceOrderDate.toLocalDate());
         }
+
+        fdcEntity.setRepOrderEntity(repOrderEntity);
         return fdcEntity;
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/DebtCollectionRepository.java
@@ -44,7 +44,7 @@ public class DebtCollectionRepository {
         return jdbcTemplate.queryForList(query, String.class, fromDate, toDate);
     }
 
-    List<FdcContributionsEntity> getFdcEntriesByStatus(FdcContributionsStatus status){
+    List<FdcContributionsEntity> findFdcEntriesByStatus(FdcContributionsStatus status){
         String query = """
                 SELECT fdc.id, fdc.FINAL_COST, fdc.DATE_CALCULATED, fdc.LGFS_COST, fdc.AGFS_COST, rep.SENTENCE_ORDER_DATE, fdc.rep_id 
                 FROM TOGDATA.FDC_CONTRIBUTIONS fdc INNER JOIN TOGDATA.REP_ORDERS rep
@@ -54,7 +54,7 @@ public class DebtCollectionRepository {
         return jdbcTemplate.query(query, new FdcMapper(), status.toString());
     }
 
-    List<FdcContributionsEntity> getFdcEntriesByIdIn(Set<Integer> idList){
+    List<FdcContributionsEntity> findFdcEntriesByIdIn(Set<Integer> idList){
         String query = """
                 SELECT fdc.id, fdc.FINAL_COST, fdc.DATE_CALCULATED, fdc.LGFS_COST, fdc.AGFS_COST, rep.SENTENCE_ORDER_DATE, fdc.rep_id 
                 FROM TOGDATA.FDC_CONTRIBUTIONS fdc INNER JOIN TOGDATA.REP_ORDERS rep

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -79,12 +79,12 @@ public class FdcContributionsService {
 
     public FdcContributionsResponse getFdcContributions(FdcContributionsStatus status) {
         log.info("Getting fdc contributions with status -> {}", status);
-        return buildFdcContributionsResponse(() -> fdcContributionsRepository.findByStatus(status));
+        return buildFdcContributionsResponse(() -> debtCollectionRepository.getFdcEntriesByStatus(status));
     }
 
     public FdcContributionsResponse getFdcContributions(List<Integer> fdcContributionIdList) {
         log.info("Getting fdc contributions for IDs in a list of size {}", fdcContributionIdList.size());
-        return buildFdcContributionsResponse(() -> fdcContributionsRepository.findByIdIn(new HashSet<>(fdcContributionIdList)));
+        return buildFdcContributionsResponse(() -> debtCollectionRepository.getFdcEntriesByIdIn(new HashSet<>(fdcContributionIdList)));
     }
 
     public FdcContributionsGlobalUpdateResponse fdcContributionGlobalUpdate() {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -79,12 +79,12 @@ public class FdcContributionsService {
 
     public FdcContributionsResponse getFdcContributions(FdcContributionsStatus status) {
         log.info("Getting fdc contributions with status -> {}", status);
-        return buildFdcContributionsResponse(() -> debtCollectionRepository.getFdcEntriesByStatus(status));
+        return buildFdcContributionsResponse(() -> debtCollectionRepository.findFdcEntriesByStatus(status));
     }
 
     public FdcContributionsResponse getFdcContributions(List<Integer> fdcContributionIdList) {
         log.info("Getting fdc contributions for IDs in a list of size {}", fdcContributionIdList.size());
-        return buildFdcContributionsResponse(() -> debtCollectionRepository.getFdcEntriesByIdIn(new HashSet<>(fdcContributionIdList)));
+        return buildFdcContributionsResponse(() -> debtCollectionRepository.findFdcEntriesByIdIn(new HashSet<>(fdcContributionIdList)));
     }
 
     public FdcContributionsGlobalUpdateResponse fdcContributionGlobalUpdate() {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/FdcContributionsService.java
@@ -73,7 +73,7 @@ public class FdcContributionsService {
                 .lgfsCost(entity.getLgfsCost())
                 .agfsCost(entity.getAgfsCost())
                 .maatId(entity.getRepOrderEntity().getId())
-                .sentenceOrderDate(Objects.nonNull(entity.getRepOrderEntity()) ? entity.getRepOrderEntity().getSentenceOrderDate() : null)
+                .sentenceOrderDate(entity.getRepOrderEntity().getSentenceOrderDate())
                 .build();
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FdcContributionsEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FdcContributionsEntity.java
@@ -96,7 +96,7 @@ public class FdcContributionsEntity {
     private String userModified;
 
     @JsonBackReference
-    @OneToOne(targetEntity = RepOrderEntity.class, fetch = FetchType.EAGER)
+    @OneToOne(targetEntity = RepOrderEntity.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "REP_ID", referencedColumnName = "ID")
     private RepOrderEntity repOrderEntity;
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FdcContributionsEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FdcContributionsEntity.java
@@ -96,8 +96,12 @@ public class FdcContributionsEntity {
     private String userModified;
 
     @JsonBackReference
-    @OneToOne(targetEntity = RepOrderEntity.class, fetch = FetchType.LAZY)
+    @OneToOne(targetEntity = RepOrderEntity.class, fetch = FetchType.EAGER)
     @JoinColumn(name = "REP_ID", referencedColumnName = "ID")
     private RepOrderEntity repOrderEntity;
+
+    private LocalDate sentenceOrderDate;
+
+    private Integer maatId;
 
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FdcContributionsEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/FdcContributionsEntity.java
@@ -100,8 +100,4 @@ public class FdcContributionsEntity {
     @JoinColumn(name = "REP_ID", referencedColumnName = "ID")
     private RepOrderEntity repOrderEntity;
 
-    private LocalDate sentenceOrderDate;
-
-    private Integer maatId;
-
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/FdcContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/FdcContributionsServiceTest.java
@@ -95,7 +95,7 @@ class FdcContributionsServiceTest {
 
     @Test
     void testGetContributionFilesWhenFdcFileStatusIsRequested() {
-        when(fdcContributionsRepository.findByStatus(statusCaptor.capture())).thenReturn(fdcContributionsEntityList);
+        when(debtCollectionRepository.findFdcEntriesByStatus(statusCaptor.capture())).thenReturn(fdcContributionsEntityList);
 
         FdcContributionsResponse response = fdcContributionsService.getFdcContributions(REQUESTED);
 
@@ -108,14 +108,14 @@ class FdcContributionsServiceTest {
 
     @Test
     void testGetContributionsWhenNotFound() {
-        when(fdcContributionsRepository.findByIdIn(any())).thenReturn(new ArrayList<>());
+        when(debtCollectionRepository.findFdcEntriesByIdIn(any())).thenReturn(new ArrayList<>());
         FdcContributionsResponse response = fdcContributionsService.getFdcContributions(List.of(1));
         assertEquals(new ArrayList<>(), response.getFdcContributions());
     }
 
     @Test
     void testGetContributionsWhenFound() {
-        when(fdcContributionsRepository.findByIdIn(any())).thenReturn(fdcContributionsEntityList);
+        when(debtCollectionRepository.findFdcEntriesByIdIn(any())).thenReturn(fdcContributionsEntityList);
         FdcContributionsResponse response = fdcContributionsService.getFdcContributions(List.of(1));
         assertEqualsWithExpectedValues(response);
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-694)

Refactoring the FDC get endpoints to use a native query.
Under current JPA method, if there are 200 Fdc Contributions found by the FindBy, when we map the object over to the response object. It will then perform 200 additional database queries to populate the RepOrderEntities.
While these are very simple queries ( select * from RepOrder where id = ? ) it both takes extra time, and hits the db unexpectedly.
The native query, and mapper will remove that additional burden, and keeps the response to what is needed.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.