### PR TITLE
Lasb 3900 [CAA & MAAT API] Adding field review_type of the means_test to the API result

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/RepOrderStateDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/RepOrderStateDTO.java
@@ -45,5 +45,6 @@ public class RepOrderStateDTO {
     private String iojAppealAssessorName;
     private LocalDateTime iojAppealDate;
 
-    private String reviewType;
+    private String meansReviewType;
+    private String passportReviewType;
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/mapper/RepOrderMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/mapper/RepOrderMapper.java
@@ -78,7 +78,8 @@ public interface RepOrderMapper {
                 .iojAppealResult(maxIdIOJAppealEntity.map(IOJAppealEntity::getDecisionResult).orElse(null))
                 .iojAppealAssessorName(maxIdIOJAppealEntity.map(IOJAppealEntity::getUserCreated).orElse(null))
                 .iojAppealDate(maxIdIOJAppealEntity.map(IOJAppealEntity::getDecisionDate).orElse(null))
-                .reviewType(maxIdFinancialAssessmentEntity.map(FinancialAssessmentEntity::getRtCode).orElse(null))
+                .meansReviewType(maxIdFinancialAssessmentEntity.map(FinancialAssessmentEntity::getRtCode).orElse(null))
+                .passportReviewType(maxIdPassportAssessmentEntity.map(PassportAssessmentEntity::getRtCode).orElse(null))
                 .build();
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/mapper/RepOrderMapperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/mapper/RepOrderMapperTest.java
@@ -39,7 +39,8 @@ class RepOrderMapperTest {
     private static final String IOJ_APPEAL_RESULT_FAIL = "FAIL";
     private static final String IOJ_APPEAL_ASSESSOR_NAME = "ocon-m";
     private static final LocalDateTime IOJ_APPEAL_DATE = LocalDateTime.of(2015, 1, 9, 11, 16, 32);
-    private static final String REVIEW_TYPE = "NAFI";
+    private static final String MEANS_REVIEW_TYPE = "NAFI";
+    private static final String PASSPORT_REVIEW_TYPE = "ER";
 
     private final RepOrderMapper repOrderMapper = new RepOrderMapperImpl(); // Assuming an implementation exists
 
@@ -69,6 +70,7 @@ class RepOrderMapperTest {
                 .pastStatus(PASSPORT_STATUS)
                 .dateCreated(DATE_PASSPORT_CREATED)
                 .userCreatedEntity(userEntity)
+                .rtCode(PASSPORT_REVIEW_TYPE)
                 .build();
 
         passportAssessmentFail = PassportAssessmentEntity.builder()
@@ -86,7 +88,7 @@ class RepOrderMapperTest {
                 .fassInitStatus(MEANS_STATUS)
                 .dateCreated(DATE_MEANS_CREATED)
                 .userCreatedEntity(userEntity)
-                .rtCode(REVIEW_TYPE)
+                .rtCode(MEANS_REVIEW_TYPE)
                 .build();
 
         financialAssessmentInitialFail = FinancialAssessmentEntity.builder()
@@ -169,7 +171,8 @@ class RepOrderMapperTest {
                 () -> assertNull(repOrderState.getIojAppealAssessorName()),
                 () -> assertNull(repOrderState.getIojAppealDate()),
                 () -> assertEquals(FUNDING_DECISION, repOrderState.getFundingDecision()),
-                () -> assertEquals(CC_REP_DECISION, repOrderState.getCcRepDecision())
+                () -> assertEquals(CC_REP_DECISION, repOrderState.getCcRepDecision()),
+                () -> assertEquals(PASSPORT_REVIEW_TYPE, repOrderState.getPassportReviewType())
         );
     }
 
@@ -204,7 +207,7 @@ class RepOrderMapperTest {
                 () -> assertEquals(DATE_PASSPORT_CREATED, repOrderState.getDatePassportCreated()),
                 () -> assertEquals(FUNDING_DECISION, repOrderState.getFundingDecision()),
                 () -> assertEquals(CC_REP_DECISION, repOrderState.getCcRepDecision()),
-                () -> assertEquals(REVIEW_TYPE, repOrderState.getReviewType())
+                () -> assertEquals(MEANS_REVIEW_TYPE, repOrderState.getMeansReviewType())
         );
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3900)

Describe what you did and why.

As part of the enhancement to the LAA Crime Applications Adapter, we need to include the review_type field from the means_test in the API response. Added the review type field in the response

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.