### PR TITLE
LASB-3908 [CAA & MAAT API] Adding field Means & Passport Work Reasons of the means_test to the API result

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/RepOrderStateDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dto/RepOrderStateDTO.java
@@ -47,4 +47,6 @@ public class RepOrderStateDTO {
 
     private String meansReviewType;
     private String passportReviewType;
+    private String meansWorkReason;
+    private String passportWorkReason;
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/mapper/RepOrderMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/mapper/RepOrderMapper.java
@@ -6,6 +6,7 @@ import gov.uk.courtdata.dto.RepOrderDTO;
 import gov.uk.courtdata.entity.FinancialAssessmentEntity;
 import gov.uk.courtdata.entity.IOJAppealEntity;
 import gov.uk.courtdata.entity.PassportAssessmentEntity;
+import gov.uk.courtdata.entity.NewWorkReasonEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.model.CreateRepOrder;
 import gov.uk.courtdata.model.UpdateRepOrder;
@@ -80,6 +81,11 @@ public interface RepOrderMapper {
                 .iojAppealDate(maxIdIOJAppealEntity.map(IOJAppealEntity::getDecisionDate).orElse(null))
                 .meansReviewType(maxIdFinancialAssessmentEntity.map(FinancialAssessmentEntity::getRtCode).orElse(null))
                 .passportReviewType(maxIdPassportAssessmentEntity.map(PassportAssessmentEntity::getRtCode).orElse(null))
+                .passportWorkReason(maxIdPassportAssessmentEntity.map(PassportAssessmentEntity::getNworCode).orElse(null))
+                .meansWorkReason(maxIdFinancialAssessmentEntity
+                        .map(FinancialAssessmentEntity::getNewWorkReason)
+                        .map(NewWorkReasonEntity::getCode)
+                        .orElse(null))
                 .build();
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/mapper/RepOrderMapperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/mapper/RepOrderMapperTest.java
@@ -4,6 +4,7 @@ import gov.uk.courtdata.dto.RepOrderStateDTO;
 import gov.uk.courtdata.entity.FinancialAssessmentEntity;
 import gov.uk.courtdata.entity.IOJAppealEntity;
 import gov.uk.courtdata.entity.PassportAssessmentEntity;
+import gov.uk.courtdata.entity.NewWorkReasonEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.UserEntity;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,8 @@ class RepOrderMapperTest {
     private static final LocalDateTime IOJ_APPEAL_DATE = LocalDateTime.of(2015, 1, 9, 11, 16, 32);
     private static final String MEANS_REVIEW_TYPE = "NAFI";
     private static final String PASSPORT_REVIEW_TYPE = "ER";
+    private static final String MEANS_WORK_REASON = "HR";
+    private static final String PASSPORT_WORK_REASON = "FMA";
 
     private final RepOrderMapper repOrderMapper = new RepOrderMapperImpl(); // Assuming an implementation exists
 
@@ -71,6 +74,7 @@ class RepOrderMapperTest {
                 .dateCreated(DATE_PASSPORT_CREATED)
                 .userCreatedEntity(userEntity)
                 .rtCode(PASSPORT_REVIEW_TYPE)
+                .nworCode(PASSPORT_WORK_REASON)
                 .build();
 
         passportAssessmentFail = PassportAssessmentEntity.builder()
@@ -89,6 +93,7 @@ class RepOrderMapperTest {
                 .dateCreated(DATE_MEANS_CREATED)
                 .userCreatedEntity(userEntity)
                 .rtCode(MEANS_REVIEW_TYPE)
+                .newWorkReason(NewWorkReasonEntity.builder().code(MEANS_WORK_REASON).build())
                 .build();
 
         financialAssessmentInitialFail = FinancialAssessmentEntity.builder()
@@ -172,7 +177,8 @@ class RepOrderMapperTest {
                 () -> assertNull(repOrderState.getIojAppealDate()),
                 () -> assertEquals(FUNDING_DECISION, repOrderState.getFundingDecision()),
                 () -> assertEquals(CC_REP_DECISION, repOrderState.getCcRepDecision()),
-                () -> assertEquals(PASSPORT_REVIEW_TYPE, repOrderState.getPassportReviewType())
+                () -> assertEquals(PASSPORT_REVIEW_TYPE, repOrderState.getPassportReviewType()),
+                () -> assertEquals(PASSPORT_WORK_REASON, repOrderState.getPassportWorkReason())
         );
     }
 
@@ -207,7 +213,8 @@ class RepOrderMapperTest {
                 () -> assertEquals(DATE_PASSPORT_CREATED, repOrderState.getDatePassportCreated()),
                 () -> assertEquals(FUNDING_DECISION, repOrderState.getFundingDecision()),
                 () -> assertEquals(CC_REP_DECISION, repOrderState.getCcRepDecision()),
-                () -> assertEquals(MEANS_REVIEW_TYPE, repOrderState.getMeansReviewType())
+                () -> assertEquals(MEANS_REVIEW_TYPE, repOrderState.getMeansReviewType()),
+                () -> assertEquals(MEANS_WORK_REASON, repOrderState.getMeansWorkReason())
         );
     }
 


### PR DESCRIPTION


## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3908)

Describe what you did and why.

As part of the enhancement to the LAA Crime Applications Adapter, we need to include the Work Reason Code field from the means_test in the API response. Added the meansWorkReason & passportWorkReason field in the response

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.