### PR TITLE
Replace deprecated testing annotations

### DIFF
--- a/maat-court-data-api/gradle.properties
+++ b/maat-court-data-api/gradle.properties
@@ -2,7 +2,7 @@
 javaVersion=17
 # Plugin Dependency Versions
 semverVersion=0.5.0
-springframeworkBootVersion=3.4.1
+springframeworkBootVersion=3.4.2
 springDependencyManagementVersion=1.1.7
 sonarQubeVersion=4.0.0.2929
 pitestVersion=1.9.11

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/address/controller/AddressControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/address/controller/AddressControllerTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -35,7 +35,7 @@ class AddressControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private AddressService addressService;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/address/service/AddressServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/address/service/AddressServiceTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.HashMap;
 import java.util.Optional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 class AddressServiceTest {
 
     private static final int ID = 1;
-    @MockBean
+    @MockitoBean
     private AddressRepository addressRepository;
     private AddressService addressService;
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/controller/ApplicantControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/controller/ApplicantControllerTest.java
@@ -17,13 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import uk.gov.justice.laa.crime.util.RequestBuilderUtils;
 
 import java.util.List;
 
@@ -44,16 +42,16 @@ public class ApplicantControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private ApplicantService applicantService;
 
-    @MockBean
+    @MockitoBean
     private ApplicantHistoryService applicantHistoryService;
 
-    @MockBean
+    @MockitoBean
     private RepOrderApplicantLinksService repOrderApplicantLinksService;
 
-    @MockBean
+    @MockitoBean
     private ApplicantValidationProcessor validator;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/controller/ApplicantDisabilitiesControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/controller/ApplicantDisabilitiesControllerTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -31,7 +31,7 @@ public class ApplicantDisabilitiesControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private ApplicantDisabilitiesService applicantDisabilitiesService;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/service/ApplicantServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/service/ApplicantServiceTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.HashMap;
 import java.util.Optional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,12 +25,12 @@ import static org.mockito.Mockito.*;
 public class ApplicantServiceTest {
 
     private static final int ID = 1;
-    @MockBean
+    @MockitoBean
     private ApplicantRepository applicantRepository;
     private ApplicantService applicantService;
-    @MockBean
+    @MockitoBean
     private RepOrderService repOrderService;
-    @MockBean
+    @MockitoBean
     private ApplicantHistoryService applicantHistoryService;
 
     @BeforeEach

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/controller/FinancialAssessmentControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/controller/FinancialAssessmentControllerTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -54,13 +54,13 @@ class FinancialAssessmentControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private FinancialAssessmentValidationProcessor financialAssessmentValidationProcessor;
 
-    @MockBean
+    @MockitoBean
     private FinancialAssessmentService financialAssessmentService;
 
-    @MockBean
+    @MockitoBean
     private FinancialAssessmentHistoryService financialAssessmentHistoryService;
 
     private String financialAssessmentJson;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/controller/PassportAssessmentControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/assessment/controller/PassportAssessmentControllerTest.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -34,10 +34,10 @@ class PassportAssessmentControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private PassportAssessmentValidationProcessor passportAssessmentValidationProcessor;
 
-    @MockBean
+    @MockitoBean
     private PassportAssessmentService passportAssessmentService;
 
     private final PassportAssessmentMapper passportAssessmentMapper = new PassportAssessmentMapperImpl();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/authorization/controller/AuthorizationControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/authorization/controller/AuthorizationControllerTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -23,10 +23,10 @@ public class AuthorizationControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private AuthorizationService authorizationService;
 
-    @MockBean
+    @MockitoBean
     private UserReservationValidator userReservationValidator;
 
     private final String baseURL = "/api/internal/v1/assessment/authorization";

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/contribution/controller/ContributionCalcControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/contribution/controller/ContributionCalcControllerTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -25,7 +25,7 @@ class ContributionCalcControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ContributionCalcService contributionCalcService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/contribution/controller/ContributionsControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/contribution/controller/ContributionsControllerTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.justice.laa.crime.common.model.contribution.maat_api.CreateContributionRequest;
@@ -32,9 +32,9 @@ class ContributionsControllerTest {
     private static final Integer TEST_CONTRIBUTIONS_ID = 999;
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private ContributionsService contributionsService;
-    @MockBean
+    @MockitoBean
     private CreateContributionsValidator createContributionsValidator;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/CrownCourtControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/CrownCourtControllerTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -28,10 +28,10 @@ public class CrownCourtControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private CrownCourtOutcomeService crownCourtOutcomeService;
 
-    @MockBean
+    @MockitoBean
     private MaatIdValidator maatIdValidator;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/ResultControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/ResultControllerTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -23,7 +23,7 @@ public class ResultControllerTest {
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/result";
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private ResultsService resultsService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/StoredProcedureControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/StoredProcedureControllerTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -31,7 +31,7 @@ class StoredProcedureControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private StoredProcedureService service;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/WQResultControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/WQResultControllerTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -23,7 +23,7 @@ public class WQResultControllerTest {
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/wq-result";
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private ResultsService resultsService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/XLATResultControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/controller/XLATResultControllerTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -25,7 +25,7 @@ public class XLATResultControllerTest {
     private static final Integer TEST_SUB_TYPE = 666;
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private ResultsService resultsService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ConcorContributionsRestControllerTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -51,7 +51,7 @@ class ConcorContributionsRestControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private ConcorContributionsService concorContributionsService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ContributionFileControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/ContributionFileControllerTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -35,7 +35,7 @@ class ContributionFileControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ContributionFileService contributionFileService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/DebtCollectionControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/DebtCollectionControllerTest.java
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -25,7 +25,7 @@ class DebtCollectionControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private DebtCollectionService debtCollectionService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/FdcContributionsControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/FdcContributionsControllerTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -43,7 +43,7 @@ class FdcContributionsControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private FdcContributionsService fdcContributionsService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/FdcItemsControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/controller/FdcItemsControllerTest.java
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import wiremock.com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,7 +31,7 @@ class FdcItemsControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private FdcContributionsService fdcContributionsService;
 
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformAuditControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformAuditControllerTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -31,7 +31,7 @@ public class EformAuditControllerTest {
 
     private static final UsnException USN_VALIDATION_EXCEPTION = USNExceptionUtil.nonexistent(NON_EXISTENT_USN);
 
-    @MockBean
+    @MockitoBean
     private EformAuditService mockEformAuditService;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformResultsControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformResultsControllerTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -40,7 +40,7 @@ public class EformResultsControllerTest {
     private static final String CASE_TYPE = "EITHER WAY";
     private static final String STAGE = "C";
 
-    @MockBean
+    @MockitoBean
     private EformResultsService eformResultsService;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformStagingControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformStagingControllerTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -36,13 +36,13 @@ class EformStagingControllerTest {
     private static final EformStagingDTO EFORM_STAGING_DTO = EformStagingDTO.builder().usn(USN).type(TYPE).userCreated(CA_USER).build();
     private static final UsnException USN_VALIDATION_EXCEPTION = USNExceptionUtil.nonexistent(987);
 
-    @MockBean
+    @MockitoBean
     private EformStagingService mockEFormStagingService;
 
-    @MockBean
+    @MockitoBean
     private EformStagingDTOMapper mockEformStagingDTOMapper;
 
-    @MockBean
+    @MockitoBean
     private UsnValidator mockUsnValidator;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsDecisionHistoryControllerTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -22,7 +22,7 @@ public class EformsDecisionHistoryControllerTest {
 
     private static final String BASE_ENDPOINT_FORMAT = "/api/eform/decision-history";
 
-    @MockBean
+    @MockitoBean
     private EformsDecisionHistoryService eformsDecisionHistoryService;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsHistoryControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/controller/EformsHistoryControllerTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -22,7 +22,7 @@ public class EformsHistoryControllerTest {
 
     private static final String BASE_ENDPOINT_FORMAT = "/api/eform/history";
 
-    @MockBean
+    @MockitoBean
     private EformsHistoryService eformsHistoryService;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformAuditServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformAuditServiceTest.java
@@ -1,6 +1,5 @@
 package gov.uk.courtdata.eform.service;
 
-import gov.uk.courtdata.eform.exception.UsnException;
 import gov.uk.courtdata.eform.repository.EformAuditRepository;
 import gov.uk.courtdata.eform.repository.entity.EformsAudit;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,11 +8,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Optional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,7 +32,7 @@ public class EformAuditServiceTest {
             .maatRef(null)
             .build();
 
-    @MockBean
+    @MockitoBean
     private EformAuditRepository mockEformAuditRepository;
 
     private EformAuditService eformAuditService;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformStagingServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/eform/service/EformStagingServiceTest.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -40,10 +40,10 @@ class EformStagingServiceTest {
             .maatRef(MAAT_ID)
             .build();
 
-    @MockBean
+    @MockitoBean
     private EformStagingRepository mockEformStagingRepository;
 
-    @MockBean
+    @MockitoBean
     private EformStagingDTOMapper mockEformStagingDTOMapper;
 
     private EformStagingService eformStagingService;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/controller/HardshipReviewControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/hardship/controller/HardshipReviewControllerTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -37,9 +37,9 @@ class HardshipReviewControllerTest {
     private static final String PATCH_ENDPOINT_URL = ENDPOINT_URL.concat("/{hardshipReviewId}");
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private HardshipReviewService hardshipReviewService;
-    @MockBean
+    @MockitoBean
     private HardshipReviewValidationProcessor hardshipReviewValidationProcessor;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ConcorContributionsRestControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/ConcorContributionsRestControllerIntegrationTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDateTime;
@@ -45,7 +45,7 @@ class ConcorContributionsRestControllerIntegrationTest extends MockMvcIntegratio
     private static final String ENDPOINT_URL = "/api/internal/v1/debt-collection-enforcement/concor-contribution-files?status=";
     private static final String DRC_UPDATE_URL = "/api/internal/v1/debt-collection-enforcement/log-contribution-response";
 
-    @SpyBean
+    @MockitoSpyBean
     DebtCollectionRepository debtCollectionRepositorySpy;
 
     private static int savedEntityId3;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/FdcContributionsIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/dces/FdcContributionsIntegrationTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -61,7 +61,7 @@ class FdcContributionsIntegrationTest extends MockMvcIntegrationTest {
     private static int file2Id;
     private static final String FILE_TWO = "FileTwo";
 
-    @SpyBean
+    @MockitoSpyBean
     DebtCollectionRepository debtCollectionRepositorySpy;
 
     @BeforeEach

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/iojappeal/controller/IOJAppealControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/iojappeal/controller/IOJAppealControllerTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -33,9 +33,9 @@ public class IOJAppealControllerTest {
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/ioj-appeal";
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private IOJAppealService iojAppealService;
-    @MockBean
+    @MockitoBean
     private IOJAppealValidationProcessor iojAppealValidationProcessor;
     @Autowired
     private ObjectMapper objectMapper;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/offence/controller/OffenceControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/offence/controller/OffenceControllerTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -24,7 +24,7 @@ public class OffenceControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private OffenceService offenceService;
 
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/offence";

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/CCOutcomeControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/CCOutcomeControllerTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -31,10 +31,10 @@ class CCOutcomeControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private CCOutComeValidationProcessor validator;
 
-    @MockBean
+    @MockitoBean
     private CCOutcomeService service;
 
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/cc-outcome";

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderCapitalControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderCapitalControllerTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -27,9 +27,9 @@ class RepOrderCapitalControllerTest {
     private static final Integer INVALID_REP_ID = -1;
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private MaatIdValidator maatIdValidator;
-    @MockBean
+    @MockitoBean
     private RepOrderCapitalService service;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
@@ -18,15 +18,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
@@ -68,17 +67,17 @@ class RepOrderControllerTest {
 
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private UpdateAppDateCompletedValidator updateAppDateCompletedValidator;
-    @MockBean
+    @MockitoBean
     private MaatIdValidator maatIdValidator;
-    @MockBean
+    @MockitoBean
     private RepOrderService repOrderService;
-    @MockBean
+    @MockitoBean
     private RepOrderMvoRegService repOrderMvoRegService;
-    @MockBean
+    @MockitoBean
     private RepOrderMvoService repOrderMvoService;
-    @MockBean
+    @MockitoBean
     private RepOrderRepository repOrderRepository;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderEquityControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderEquityControllerTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -26,7 +26,7 @@ public class RepOrderEquityControllerTest {
     private static final int REP_ID = 777;
     private static final RepOrderEquityEntity REP_ORDER_EQUITY = RepOrderEquityEntity.builder().id(ID).build();
 
-    @MockBean
+    @MockitoBean
     RepOrderEquityService mockRepOrderEquityService;
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/ReservationsControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/ReservationsControllerTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -37,10 +37,10 @@ public class ReservationsControllerTest {
             .recordId(RESERVATION_ID)
             .build();
 
-    @MockBean
+    @MockitoBean
     private ReservationsRepositoryHelper reservationsRepositoryHelper;
 
-    @MockBean
+    @MockitoBean
     ReservationsService reservationsService;
     @Autowired
     private MockMvc mvc;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderEquityServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderEquityServiceTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Optional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,7 +30,7 @@ public class RepOrderEquityServiceTest {
             .id(ID)
             .build();
 
-    @MockBean
+    @MockitoBean
     private RepOrderEquityRepository mockRepOrderEquityRepository;
 
     private RepOrderEquityService repOrderEquityService;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/ReservationsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/ReservationsServiceTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Optional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static gov.uk.courtdata.builder.TestModelDataBuilder.RESERVATION_ID;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 @WebMvcTest(ReservationsService.class)
 public class ReservationsServiceTest {
 
-    @MockBean
+    @MockitoBean
     ReservationsRepository reservationsRepository;
 
     private ReservationsService reservationsService;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/users/controller/UserSummaryControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/users/controller/UserSummaryControllerTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -24,7 +24,7 @@ public class UserSummaryControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private UserSummaryService userSummaryService;
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/wqhearing/controller/WQHearingControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/wqhearing/controller/WQHearingControllerTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 class WQHearingControllerTest {
 
-    @MockBean
+    @MockitoBean
     private WQHearingService wqHearingService;
     @Autowired
     private MockMvc mvc;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/wqlinkregister/controller/WQLinkRegisterControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/wqlinkregister/controller/WQLinkRegisterControllerTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -23,7 +23,7 @@ class WQLinkRegisterControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private WQLinkRegisterService wqLinkRegisterService;
 
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/wq-link-register";

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/wqoffence/controller/WQOffenceControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/wqoffence/controller/WQOffenceControllerTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class WQOffenceControllerTest {
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private WQOffenceService wqOffenceService;
 
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/wq-offence";

--- a/maat-court-data-api/src/testSqsIntegration/java/integration/CreateLinkListenerEndToEndTest.java
+++ b/maat-court-data-api/src/testSqsIntegration/java/integration/CreateLinkListenerEndToEndTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -38,10 +38,10 @@ class CreateLinkListenerEndToEndTest {
 
     private static final int ONCE = 1;
 
-    @MockBean
+    @MockitoBean
     private CreateLinkService createLinkService;
 
-    @MockBean
+    @MockitoBean
     private QueueMessageLogService queueMessageLogService;
 
 


### PR DESCRIPTION
This PR replaces the deprecated testing annotations `@MockBean` and `@SpyBean` with the recommended `@MockitoBean` and `@MockitoSpyBean` annotations. Prior to Spring Framework version `6.2.2` this new annotation could only be applied at a field-level and not directly to types, however this has been fixed with `6.2.2` (which is used by Spring Boot `3.4.2`).

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1700)