### PR TITLE
LCAM-1789: Fix Failing Evidence Fee Test Scenarios in the Functional Test Suite

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/CCOutcomeController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/CCOutcomeController.java
@@ -4,7 +4,6 @@ import gov.uk.courtdata.annotation.StandardApiResponse;
 import gov.uk.courtdata.dto.ErrorDTO;
 import gov.uk.courtdata.dto.RepOrderCCOutcomeDTO;
 import gov.uk.courtdata.enums.LoggingData;
-import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.model.RepOrderCCOutcome;
 import gov.uk.courtdata.reporder.service.CCOutcomeService;
 import gov.uk.courtdata.reporder.validator.CCOutComeValidationProcessor;
@@ -19,19 +18,17 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import static java.util.Objects.nonNull;
 
 
 @Slf4j
@@ -42,9 +39,7 @@ import static java.util.Objects.nonNull;
 public class CCOutcomeController {
 
     private final CCOutcomeService service;
-
     private final CCOutComeValidationProcessor validator;
-
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Create a new RepOrder CC outcome")
@@ -62,14 +57,16 @@ public class CCOutcomeController {
                     schema = @Schema(implementation = ErrorDTO.class)
             )
     )
-    public ResponseEntity<RepOrderCCOutcomeDTO> create(@Parameter(description = "RepOrder CC outcome data",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = RepOrderCCOutcome.class))) @RequestBody RepOrderCCOutcome repOrderCCOutCome) {
+    public ResponseEntity<RepOrderCCOutcomeDTO> create(
+            @Parameter(description = "RepOrder CC outcome data",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RepOrderCCOutcome.class))) @RequestBody RepOrderCCOutcome repOrderCCOutCome) {
         LoggingData.MAAT_ID.putInMDC(repOrderCCOutCome.getRepId());
         log.info("Create Financial RepOrder CC outcome");
         validator.validate(repOrderCCOutCome);
         return ResponseEntity.ok(service.create(repOrderCCOutCome));
     }
+
 
     @PutMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Update a RepOrder CC outcome Record")
@@ -87,16 +84,18 @@ public class CCOutcomeController {
                     schema = @Schema(implementation = ErrorDTO.class)
             )
     )
-    public ResponseEntity<RepOrderCCOutcomeDTO> update(@Parameter(description = "RepOrder CC outcome data",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = RepOrderCCOutcome.class)
-            )
-    ) @RequestBody RepOrderCCOutcome repOrderCCOutCome) {
+    public ResponseEntity<RepOrderCCOutcomeDTO> update(
+            @Parameter(description = "RepOrder CC outcome data",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RepOrderCCOutcome.class)
+                    )
+            ) @RequestBody RepOrderCCOutcome repOrderCCOutCome) {
         LoggingData.MAAT_ID.putInMDC(repOrderCCOutCome.getRepId());
         log.info("Update RepOrder CC outcome  Request Received");
         validator.validate(repOrderCCOutCome);
         return ResponseEntity.ok(service.update(repOrderCCOutCome));
     }
+
 
     @GetMapping(value = "/reporder/{repId}",
             produces = MediaType.APPLICATION_JSON_VALUE

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/CCOutcomeController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/CCOutcomeController.java
@@ -120,36 +120,12 @@ public class CCOutcomeController {
         LoggingData.MAAT_ID.putInMDC(repId);
         log.info("Find RepOrder CC Outcome Request Received");
         validator.validate(repId);
-        return ResponseEntity.ok(service.findByRepId(repId));
+        List<RepOrderCCOutcomeDTO> outcomes = service.findByRepId(repId);
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.add("X-Total-Records", String.valueOf(outcomes.size()));
+        return new ResponseEntity<>(service.findByRepId(repId), responseHeaders, HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/reporder/{repId}",
-            method = {RequestMethod.HEAD},
-            produces = MediaType.APPLICATION_JSON_VALUE
-    )
-    @Operation(description = "Retrieve a RepOrder CCOutCome size in the header")
-    @ApiResponse(responseCode = "200",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-    @ApiResponse(responseCode = "400",
-            description = "Bad Request.",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = ErrorDTO.class)
-            )
-    )
-    @ApiResponse(responseCode = "500",
-            description = "Server Error.",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = ErrorDTO.class)
-            )
-    )
-    public ResponseEntity<List<RepOrderCCOutcomeDTO>> findByRepIdLengthInHeader(@PathVariable int repId) {
-        LoggingData.MAAT_ID.putInMDC(repId);
-        log.info("Find RepOrder CC Outcome Request Received");
-        validator.validate(repId);
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setContentLength(service.findByRepId(repId).size());
-        return ResponseEntity.ok().headers(responseHeaders).build();
-    }
 
     @Operation(description = "Deleting Crown Court Outcome by a Rep Order Id")
     @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/CCOutcomeController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/CCOutcomeController.java
@@ -8,6 +8,7 @@ import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.model.RepOrderCCOutcome;
 import gov.uk.courtdata.reporder.service.CCOutcomeService;
 import gov.uk.courtdata.reporder.validator.CCOutComeValidationProcessor;
+import gov.uk.courtdata.util.ApiHeaders;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -122,7 +123,7 @@ public class CCOutcomeController {
         validator.validate(repId);
         List<RepOrderCCOutcomeDTO> outcomes = service.findByRepId(repId);
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.add("X-Total-Records", String.valueOf(outcomes.size()));
+        responseHeaders.add(ApiHeaders.TOTAL_RECORDS, String.valueOf(outcomes.size()));
         return new ResponseEntity<>(service.findByRepId(repId), responseHeaders, HttpStatus.OK);
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/util/ApiHeaders.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/util/ApiHeaders.java
@@ -1,0 +1,8 @@
+package gov.uk.courtdata.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class ApiHeaders {
+    public static final String TOTAL_RECORDS = "X-Total-Records";
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/CCOutcomeControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/CCOutcomeControllerIntegrationTest.java
@@ -30,33 +30,32 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
-public class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
-
-    private static final String endpointUrl = "/api/internal/v1/assessment/rep-orders/cc-outcome";
+class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
 
     private static final Integer INVALID_REP_ID = 999999;
     private static final Integer INVALID_OUTCOME_ID = -1;
+    private static final String ENDPOINT_URL = "/api/internal/v1/assessment/rep-orders/cc-outcome";
+
+    private Integer repID;
+    private Integer mockRepId1;
+    private Integer mockRepId2;
+    private RepOrderEntity repOrderEntity;
     private RepOrderEntity existingRepOrder;
 
-    private RepOrderEntity repOrderEntity;
-
-    private RepOrderEntity repOrder;
     @InjectSoftAssertions
     private SoftAssertions softly;
 
-    private Integer REP_ID;
-    private Integer MOCK1_REP_ID;
-    private Integer MOCK2_REP_ID;
 
     @BeforeEach
     void setUp() {
         existingRepOrder = repos.repOrder.saveAndFlush(
             TestEntityDataBuilder.getPopulatedRepOrder());
-        REP_ID = existingRepOrder.getId();
+        repID = existingRepOrder.getId();
         repOrderEntity = repos.repOrder.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
-        MOCK1_REP_ID = repOrderEntity.getId();
-        repOrder = repos.repOrder.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
-        MOCK2_REP_ID = repOrder.getId();
+        mockRepId1 = repOrderEntity.getId();
+        RepOrderEntity repOrder = repos.repOrder.saveAndFlush(
+                TestEntityDataBuilder.getPopulatedRepOrder());
+        mockRepId2 = repOrder.getId();
     }
 
     @AfterEach
@@ -70,29 +69,30 @@ public class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
         repOrderCCOutCome.setUserCreated(null);
         repOrderCCOutCome.setId(null);
         assertTrue(runBadRequestErrorScenario("User created is required",
-                post(endpointUrl).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(repOrderCCOutCome))));
+                post(ENDPOINT_URL).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(repOrderCCOutCome))));
     }
 
     @Test
     void givenAValidData_whenCreateIsInvoked_thenCreateOutcomeIsSuccess() throws Exception {
         RepOrderCCOutcome repOrderCCOutCome = TestModelDataBuilder.getRepOrderCCOutcome();
         repOrderCCOutCome.setId(null);
-        repOrderCCOutCome.setRepId(REP_ID);
-        mockMvc.perform(MockMvcRequestBuilders.post(endpointUrl)
+        repOrderCCOutCome.setRepId(repID);
+        mockMvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL)
                         .content(objectMapper.writeValueAsString(repOrderCCOutCome))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").isNotEmpty())
-                .andExpect(jsonPath("$.repId").value(REP_ID));
+                .andExpect(jsonPath("$.repId").value(repID));
     }
 
     @Test
     void givenAInValidOutcomeId_whenUpdateIsInvoked_thenThrowException() throws Exception {
-        RepOrderCCOutcome repOrderCCOutcome = TestModelDataBuilder.getUpdateRepOrderCCOutcome(INVALID_OUTCOME_ID, REP_ID);
-        repOrderCCOutcome.setRepId(REP_ID);
+        RepOrderCCOutcome repOrderCCOutcome = TestModelDataBuilder.getUpdateRepOrderCCOutcome(INVALID_OUTCOME_ID,
+                repID);
+        repOrderCCOutcome.setRepId(repID);
         assertTrue(runNotFoundErrorScenario("No CC Outcome found for ID: -1",
-                MockMvcRequestBuilders.put(endpointUrl).contentType(MediaType.APPLICATION_JSON)
+                MockMvcRequestBuilders.put(ENDPOINT_URL).contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(repOrderCCOutcome)))
         );
     }
@@ -101,11 +101,12 @@ public class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
     void givenAValidData_whenUpdateIsInvoked_thenShouldUpdatedCCOutCome() throws Exception {
         RepOrderCCOutComeEntity savedOutcome = repos.crownCourtProcessing.saveAndFlush(
             TestEntityDataBuilder.getRepOrderCCOutcomeEntity(1, existingRepOrder));
-        runSuccessScenario(MockMvcRequestBuilders.put(endpointUrl).contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(TestModelDataBuilder.getUpdateRepOrderCCOutcome(savedOutcome.getId(), REP_ID))));
+        runSuccessScenario(MockMvcRequestBuilders.put(ENDPOINT_URL).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(TestModelDataBuilder.getUpdateRepOrderCCOutcome(savedOutcome.getId(),
+                        repID))));
         RepOrderCCOutComeEntity ccOutCome = repos.crownCourtProcessing.findById(
             savedOutcome.getId()).get();
-        softly.assertThat(REP_ID).isEqualTo(ccOutCome.getRepOrder().getId());
+        softly.assertThat(repID).isEqualTo(ccOutCome.getRepOrder().getId());
         softly.assertThat(TestModelDataBuilder.TEST_CASE_ID.toString()).isEqualTo(ccOutCome.getCaseNumber());
         softly.assertThat("430").isEqualTo(ccOutCome.getCrownCourtCode());
         softly.assertThat(TestModelDataBuilder.TEST_USER).isEqualTo(ccOutCome.getUserModified());
@@ -115,22 +116,22 @@ public class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenAInvalidRepId_whenFindIsInvoked_thenReturnValidationException() throws Exception {
         runBadRequestErrorScenario("MAAT/REP ID [999999] is invalid",
-                MockMvcRequestBuilders.get(endpointUrl + "/reporder/" + INVALID_REP_ID));
+                MockMvcRequestBuilders.get(ENDPOINT_URL + "/reporder/" + INVALID_REP_ID));
     }
 
     @Test
     void givenARepIdNotFoundInOutcome_whenFindIsInvoked_thenReturnEmpty() throws Exception {
-        runSuccessScenario(List.of(), MockMvcRequestBuilders.get(endpointUrl + "/reporder/" + REP_ID));
+        runSuccessScenario(List.of(), MockMvcRequestBuilders.get(ENDPOINT_URL + "/reporder/" + repID));
     }
 
     @Test
     void givenAValidRepId_whenFindIsInvoked_thenReturnOutcome() throws Exception {
         repos.crownCourtProcessing.saveAndFlush(
             TestEntityDataBuilder.getRepOrderCCOutcomeEntity(2, existingRepOrder));
-        mockMvc.perform(MockMvcRequestBuilders.get(endpointUrl + "/reporder/" + REP_ID))
+        mockMvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL + "/reporder/" + repID))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$[0].repId").value(REP_ID))
+                .andExpect(jsonPath("$[0].repId").value(repID))
                 .andExpect(jsonPath("$[0].dateCreated").isNotEmpty())
                 .andExpect(jsonPath("$[0].dateModified").isNotEmpty());
     }
@@ -139,7 +140,8 @@ public class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
     void givenAValidRepId_whenFindIsInvoked_thenReturnOutcomeCount() throws Exception {
         RepOrderCCOutComeEntity repOrderCCOutComeEntity = TestEntityDataBuilder.getRepOrderCCOutcomeEntity(3, repOrderEntity);
         repos.crownCourtProcessing.saveAndFlush(repOrderCCOutComeEntity);
-        MvcResult result = runSuccessScenario(MockMvcRequestBuilders.head(endpointUrl + "/reporder/" + MOCK1_REP_ID));
+        MvcResult result = runSuccessScenario(MockMvcRequestBuilders.head(
+                ENDPOINT_URL + "/reporder/" + mockRepId1));
         assertThat(result.getResponse().getHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo("1");
     }
 
@@ -147,7 +149,8 @@ public class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
     void givenAEmptyRepIdInRepOrderOutcome_whenFindIsInvoked_thenReturnOutcomeCountAsZero() throws Exception {
         RepOrderCCOutComeEntity repOrderCCOutComeEntity = TestEntityDataBuilder.getRepOrderCCOutcomeEntity(4, repOrderEntity);
         repos.crownCourtProcessing.saveAndFlush(repOrderCCOutComeEntity);
-        MvcResult result = runSuccessScenario(MockMvcRequestBuilders.head(endpointUrl + "/reporder/" + MOCK2_REP_ID));
+        MvcResult result = runSuccessScenario(MockMvcRequestBuilders.head(
+                ENDPOINT_URL + "/reporder/" + mockRepId2));
         assertThat(result.getResponse().getHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo("0");
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/CCOutcomeControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/CCOutcomeControllerIntegrationTest.java
@@ -14,6 +14,7 @@ import gov.uk.courtdata.entity.RepOrderCCOutComeEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
 import gov.uk.courtdata.model.RepOrderCCOutcome;
+import gov.uk.courtdata.util.ApiHeaders;
 import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -23,7 +24,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -142,7 +142,7 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
         repos.crownCourtProcessing.saveAndFlush(repOrderCCOutComeEntity);
         MvcResult result = runSuccessScenario(MockMvcRequestBuilders.head(
                 ENDPOINT_URL + "/reporder/" + mockRepId1));
-        assertThat(result.getResponse().getHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo("1");
+        assertThat(result.getResponse().getHeader(ApiHeaders.TOTAL_RECORDS)).isEqualTo("1");
     }
 
     @Test
@@ -151,6 +151,6 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
         repos.crownCourtProcessing.saveAndFlush(repOrderCCOutComeEntity);
         MvcResult result = runSuccessScenario(MockMvcRequestBuilders.head(
                 ENDPOINT_URL + "/reporder/" + mockRepId2));
-        assertThat(result.getResponse().getHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo("0");
+        assertThat(result.getResponse().getHeader(ApiHeaders.TOTAL_RECORDS)).isEqualTo("0");
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/CCOutcomeControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/CCOutcomeControllerIntegrationTest.java
@@ -49,7 +49,7 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
     @BeforeEach
     void setUp() {
         existingRepOrder = repos.repOrder.saveAndFlush(
-            TestEntityDataBuilder.getPopulatedRepOrder());
+                TestEntityDataBuilder.getPopulatedRepOrder());
         repID = existingRepOrder.getId();
         repOrderEntity = repos.repOrder.saveAndFlush(TestEntityDataBuilder.getPopulatedRepOrder());
         mockRepId1 = repOrderEntity.getId();
@@ -69,7 +69,8 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
         repOrderCCOutCome.setUserCreated(null);
         repOrderCCOutCome.setId(null);
         assertTrue(runBadRequestErrorScenario("User created is required",
-                post(ENDPOINT_URL).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(repOrderCCOutCome))));
+                post(ENDPOINT_URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(repOrderCCOutCome))));
     }
 
     @Test
@@ -88,8 +89,8 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenAInValidOutcomeId_whenUpdateIsInvoked_thenThrowException() throws Exception {
-        RepOrderCCOutcome repOrderCCOutcome = TestModelDataBuilder.getUpdateRepOrderCCOutcome(INVALID_OUTCOME_ID,
-                repID);
+        RepOrderCCOutcome repOrderCCOutcome =
+                TestModelDataBuilder.getUpdateRepOrderCCOutcome(INVALID_OUTCOME_ID, repID);
         repOrderCCOutcome.setRepId(repID);
         assertTrue(runNotFoundErrorScenario("No CC Outcome found for ID: -1",
                 MockMvcRequestBuilders.put(ENDPOINT_URL).contentType(MediaType.APPLICATION_JSON)
@@ -100,14 +101,19 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
     @Test
     void givenAValidData_whenUpdateIsInvoked_thenShouldUpdatedCCOutCome() throws Exception {
         RepOrderCCOutComeEntity savedOutcome = repos.crownCourtProcessing.saveAndFlush(
-            TestEntityDataBuilder.getRepOrderCCOutcomeEntity(1, existingRepOrder));
-        runSuccessScenario(MockMvcRequestBuilders.put(ENDPOINT_URL).contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(TestModelDataBuilder.getUpdateRepOrderCCOutcome(savedOutcome.getId(),
-                        repID))));
+                TestEntityDataBuilder.getRepOrderCCOutcomeEntity(1, existingRepOrder));
+        runSuccessScenario(
+                MockMvcRequestBuilders.put(ENDPOINT_URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                TestModelDataBuilder.getUpdateRepOrderCCOutcome(
+                                        savedOutcome.getId(),
+                                        repID)))
+        );
         RepOrderCCOutComeEntity ccOutCome = repos.crownCourtProcessing.findById(
-            savedOutcome.getId()).get();
+                savedOutcome.getId()).get();
         softly.assertThat(repID).isEqualTo(ccOutCome.getRepOrder().getId());
-        softly.assertThat(TestModelDataBuilder.TEST_CASE_ID.toString()).isEqualTo(ccOutCome.getCaseNumber());
+        softly.assertThat(TestModelDataBuilder.TEST_CASE_ID.toString())
+                .isEqualTo(ccOutCome.getCaseNumber());
         softly.assertThat("430").isEqualTo(ccOutCome.getCrownCourtCode());
         softly.assertThat(TestModelDataBuilder.TEST_USER).isEqualTo(ccOutCome.getUserModified());
         softly.assertThat(ccOutCome.getDateModified()).isNotNull();
@@ -121,13 +127,14 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenARepIdNotFoundInOutcome_whenFindIsInvoked_thenReturnEmpty() throws Exception {
-        runSuccessScenario(List.of(), MockMvcRequestBuilders.get(ENDPOINT_URL + "/reporder/" + repID));
+        runSuccessScenario(List.of(),
+                MockMvcRequestBuilders.get(ENDPOINT_URL + "/reporder/" + repID));
     }
 
     @Test
     void givenAValidRepId_whenFindIsInvoked_thenReturnOutcome() throws Exception {
         repos.crownCourtProcessing.saveAndFlush(
-            TestEntityDataBuilder.getRepOrderCCOutcomeEntity(2, existingRepOrder));
+                TestEntityDataBuilder.getRepOrderCCOutcomeEntity(2, existingRepOrder));
         mockMvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL + "/reporder/" + repID))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -138,7 +145,8 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
 
     @Test
     void givenAValidRepId_whenFindIsInvoked_thenReturnOutcomeCount() throws Exception {
-        RepOrderCCOutComeEntity repOrderCCOutComeEntity = TestEntityDataBuilder.getRepOrderCCOutcomeEntity(3, repOrderEntity);
+        RepOrderCCOutComeEntity repOrderCCOutComeEntity =
+                TestEntityDataBuilder.getRepOrderCCOutcomeEntity(3, repOrderEntity);
         repos.crownCourtProcessing.saveAndFlush(repOrderCCOutComeEntity);
         MvcResult result = runSuccessScenario(MockMvcRequestBuilders.head(
                 ENDPOINT_URL + "/reporder/" + mockRepId1));
@@ -146,8 +154,10 @@ class CCOutcomeControllerIntegrationTest extends MockMvcIntegrationTest {
     }
 
     @Test
-    void givenAEmptyRepIdInRepOrderOutcome_whenFindIsInvoked_thenReturnOutcomeCountAsZero() throws Exception {
-        RepOrderCCOutComeEntity repOrderCCOutComeEntity = TestEntityDataBuilder.getRepOrderCCOutcomeEntity(4, repOrderEntity);
+    void givenAEmptyRepIdInRepOrderOutcome_whenFindIsInvoked_thenReturnOutcomeCountAsZero()
+            throws Exception {
+        RepOrderCCOutComeEntity repOrderCCOutComeEntity =
+                TestEntityDataBuilder.getRepOrderCCOutcomeEntity(4, repOrderEntity);
         repos.crownCourtProcessing.saveAndFlush(repOrderCCOutComeEntity);
         MvcResult result = runSuccessScenario(MockMvcRequestBuilders.head(
                 ENDPOINT_URL + "/reporder/" + mockRepId2));


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1789)

Due to a recent Spring Boot upgrade, the framework now strictly adheres to HTTP standards by removing or overriding a manually set `Content-Length` headers when the response body is empty. This change broke our previous approach of using `Content-Length` headers to indicate the no. of records returned by some endpoints and therefore needed to be updated.

To resolve this the `CCOutcomeController` was refactored:
- Removed the dedicated `HEAD` endpoint, letting Spring Boot automatically handle `HEAD` requests via the `GET` endpoint.
- Updated the `GET` endpoint to include a custom `X-Total-Records` header that directly returns the record count without needing to serialise the full JSON response.

This solution avoids unnecessary overhead while providing clients with accurate metadata regarding the number of records.

- Several SonarQube issues were also addressed and formatting improved in several areas.