### PR TITLE
LASB-3873 - Updated some connection pool settings to help with connec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Make sure that all tests are passing by running the following ‘gradle’ comma
 The apps should then start cleanly if you run
 
 ```sh
-./startup-local.sh
+./start-local.sh
 ```
 
 laa-maat-court-data-api application will be running on http://localhost:8090 

--- a/maat-court-data-api/src/main/resources/application.yaml
+++ b/maat-court-data-api/src/main/resources/application.yaml
@@ -19,6 +19,8 @@ spring:
     driver-class-name: oracle.jdbc.OracleDriver
     hikari:
       maximum-pool-size: 50
+      minimum-idle: 5 # Min number of idle connections in the pool as otherwise will default to maximum-pool-size
+      leak-detection-threshold: 30000 # will flag leaks in the logs - connections held for > 30 seconds outside the pool
 
   liquibase:
     enabled: false


### PR DESCRIPTION
…tion exhaustion in the MAAT DB

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3873)

Updated the min idle connections to lower than the connection pool size to potentially free up connections on the MAAT DB.
Also, updated the leak-detection-threshold to aid with identifying connection leaks. This property controls the amount of time that a connection can be out of the pool before a message is logged indicating a possible connection leak.

The other configuration parameters detailed in ticket LASB-3873 were reviewed against the HikariCP implementation in MAAT CD API and the existing defaults were considered valid so were not changed.

The max connections would ideally be increased for this service however after review [here](https://dsdmoj.atlassian.net/wiki/spaces/ASLST/pages/5589762332/MAAT+DB+Connection+Analysis) it was not considered wise at this time (some environments require the Oracle MAAT DB to be able to support this, as well as reducing the instances of the MAAT API in some environments).

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.