### PR TITLE
LCAM-1812: Disable Hibernate SQL Logging

### DIFF
--- a/maat-court-data-api/src/main/resources/application.yaml
+++ b/maat-court-data-api/src/main/resources/application.yaml
@@ -40,7 +40,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.OracleDialect
     open-in-view: false
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         jdbc.lob.non_contextual_creation: true


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1812)

Set `jpa.show-sql` to false in the Court Data API configuration to reduce excessive log noise from SQL statements.