### PR TITLE
[LASB-4220] Create new endpoint to populate MAAT_REFS_TO_EXTRACT table

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
@@ -1,0 +1,40 @@
+package gov.uk.courtdata.billing.controller;
+
+import gov.uk.courtdata.billing.service.MaatReferenceService;
+import gov.uk.courtdata.eform.controller.StandardApiResponseCodes;
+import gov.uk.courtdata.exception.RecordsAlreadyExistException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Maat Reference Extraction", description = "Rest API for extracting MAAT references to send to billing teams")
+@RequestMapping("${api-endpoints.billing-domain}")
+public class MaatReferenceExtractionController {
+    
+    private final MaatReferenceService maatReferenceService;
+    
+    @PostMapping(value = "/populate-maat-references")
+    @Operation(description = "Populate the MAAT_REFS_TO_EXTRACT table with data from REP_ORDERS")
+    @StandardApiResponseCodes
+    public ResponseEntity<Object> populateMaatReferencesToExtract() {
+        log.info("Populate MAAT references Request received");
+        
+        try {
+            maatReferenceService.populateTable();
+            log.info("Populate MAAT references Request completed successfully");
+            return ResponseEntity.ok().build();
+        } catch (RecordsAlreadyExistException ex) {
+            log.error(ex.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
@@ -23,7 +23,7 @@ public class MaatReferenceExtractionController {
     private final MaatReferenceService maatReferenceService;
     
     @PostMapping(value = "/populate-maat-references")
-    @Operation(description = "Populate the MAAT_REFS_TO_EXTRACT table with data from REP_ORDERS")
+    @Operation(description = "Create MAAT reference records")
     @StandardApiResponseCodes
     public ResponseEntity<Object> populateMaatReferencesToExtract() {
         log.info("Populate MAAT references Request received");

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
@@ -2,12 +2,10 @@ package gov.uk.courtdata.billing.controller;
 
 import gov.uk.courtdata.billing.service.MaatReferenceService;
 import gov.uk.courtdata.eform.controller.StandardApiResponseCodes;
-import gov.uk.courtdata.exception.RecordsAlreadyExistException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,14 +25,8 @@ public class MaatReferenceExtractionController {
     @StandardApiResponseCodes
     public ResponseEntity<Object> populateMaatReferencesToExtract() {
         log.info("Populate MAAT references Request received");
-        
-        try {
-            maatReferenceService.populateTable();
-            log.info("Populate MAAT references Request completed successfully");
-            return ResponseEntity.ok().build();
-        } catch (RecordsAlreadyExistException ex) {
-            log.error(ex.getMessage());
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
+        maatReferenceService.populateTable();
+        log.info("Populate MAAT references Request completed successfully");
+        return ResponseEntity.ok().build();
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/entity/MaatReferenceEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/entity/MaatReferenceEntity.java
@@ -1,0 +1,38 @@
+package gov.uk.courtdata.billing.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity
+@IdClass(MaatReferenceId.class)
+@Table(name = "MAAT_REFS_TO_EXTRACT", schema = "TOGDATA")
+public class MaatReferenceEntity {
+
+    @Id
+    @Column(name = "MAAT_ID")
+    private Integer maatId;
+
+    @Id
+    @Column(name = "APPL_ID")
+    private Integer applicantId;
+    
+    @Id
+    @Column(name = "APHI_ID")
+    private Integer applicantHistoryId;
+    
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/entity/MaatReferenceId.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/entity/MaatReferenceId.java
@@ -1,0 +1,15 @@
+package gov.uk.courtdata.billing.entity;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MaatReferenceId implements Serializable {
+    private Integer maatId;
+    private Integer applicantId;
+    private Integer applicantHistoryId;
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/repository/MaatReferenceRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/repository/MaatReferenceRepository.java
@@ -1,0 +1,15 @@
+package gov.uk.courtdata.billing.repository;
+
+import gov.uk.courtdata.billing.entity.MaatReferenceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MaatReferenceRepository extends JpaRepository<MaatReferenceEntity, Integer> {
+    
+    @Modifying
+    @Query(value = "INSERT INTO TOGDATA.maat_refs_to_extract (MAAT_ID, APPL_ID, APHI_ID) SELECT id, appl_id, aphi_id FROM rep_orders WHERE send_to_cclf = 'Y'", nativeQuery = true)
+    void populateMaatReferences();
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/repository/MaatReferenceRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/repository/MaatReferenceRepository.java
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface MaatReferenceRepository extends JpaRepository<MaatReferenceEntity, Integer> {
     
     @Modifying
-    @Query(value = "INSERT INTO TOGDATA.maat_refs_to_extract (MAAT_ID, APPL_ID, APHI_ID) SELECT id, appl_id, aphi_id FROM rep_orders WHERE send_to_cclf = 'Y'", nativeQuery = true)
+    @Query(value = "INSERT INTO TOGDATA.maat_refs_to_extract (MAAT_ID, APPL_ID, APHI_ID) SELECT id, appl_id, aphi_id FROM TOGDATA.rep_orders WHERE send_to_cclf = 'Y'", nativeQuery = true)
     void populateMaatReferences();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/MaatReferenceService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/MaatReferenceService.java
@@ -25,7 +25,7 @@ public class MaatReferenceService {
         return ResponseEntity.ok().build();
     }
     
-    private Boolean isTableEmpty() {
+    private boolean isTableEmpty() {
         return maatReferenceRepository.count() == 0;
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/MaatReferenceService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/MaatReferenceService.java
@@ -1,0 +1,31 @@
+package gov.uk.courtdata.billing.service;
+
+import gov.uk.courtdata.billing.repository.MaatReferenceRepository;
+import gov.uk.courtdata.exception.RecordsAlreadyExistException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MaatReferenceService {
+    
+    private final MaatReferenceRepository maatReferenceRepository;
+
+    @Transactional
+    public ResponseEntity<Void> populateTable() {
+        if (!isTableEmpty()) {
+            throw new RecordsAlreadyExistException("The MAAT_REFS_TO_EXTRACT table already has entries");
+        }
+        
+        maatReferenceRepository.populateMaatReferences();
+        return ResponseEntity.ok().build();
+    }
+    
+    private Boolean isTableEmpty() {
+        return maatReferenceRepository.count() == 0;
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/exception/RecordsAlreadyExistException.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/exception/RecordsAlreadyExistException.java
@@ -1,0 +1,7 @@
+package gov.uk.courtdata.exception;
+
+public class RecordsAlreadyExistException extends RuntimeException {
+    public RecordsAlreadyExistException(String message) {
+        super(message);
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/exception/RestControllerAdviser.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/exception/RestControllerAdviser.java
@@ -144,4 +144,14 @@ public class RestControllerAdviser extends ResponseEntityExceptionHandler {
                 .message(errorMessage)
                 .build());
     }
+
+    @ExceptionHandler(RecordsAlreadyExistException.class)
+    public ResponseEntity<ErrorDTO> handleRecordsAlreadyExistException(RecordsAlreadyExistException ex) {
+        String errorMessage = ex.getMessage();
+        log.error(errorMessage);
+
+        return ResponseEntity.internalServerError().body(ErrorDTO.builder()
+            .message(errorMessage)
+            .build());
+    }
 }

--- a/maat-court-data-api/src/main/resources/application.yaml
+++ b/maat-court-data-api/src/main/resources/application.yaml
@@ -129,6 +129,7 @@ api-endpoints:
   applicant-domain: /api/internal/v1/applicant
   debt-collection-enforcement-domain: /api/internal/v1/debt-collection-enforcement
   address-domain: /api/internal/v1/address
+  billing-domain: /api/internal/v1/billing
 
 feature:
   postMvpEnabled: ${POST_MVP_ENABLED}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
@@ -28,7 +28,7 @@ class MaatReferenceExtractionControllerTest {
     private MaatReferenceService maatReferenceService;
 
     @Test
-    void givenNoInput_whenPopulateMaatReferencesToExtract_thenResponseIsReturned() throws Exception {
+    void givenNoInput_whenPopulateMaatReferencesToExtract_thenSuccessResponseIsReturned() throws Exception {
         mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL))
             .andExpect(status().isOk());
         verify(maatReferenceService).populateTable();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @WebMvcTest(MaatReferenceExtractionController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-public class MaatReferenceExtractionControllerTest {
+class MaatReferenceExtractionControllerTest {
     private static final String ENDPOINT_URL = "/api/internal/v1/billing/populate-maat-references";
 
     @Autowired

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
@@ -1,0 +1,44 @@
+package gov.uk.courtdata.billing.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import gov.uk.courtdata.billing.service.MaatReferenceService;
+import gov.uk.courtdata.exception.RecordsAlreadyExistException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(MaatReferenceExtractionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class MaatReferenceExtractionControllerTest {
+    private static final String ENDPOINT_URL = "/api/internal/v1/billing/populate-maat-references";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private MaatReferenceService maatReferenceService;
+
+    @Test
+    void givenNoInput_whenPopulateMaatReferencesToExtract_thenResponseIsReturned() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL))
+            .andExpect(status().isOk());
+        verify(maatReferenceService).populateTable();
+    }
+    @Test
+    void givenRecordsAlreadyExist_whenPopulateMaatReferencesToExtract_thenReturnError() throws Exception {
+        when(maatReferenceService.populateTable()).thenThrow(RecordsAlreadyExistException.class);
+
+        mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL))
+            .andExpect(status().isInternalServerError());
+        verify(maatReferenceService).populateTable();
+    }
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/MaatReferenceServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/MaatReferenceServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class MaatReferenceServiceTest {
+class MaatReferenceServiceTest {
 
     @Mock
     private MaatReferenceRepository maatReferenceRepository;

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/MaatReferenceServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/MaatReferenceServiceTest.java
@@ -1,0 +1,43 @@
+package gov.uk.courtdata.billing.service;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import gov.uk.courtdata.billing.repository.MaatReferenceRepository;
+import gov.uk.courtdata.exception.RecordsAlreadyExistException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MaatReferenceServiceTest {
+
+    @Mock
+    private MaatReferenceRepository maatReferenceRepository;
+    
+    private MaatReferenceService maatReferenceService;
+    
+    @BeforeEach
+    void setUp() {
+        maatReferenceService = new MaatReferenceService(maatReferenceRepository);
+    }
+
+    @Test
+    void givenNoInput_whenPopulateTableInvoked_thenInsertIsSuccessful() {
+        maatReferenceService.populateTable();
+        verify(maatReferenceRepository, atLeastOnce()).count();
+        verify(maatReferenceRepository, atLeastOnce()).populateMaatReferences();
+    }
+    
+    @Test
+    void givenEntriesAlreadyExist_whenPopulateTableInvoked_thenThrowAnException() {
+        when(maatReferenceRepository.count()).thenReturn(10L);
+
+        Assertions.assertThrows(RecordsAlreadyExistException.class,
+            () -> maatReferenceService.populateTable());
+    }
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -43,6 +43,7 @@ public class TestEntityDataBuilder {
     public static final Integer TEST_CASE_ID = 665313;
     public static final String TEST_OFFENCE_ID = "634169aa-265b-4bb5-a7b0-04718f896d2f";
     public static final String TEST_ASN_SEQ = "123";
+    public static final Integer APPLICATION_ID = 7852;
     public static final Integer APPLICANT_ID = 2345;
     public static final Integer APPLICANT_HISTORY_ID = 9876;
 
@@ -92,6 +93,23 @@ public class TestEntityDataBuilder {
                 .sentenceOrderDate(sentenceOrderDate)
                 .dateReceived(dateReceived)
                 .build();
+    }
+
+    public static RepOrderEntity getPopulatedRepOrderToSendToCclf() {
+        return RepOrderEntity.builder()
+            .catyCaseType("case-type")
+            .magsOutcome("outcome")
+            .magsOutcomeDate(TEST_DATE.toString())
+            .magsOutcomeDateSet(TEST_DATE)
+            .committalDate(TEST_DATE.toLocalDate())
+            .decisionReasonCode("rder-code")
+            .crownRepOrderDecision("cc-rep-doc")
+            .crownRepOrderType("cc-rep-type")
+            .sentenceOrderDate(TEST_DATE.toLocalDate())
+            .applicationId(APPLICATION_ID)
+            .applicantHistoryId(APPLICANT_HISTORY_ID)
+            .isSendToCCLF(true)
+            .build();
     }
 
     public static ApplicantDisabilitiesEntity getApplicantDisabilitiesEntity() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -3,6 +3,7 @@ package gov.uk.courtdata.builder;
 import gov.uk.courtdata.applicant.entity.ApplicantDisabilitiesEntity;
 import gov.uk.courtdata.applicant.entity.ApplicantHistoryEntity;
 import gov.uk.courtdata.applicant.entity.RepOrderApplicantLinksEntity;
+import gov.uk.courtdata.billing.entity.MaatReferenceEntity;
 import gov.uk.courtdata.entity.*;
 import gov.uk.courtdata.enums.ConcorContributionStatus;
 import gov.uk.courtdata.enums.FdcContributionsStatus;
@@ -43,6 +44,7 @@ public class TestEntityDataBuilder {
     public static final String TEST_OFFENCE_ID = "634169aa-265b-4bb5-a7b0-04718f896d2f";
     public static final String TEST_ASN_SEQ = "123";
     public static final Integer APPLICANT_ID = 2345;
+    public static final Integer APPLICANT_HISTORY_ID = 9876;
 
     public static RepOrderEntity getRepOrder() {
         return RepOrderEntity.builder().id(REP_ID).build();
@@ -890,6 +892,14 @@ public class TestEntityDataBuilder {
                 .defendantId("556677")
                 .caseUrn("testCaseURN")
                 .build();
+    }
+
+    public MaatReferenceEntity getMaatReferenceEntity() {
+        return MaatReferenceEntity.builder()
+            .maatId(REP_ID)
+            .applicantId(APPLICANT_ID)
+            .applicantHistoryId(APPLICANT_HISTORY_ID)
+            .build();
     }
 
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/billing/MaatReferenceExtractionControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/billing/MaatReferenceExtractionControllerIntegrationTest.java
@@ -1,0 +1,43 @@
+package gov.uk.courtdata.integration.billing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import gov.uk.MAATCourtDataApplication;
+import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.integration.util.MockMvcIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@SpringBootTest(classes = {MAATCourtDataApplication.class})
+public class MaatReferenceExtractionControllerIntegrationTest extends MockMvcIntegrationTest {
+
+    private static final String ENDPOINT_URL = "/api/internal/v1/billing/populate-maat-references";
+
+    @Autowired
+    private TestEntityDataBuilder testEntityDataBuilder;
+    
+    @Test
+    void givenNoInput_whenPopulateMaatReferencesToExtract_thenSuccessResponseIsReturned() throws Exception {
+        assertThat(runSuccessScenario(post(ENDPOINT_URL)).getResponse().getStatus()).isEqualTo(200);
+    }
+    
+    @Test
+    void givenRecordsAlreadyExist_whenPopulateMaatReferencesToExtract_thenReturnError() throws Exception {
+        repos.maatReference.saveAndFlush(testEntityDataBuilder.getMaatReferenceEntity());
+        
+        assertTrue(
+            runServerErrorScenario("The MAAT_REFS_TO_EXTRACT table already has entries",
+                getPostRequest()));
+    }
+
+    private MockHttpServletRequestBuilder getPostRequest() {
+        return post(ENDPOINT_URL)
+            .contentType(MediaType.APPLICATION_JSON);
+    }
+
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/billing/MaatReferenceExtractionControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/billing/MaatReferenceExtractionControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package gov.uk.courtdata.integration.billing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
@@ -22,8 +23,11 @@ public class MaatReferenceExtractionControllerIntegrationTest extends MockMvcInt
     private TestEntityDataBuilder testEntityDataBuilder;
     
     @Test
-    void givenNoInput_whenPopulateMaatReferencesToExtract_thenSuccessResponseIsReturned() throws Exception {
+    void givenAValidRepOrder_whenPopulateMaatReferencesToExtract_thenSuccessResponseIsReturned() throws Exception {
+        repos.repOrder.saveAndFlush(testEntityDataBuilder.getPopulatedRepOrderToSendToCclf());
+        
         assertThat(runSuccessScenario(post(ENDPOINT_URL)).getResponse().getStatus()).isEqualTo(200);
+        assertEquals(1, repos.maatReference.count());
     }
     
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/util/Repositories.java
@@ -3,6 +3,7 @@ package gov.uk.courtdata.integration.util;
 import gov.uk.courtdata.applicant.repository.ApplicantDisabilitiesRepository;
 import gov.uk.courtdata.applicant.repository.ApplicantHistoryRepository;
 import gov.uk.courtdata.applicant.repository.RepOrderApplicantLinksRepository;
+import gov.uk.courtdata.billing.repository.MaatReferenceRepository;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.contribution.repository.ContributionsRepository;
 import gov.uk.courtdata.eform.repository.EformStagingRepository;
@@ -269,7 +270,10 @@ public class Repositories {
 
   @Autowired
   public XLATResultRepository xlatResult;
-
+  
+  @Autowired
+  public MaatReferenceRepository maatReference;
+  
   @Autowired
   private RepositoryUtil repositoryUtil;
 
@@ -340,7 +344,8 @@ public class Repositories {
         wqSession,
         xlatOffence,
         fdcItemsRepository,
-        xlatResult};
+        xlatResult,
+        maatReference};
   }
 
   public void insertCommonTestData() {

--- a/maat-court-data-api/src/test/resources/application.yaml
+++ b/maat-court-data-api/src/test/resources/application.yaml
@@ -123,3 +123,4 @@ api-endpoints:
   debt-collection-enforcement-domain: /api/internal/v1/debt-collection-enforcement
   user-domain: /api/internal/v1/users
   address-domain: /api/internal/v1/address
+  billing-domain: /api/internal/v1/billing


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4220)

Added a new endpoint "populate-maat-references" to populate a new table "MAAT_REFS_TO_EXTRACT" with required data from the "REP_ORDERS" table. This task is part of the replacement of one of the hub jobs. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.