### PR TITLE
LASB-4235 - DRC Integration Tests Timeout Fix

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -67,8 +67,8 @@ public class ConcorContributionsService {
         }
         log.info("Searching concor contribution file with status {}, startId {} and count {}", status, concorContributionId, noOfRecords);
         Pageable pageable = PageRequest.of(0, noOfRecords, Sort.by("id"));
-        return buildConcorContributionResponseList(() -> concorRepository.findByStatusAndIdGreaterThan(status,
-            finalConcorContributionId, pageable));
+        List<Integer> idList = concorRepository.findIdsByStatusAndIdGreaterThan(status, finalConcorContributionId, pageable);
+        return buildConcorContributionResponseList(() -> concorRepository.findByIdIn(Set.copyOf(idList)));
     }
 
     public List<ConcorContributionResponse> getConcorContributionXml(List<Integer> idList) {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
@@ -18,12 +18,12 @@ public interface ConcorContributionsRepository extends JpaRepository<ConcorContr
     List<ConcorContributionsEntity> findByIdIn(Set<Integer> ids);
 
     @Query("""
-       SELECT cc
+       SELECT cc.id
        FROM ConcorContributionsEntity cc
        WHERE cc.status = :status
        AND cc.id > :startId
-       ORDER BY cc.id ASC""")
-    List<ConcorContributionsEntity> findByStatusAndIdGreaterThan(
+       """)
+    List<Integer> findIdsByStatusAndIdGreaterThan(
             @Param("status") ConcorContributionStatus status,
             @Param("startId") Integer startId,
             Pageable pageable);

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/dces/service/ConcorContributionsServiceTest.java
@@ -100,12 +100,17 @@ class ConcorContributionsServiceTest {
                 TestEntityDataBuilder.getPopulatedConcorContributionsEntity(344, testXml),
                 TestEntityDataBuilder.getPopulatedConcorContributionsEntity(345, testXml)
         );
+        List<Integer> idList = List.of(344,345);
+        Set<Integer> idSet = Set.copyOf(idList);
+
         Pageable pageable = PageRequest.of(0, 3, Sort.by("id"));
-        when(concorRepository.findByStatusAndIdGreaterThan(ACTIVE, 343, pageable)).thenReturn(entities);
+        when(concorRepository.findIdsByStatusAndIdGreaterThan(ACTIVE, 343, pageable)).thenReturn(idList);
+        when(concorRepository.findByIdIn(idSet)).thenReturn(entities);
 
         List<ConcorContributionResponse> responseList = concorService.getConcorContributionFiles(ACTIVE, 3, 343);
 
-        verify(concorRepository).findByStatusAndIdGreaterThan(any(), any(), any());
+        verify(concorRepository).findIdsByStatusAndIdGreaterThan(ACTIVE, 343, pageable);
+        verify(concorRepository).findByIdIn(idSet);
         assertThat(responseList)
                 .isNotNull()
                 .isNotEmpty();
@@ -122,11 +127,19 @@ class ConcorContributionsServiceTest {
                 TestEntityDataBuilder.getPopulatedConcorContributionsEntity(345, testXml),
                 TestEntityDataBuilder.getPopulatedConcorContributionsEntity(346, testXml)
         );
-        when(concorRepository.findByStatusAndIdGreaterThan(any(),any(), any())).thenReturn(entities);
 
+        List<Integer> idList = List.of(343,344,345,346);
+        Set<Integer> idSet = Set.copyOf(idList);
+        Pageable pageable = PageRequest.of(0, 350, Sort.by("id"));
+
+
+        when(concorRepository.findIdsByStatusAndIdGreaterThan(ACTIVE, 0, pageable)).thenReturn(idList);
+        when(concorRepository.findByIdIn(idSet)).thenReturn(entities);
+        // do
         List<ConcorContributionResponse> responseList = concorService.getConcorContributionFiles(ACTIVE, null, null);
-
-        verify(concorRepository).findByStatusAndIdGreaterThan(any(), any(), any());
+        // verify
+        verify(concorRepository).findIdsByStatusAndIdGreaterThan(any(), any(), any());
+        verify(concorRepository).findByIdIn(idSet);
         assertThat(responseList)
                 .isNotNull()
                 .isNotEmpty();
@@ -136,8 +149,7 @@ class ConcorContributionsServiceTest {
     @Test
     void givenSomeActiveContributions_whenGetConcorContributionFilesIsCalledWithInvalidStartId_thenEmptyListIsReturned() {
         Pageable pageable = PageRequest.of(0, 2, Sort.by("id"));
-        when(concorRepository.findByStatusAndIdGreaterThan(ACTIVE, 999, pageable)).thenReturn(List.of());
-
+        when(concorRepository.findIdsByStatusAndIdGreaterThan(ACTIVE, 999, pageable)).thenReturn(List.of());
         List<ConcorContributionResponse> responseList = concorService.getConcorContributionFiles(ACTIVE, 2, 999);
 
         assertThat(responseList)


### PR DESCRIPTION


## What

DRC-Integration was having issues with timeouts on the integration tests. Have made modifications to the long call to attempt to remedy this. 
Change process for fetching ConcorContributions to find the ids first, then use a second query to fetch the details.

This will affect the main DRC-Integration process as well, and has been verified by running the integration tests, which are now passing. However an eye will have to be kept to ensure things are being sent exactly as before.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.