### PR TITLE
Add endpoint to replace Hub rep orders data extraction

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/RepOrderBillingController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/RepOrderBillingController.java
@@ -1,0 +1,31 @@
+package gov.uk.courtdata.billing.controller;
+
+import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
+import gov.uk.courtdata.billing.service.RepOrderBillingService;
+import gov.uk.courtdata.annotation.StandardApiResponseCodes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("${api-endpoints.billing-domain}/rep-orders")
+@Tag(name = "RepOrder", description = "Rest API for billing-specific rep orders")
+public class RepOrderBillingController {
+
+    private final RepOrderBillingService repOrderBillingService;
+
+    @GetMapping
+    @Operation(description = "Retrieve rep orders for billing")
+    @StandardApiResponseCodes
+    public ResponseEntity<List<RepOrderBillingDTO>> getRepOrders() {
+        return ResponseEntity.ok(repOrderBillingService.getRepOrdersForBilling());
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/dto/RepOrderBillingDTO.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/dto/RepOrderBillingDTO.java
@@ -1,0 +1,34 @@
+package gov.uk.courtdata.billing.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RepOrderBillingDTO {
+    private Integer id;
+    private Integer applicantId;
+    private String arrestSummonsNo;
+    private String evidenceFeeLevel;
+    private String supplierAccountCode;
+    private Integer magsCourtId;
+    private String magsCourtOutcome;
+    private LocalDate dateReceived;
+    private LocalDate crownCourtRepOrderDate;
+    private String offenceType;
+    private LocalDate crownCourtWithdrawalDate;
+    private Integer applicantHistoryId;
+    private String caseId;
+    private LocalDate committalDate;
+    private String repOrderStatus;
+    private String appealTypeCode;
+    private String crownCourtOutcome;
+    private LocalDate dateCreated;
+    private String userCreated;
+    private LocalDateTime dateModified;
+    private String userModified;
+    private String caseType;
+
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/mapper/RepOrderBillingMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/mapper/RepOrderBillingMapper.java
@@ -1,0 +1,41 @@
+package gov.uk.courtdata.billing.mapper;
+
+import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
+import gov.uk.courtdata.entity.RepOrderEntity;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class RepOrderBillingMapper {
+    private RepOrderBillingMapper() { }
+
+    public static RepOrderBillingDTO mapEntityToDTO(RepOrderEntity repOrderEntity) {
+        Integer magsCourtId = StringUtils.isEmpty(repOrderEntity.getMacoCourt())
+            ? null : Integer.parseInt(repOrderEntity.getMacoCourt());
+
+        return RepOrderBillingDTO.builder()
+            .id(repOrderEntity.getId())
+            .applicantId(repOrderEntity.getApplicationId())
+            .arrestSummonsNo(repOrderEntity.getArrestSummonsNo())
+            .evidenceFeeLevel(repOrderEntity.getEvidenceFeeLevel())
+            .supplierAccountCode(repOrderEntity.getSuppAccountCode())
+            .magsCourtId(magsCourtId)
+            .magsCourtOutcome(repOrderEntity.getMagsOutcome())
+            .dateReceived(repOrderEntity.getDateReceived())
+            .crownCourtRepOrderDate(repOrderEntity.getCrownRepOrderDate())
+            .offenceType(repOrderEntity.getOftyOffenceType())
+            .crownCourtWithdrawalDate(repOrderEntity.getCrownWithdrawalDate())
+            .applicantHistoryId(repOrderEntity.getApplicantHistoryId())
+            .caseId(repOrderEntity.getCaseId())
+            .committalDate(repOrderEntity.getCommittalDate())
+            .repOrderStatus(repOrderEntity.getRorsStatus())
+            .appealTypeCode(repOrderEntity.getAppealTypeCode())
+            .crownCourtOutcome(repOrderEntity.getCrownOutcome())
+            .dateCreated(repOrderEntity.getDateCreated())
+            .userCreated(repOrderEntity.getUserCreated())
+            .dateModified(repOrderEntity.getDateModified())
+            .userModified(repOrderEntity.getUserModified())
+            .caseType(repOrderEntity.getCatyCaseType())
+            .build();
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/RepOrderBillingService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/RepOrderBillingService.java
@@ -1,0 +1,32 @@
+package gov.uk.courtdata.billing.service;
+
+import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
+import gov.uk.courtdata.billing.mapper.RepOrderBillingMapper;
+import gov.uk.courtdata.entity.RepOrderEntity;
+import gov.uk.courtdata.repository.RepOrderRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RepOrderBillingService {
+
+    private final RepOrderRepository repOrderRepository;
+
+    public List<RepOrderBillingDTO> getRepOrdersForBilling() {
+        List<RepOrderEntity> extractedRepOrders = repOrderRepository.getRepOrdersForBilling();
+
+        if (extractedRepOrders.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return extractedRepOrders.stream()
+            .map(RepOrderBillingMapper::mapEntityToDTO)
+            .collect(Collectors.toList());
+    }
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/RepOrderEntity.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/entity/RepOrderEntity.java
@@ -1,7 +1,6 @@
 package gov.uk.courtdata.entity;
 
 import gov.uk.courtdata.reporderhistory.entity.RepOrderHistoryEntity;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -105,6 +104,9 @@ public class RepOrderEntity {
 
     @Column(name = "RDER_CODE")
     private String decisionReasonCode;
+
+    @Column(name = "CCOO_OUTCOME")
+    private String crownOutcome;
 
     @Column(name = "CC_REP_ID")
     private Integer crownRepId;

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
@@ -57,5 +57,34 @@ public interface RepOrderRepository extends JpaRepository<RepOrderEntity, Intege
                         """, nativeQuery = true)
     Set<Integer> findEligibleForFdcFastTracking(@Param("delayPeriod") int delayPeriod, @Param("dateReceived") LocalDate dateReceived, @Param("numRecords") int numRecords);
 
+    @Query(value = """
+                        SELECT  r.id
+                              , r.appl_id
+                              , r.arrest_summons_no
+                              , r.efel_fee_level
+                              , r.supp_account_code
+                              , r.maco_court
+                              , r.mcoo_outcome
+                              , r.date_received
+                              , r.cc_reporder_date
+                              , r.ofty_offence_type
+                              , r.cc_withdrawal_date
+                              , r.aphi_id
+                              , r.case_id
+                              , r.committal_date
+                              , r.rors_status
+                              , r.apty_code
+                              , r.ccoo_outcome
+                              , r.date_created
+                              , r.user_created
+                              , r.date_modified
+                              , r.user_modified
+                              , r.caty_case_type
+                        FROM    REP_ORDERS r
+                        JOIN    MAAT_REFS_TO_EXTRACT ex
+                        ON      r.ID = ex.MAAT_ID
+    """, nativeQuery = true)
+    List<RepOrderEntity> getRepOrdersForBilling();
+
 }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/RepOrderBillingControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/RepOrderBillingControllerTest.java
@@ -1,0 +1,43 @@
+package gov.uk.courtdata.billing.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import gov.uk.courtdata.billing.service.RepOrderBillingService;
+import gov.uk.courtdata.builder.TestModelDataBuilder;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(RepOrderBillingController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class RepOrderBillingControllerTest {
+
+    private static final String ENDPOINT_URL = "/api/internal/v1/billing/rep-orders";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RepOrderBillingService repOrderBillingService;
+
+    @Test
+    void givenValidRequest_whenGetRepOrdersForBillingIsInvoked_thenResponseIsReturned() throws Exception {
+        when(repOrderBillingService.getRepOrdersForBilling()).thenReturn(List.of(
+            TestModelDataBuilder.getRepOrderBillingDTO(123)));
+
+        mockMvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL))
+               .andExpect(status().isOk())
+               .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/mapper/RepOrderBillingMapperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/mapper/RepOrderBillingMapperTest.java
@@ -1,0 +1,55 @@
+package gov.uk.courtdata.billing.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
+import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.entity.RepOrderEntity;
+import gov.uk.courtdata.enums.CrownCourtCaseType;
+import gov.uk.courtdata.enums.CrownCourtTrialOutcome;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.enums.AppealType;
+import uk.gov.justice.laa.crime.enums.EvidenceFeeLevel;
+import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
+
+@ExtendWith(MockitoExtension.class)
+class RepOrderBillingMapperTest {
+
+    @Test
+    void givenARepOrderEntity_whenMapEntityToDtoIsInvoked_thenDtoIsReturned() {
+        RepOrderBillingDTO expectedRepOrder = RepOrderBillingDTO.builder()
+            .id(123)
+            .applicantId(12)
+            .arrestSummonsNo("ARREST-5678")
+            .evidenceFeeLevel(EvidenceFeeLevel.LEVEL1.getFeeLevel())
+            .supplierAccountCode("AB123C")
+            .magsCourtId(34)
+            .magsCourtOutcome(MagCourtOutcome.COMMITTED.getOutcome())
+            .dateReceived(LocalDate.of(2025, 6, 10))
+            .crownCourtRepOrderDate(LocalDate.of(2025, 6, 12))
+            .offenceType("BURGLARY")
+            .crownCourtWithdrawalDate(LocalDate.of(2025, 6, 30))
+            .applicantHistoryId(96)
+            .caseId("CASE-123-C")
+            .committalDate(LocalDate.of(2025, 6, 11))
+            .repOrderStatus("CURR")
+            .appealTypeCode(AppealType.ACN.getCode())
+            .crownCourtOutcome(CrownCourtTrialOutcome.CONVICTED.getValue())
+            .dateCreated(LocalDate.of(2025, 6, 20))
+            .userCreated("joe-bloggs")
+            .dateModified(LocalDate.of(2025, 6, 21).atStartOfDay())
+            .userModified("alice-smith")
+            .caseType(CrownCourtCaseType.EITHER_WAY.getValue())
+            .build();
+
+        RepOrderEntity entity = TestEntityDataBuilder.getPopulatedRepOrderForBilling(123);
+
+        RepOrderBillingDTO actualRepOrder = RepOrderBillingMapper.mapEntityToDTO(entity);
+
+        assertEquals(expectedRepOrder, actualRepOrder);
+    }
+
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/RepOrderBillingServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/RepOrderBillingServiceTest.java
@@ -1,0 +1,54 @@
+package gov.uk.courtdata.billing.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
+import gov.uk.courtdata.billing.mapper.RepOrderBillingMapper;
+import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.repository.RepOrderRepository;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RepOrderBillingServiceTest {
+
+    @Mock
+    private RepOrderRepository repOrderRepository;
+
+    @InjectMocks
+    private RepOrderBillingService repOrderBillingService;
+
+    @Test
+    void givenNoRepOrders_whenGetRepOrdersForBillingIsInvoked_thenEmptyListIsReturned() {
+        when(repOrderRepository.getRepOrdersForBilling()).thenReturn(Collections.emptyList());
+
+        List<RepOrderBillingDTO> repOrders = repOrderBillingService.getRepOrdersForBilling();
+
+        assertEquals(Collections.emptyList(), repOrders);
+    }
+
+    @Test
+    void givenRepOrdersExist_whenGetRepOrdersForBillingIsInvoked_thenRepOrdersAreReturned() {
+        when(repOrderRepository.getRepOrdersForBilling()).thenReturn(List.of(
+            TestEntityDataBuilder.getPopulatedRepOrder(123),
+            TestEntityDataBuilder.getPopulatedRepOrder(124)
+        ));
+
+        List<RepOrderBillingDTO> expectedRepOrders = List.of(
+            RepOrderBillingMapper.mapEntityToDTO(TestEntityDataBuilder.getPopulatedRepOrder(123)),
+            RepOrderBillingMapper.mapEntityToDTO(TestEntityDataBuilder.getPopulatedRepOrder(124))
+        );
+
+        List<RepOrderBillingDTO> repOrders = repOrderBillingService.getRepOrdersForBilling();
+
+        assertEquals(2, repOrders.size());
+        assertEquals(expectedRepOrders, repOrders);
+    }
+
+}

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -6,6 +6,8 @@ import gov.uk.courtdata.applicant.entity.RepOrderApplicantLinksEntity;
 import gov.uk.courtdata.billing.entity.MaatReferenceEntity;
 import gov.uk.courtdata.entity.*;
 import gov.uk.courtdata.enums.ConcorContributionStatus;
+import gov.uk.courtdata.enums.CrownCourtCaseType;
+import gov.uk.courtdata.enums.CrownCourtTrialOutcome;
 import gov.uk.courtdata.enums.FdcContributionsStatus;
 import gov.uk.courtdata.enums.Frequency;
 import gov.uk.courtdata.enums.HardshipReviewDetailReason;
@@ -16,6 +18,8 @@ import gov.uk.courtdata.reporder.projection.RepOrderMvoEntityInfo;
 import gov.uk.courtdata.reporder.projection.RepOrderMvoRegEntityInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.crime.enums.AppealType;
+import uk.gov.justice.laa.crime.enums.EvidenceFeeLevel;
 import uk.gov.justice.laa.crime.enums.HardshipReviewDetailType;
 import uk.gov.justice.laa.crime.enums.HardshipReviewStatus;
 
@@ -23,6 +27,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
 
 import static gov.uk.courtdata.builder.TestModelDataBuilder.IOJ_APPEAL_ID;
 import static gov.uk.courtdata.builder.TestModelDataBuilder.IOJ_REP_ID;
@@ -109,6 +114,33 @@ public class TestEntityDataBuilder {
             .applicationId(APPLICATION_ID)
             .applicantHistoryId(APPLICANT_HISTORY_ID)
             .isSendToCCLF(true)
+            .build();
+    }
+
+    public static RepOrderEntity getPopulatedRepOrderForBilling(Integer id) {
+        return RepOrderEntity.builder()
+            .id(id)
+            .applicationId(12)
+            .arrestSummonsNo("ARREST-5678")
+            .evidenceFeeLevel(EvidenceFeeLevel.LEVEL1.getFeeLevel())
+            .suppAccountCode("AB123C")
+            .macoCourt("34")
+            .magsOutcome(MagCourtOutcome.COMMITTED.getOutcome())
+            .dateReceived(LocalDate.of(2025, 6, 10))
+            .crownRepOrderDate(LocalDate.of(2025, 6, 12))
+            .oftyOffenceType("BURGLARY")
+            .crownWithdrawalDate(LocalDate.of(2025, 6, 30))
+            .applicantHistoryId(96)
+            .caseId("CASE-123-C")
+            .committalDate(LocalDate.of(2025, 6, 11))
+            .rorsStatus("CURR")
+            .appealTypeCode(AppealType.ACN.getCode())
+            .crownOutcome(CrownCourtTrialOutcome.CONVICTED.getValue())
+            .dateCreated(LocalDate.of(2025, 6, 20))
+            .userCreated("joe-bloggs")
+            .dateModified(LocalDate.of(2025, 6, 21).atStartOfDay())
+            .userModified("alice-smith")
+            .catyCaseType(CrownCourtCaseType.EITHER_WAY.getValue())
             .build();
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
@@ -1,6 +1,7 @@
 package gov.uk.courtdata.builder;
 
 import com.google.gson.Gson;
+import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
 import gov.uk.courtdata.address.entity.Address;
 import gov.uk.courtdata.applicant.dto.ApplicantDisabilitiesDTO;
 import gov.uk.courtdata.applicant.dto.ApplicantHistoryDTO;
@@ -803,6 +804,24 @@ public class TestModelDataBuilder {
                 .crownRepOrderDecision("cc-rep-doc")
                 .crownRepOrderType("cc-rep-type")
                 .build();
+    }
+
+    public static RepOrderBillingDTO getRepOrderBillingDTO(Integer id) {
+        return RepOrderBillingDTO.builder()
+            .id(id)
+            .applicantId(123)
+            .arrestSummonsNo("arrest-summons")
+            .magsCourtId(1)
+            .magsCourtOutcome("outcome")
+            .dateReceived(TEST_DATE.toLocalDate())
+            .offenceType("burglary")
+            .caseId("case-id")
+            .committalDate(TEST_DATE.toLocalDate())
+            .repOrderStatus("curr")
+            .userCreated("test-user")
+            .dateCreated(TEST_DATE.toLocalDate())
+            .caseType("case-type")
+            .build();
     }
 
     public static List<RepOrderMvoRegDTO> getRepOrderMvoRegDTOList() {

--- a/maat-court-data-api/src/test/resources/application.yaml
+++ b/maat-court-data-api/src/test/resources/application.yaml
@@ -117,10 +117,10 @@ feature:
 version: 0.0.1
 
 api-endpoints:
-  assessments-domain: /api/internal/v1/assessment
+  address-domain: /api/internal/v1/address
   application-domain: /api/internal/v1/application
   applicant-domain: /api/internal/v1/applicant
+  assessments-domain: /api/internal/v1/assessment
+  billing-domain: /api/internal/v1/billing
   debt-collection-enforcement-domain: /api/internal/v1/debt-collection-enforcement
   user-domain: /api/internal/v1/users
-  address-domain: /api/internal/v1/address
-  billing-domain: /api/internal/v1/billing


### PR DESCRIPTION
This PR adds an endpoint to replace the previous Hub job and associated downstream stored procedures in MAAT which would extract rep orders for the CCLF team (for billing purposes). It also makes it obvious in the new `RepOrderBillingDTO` what the fields being mapped actually are, hence the reason for a static mapper to create a new instance of this type via a builder over having things done automatically using the `@Mapper` annotation.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4223)
