### PR TITLE
Add endpoint to reset rep orders for billing

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/RepOrderBillingController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/RepOrderBillingController.java
@@ -1,15 +1,19 @@
 package gov.uk.courtdata.billing.controller;
 
 import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
+import gov.uk.courtdata.billing.request.UpdateRepOrderBillingRequest;
 import gov.uk.courtdata.billing.service.RepOrderBillingService;
 import gov.uk.courtdata.annotation.StandardApiResponseCodes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,5 +31,14 @@ public class RepOrderBillingController {
     @StandardApiResponseCodes
     public ResponseEntity<List<RepOrderBillingDTO>> getRepOrders() {
         return ResponseEntity.ok(repOrderBillingService.getRepOrdersForBilling());
+    }
+
+    @PatchMapping
+    @Operation(description = "Reset rep orders for billing")
+    @StandardApiResponseCodes
+    public ResponseEntity<Void> patchRepOrders(@Valid @RequestBody final UpdateRepOrderBillingRequest request) {
+        repOrderBillingService.resetRepOrdersSentForBilling(request);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/request/UpdateRepOrderBillingRequest.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/request/UpdateRepOrderBillingRequest.java
@@ -1,0 +1,19 @@
+package gov.uk.courtdata.billing.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateRepOrderBillingRequest {
+    @NotNull
+    private String userModified;
+    @NotNull
+    private List<Integer> repOrderIds;
+}

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/RepOrderBillingService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/RepOrderBillingService.java
@@ -2,13 +2,16 @@ package gov.uk.courtdata.billing.service;
 
 import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
 import gov.uk.courtdata.billing.mapper.RepOrderBillingMapper;
+import gov.uk.courtdata.billing.request.UpdateRepOrderBillingRequest;
 import gov.uk.courtdata.entity.RepOrderEntity;
+import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -28,5 +31,20 @@ public class RepOrderBillingService {
         return extractedRepOrders.stream()
             .map(RepOrderBillingMapper::mapEntityToDTO)
             .collect(Collectors.toList());
+    }
+
+    public boolean resetRepOrdersSentForBilling(UpdateRepOrderBillingRequest request) {
+        if (request.getRepOrderIds().isEmpty()) {
+            return true;
+        }
+
+        if (StringUtils.isBlank(request.getUserModified())) {
+            throw new ValidationException("Username must be provided");
+        }
+
+        int updatedRows = repOrderRepository.resetBillingFlagForRepOrderIds(
+            request.getUserModified(), request.getRepOrderIds());
+
+        return updatedRows > 0;
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/RepOrderBillingService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/RepOrderBillingService.java
@@ -7,6 +7,7 @@ import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.exception.MAATCourtDataException;
 import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.repository.RepOrderRepository;
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,7 +50,9 @@ public class RepOrderBillingService {
             request.getUserModified(), request.getRepOrderIds());
 
         if (updatedRows != request.getRepOrderIds().size()) {
-            throw new MAATCourtDataException("Unable to reset rep orders sent for billing");
+            String message = MessageFormat.format("Unable to reset rep orders sent for billing as only {0} rep order(s) could be processed (from a total of {1} rep order(s))", updatedRows, request.getRepOrderIds().size());
+            log.error(message);
+            throw new MAATCourtDataException(message);
         }
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
@@ -1,8 +1,10 @@
 package gov.uk.courtdata.repository;
 
 import gov.uk.courtdata.entity.RepOrderEntity;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -85,6 +87,17 @@ public interface RepOrderRepository extends JpaRepository<RepOrderEntity, Intege
                         ON      r.ID = ex.MAAT_ID
     """, nativeQuery = true)
     List<RepOrderEntity> getRepOrdersForBilling();
+
+    @Modifying
+    @Transactional
+    @Query("""
+           UPDATE RepOrderEntity repOrder
+           SET    repOrder.isSendToCCLF = null,
+                  repOrder.dateModified = CURRENT_DATE,
+                  repOrder.userModified = :userModified
+           WHERE  repOrder.id in :repOrderIds
+    """)
+    int resetBillingFlagForRepOrderIds(@Param("userModified") String userModified, @Param("repOrderIds") List<Integer> repOrderIds);
 
 }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/BillingApplicantControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/BillingApplicantControllerTest.java
@@ -46,5 +46,4 @@ class BillingApplicantControllerTest {
 
         verify(billingApplicantService).findAllApplicantsForBilling();
     }
-
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/RepOrderBillingControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/RepOrderBillingControllerTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.uk.courtdata.billing.request.UpdateRepOrderBillingRequest;
 import gov.uk.courtdata.billing.service.RepOrderBillingService;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import java.util.List;
@@ -30,6 +32,9 @@ class RepOrderBillingControllerTest {
     @MockitoBean
     private RepOrderBillingService repOrderBillingService;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Test
     void givenValidRequest_whenGetRepOrdersForBillingIsInvoked_thenResponseIsReturned() throws Exception {
         when(repOrderBillingService.getRepOrdersForBilling()).thenReturn(List.of(
@@ -38,6 +43,36 @@ class RepOrderBillingControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.get(ENDPOINT_URL))
                .andExpect(status().isOk())
                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void givenInvalidRequest_whenPatchRepOrderForBillingIsInvoked_thenFailureResponseIsReturned() throws Exception {
+        UpdateRepOrderBillingRequest request = UpdateRepOrderBillingRequest.builder()
+            .userModified(null)
+            .repOrderIds(List.of(10034567, 10034568, 10034591))
+            .build();
+
+        when(repOrderBillingService.resetRepOrdersSentForBilling(request)).thenReturn(true);
+
+        mockMvc.perform(MockMvcRequestBuilders.patch(ENDPOINT_URL)
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void givenValidRequest_whenPatchRepOrderForBillingIsInvoked_thenSuccessResponseIsReturned() throws Exception {
+        UpdateRepOrderBillingRequest request = UpdateRepOrderBillingRequest.builder()
+            .userModified("joe-bloggs")
+            .repOrderIds(List.of(10034567, 10034568, 10034591))
+            .build();
+
+        when(repOrderBillingService.resetRepOrdersSentForBilling(request)).thenReturn(true);
+
+        mockMvc.perform(MockMvcRequestBuilders.patch(ENDPOINT_URL)
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk());
     }
 
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/RepOrderBillingControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/RepOrderBillingControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -68,12 +69,13 @@ class RepOrderBillingControllerTest {
             .repOrderIds(List.of(10034567, 10034568, 10034591))
             .build();
 
-        doThrow(new MAATCourtDataException("Error")).when(repOrderBillingService).resetRepOrdersSentForBilling(request);
+        doThrow(new MAATCourtDataException("Unable to reset rep orders")).when(repOrderBillingService).resetRepOrdersSentForBilling(request);
 
         mockMvc.perform(MockMvcRequestBuilders.patch(ENDPOINT_URL)
                 .content(objectMapper.writeValueAsString(request))
                 .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().is5xxServerError());
+                .andExpect(status().is5xxServerError())
+                .andExpect(jsonPath("message").value("Unable to reset rep orders"));
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/RepOrderBillingServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/RepOrderBillingServiceTest.java
@@ -1,11 +1,16 @@
 package gov.uk.courtdata.billing.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
 import gov.uk.courtdata.billing.mapper.RepOrderBillingMapper;
+import gov.uk.courtdata.billing.request.UpdateRepOrderBillingRequest;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import java.util.Collections;
 import java.util.List;
@@ -51,4 +56,60 @@ class RepOrderBillingServiceTest {
         assertEquals(expectedRepOrders, repOrders);
     }
 
+    @Test
+    void givenNoRepOrdersToUpdate_whenResetRepOrdersSentForBillingIsInvoked_thenReturnsTrue() {
+        UpdateRepOrderBillingRequest request = UpdateRepOrderBillingRequest.builder()
+            .userModified("joe-bloggs")
+            .repOrderIds(Collections.emptyList())
+            .build();
+
+        boolean result = repOrderBillingService.resetRepOrdersSentForBilling(request);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void givenUsernameNotSupplied_whenResetRepOrdersSentForBillingIsInvoked_thenReturnsFalse() {
+        UpdateRepOrderBillingRequest request = UpdateRepOrderBillingRequest.builder()
+            .userModified(null)
+            .repOrderIds(List.of(1003456, 1003457))
+            .build();
+
+        ValidationException exception = assertThrows(ValidationException.class,
+            () -> repOrderBillingService.resetRepOrdersSentForBilling(request));
+
+        assertEquals("Username must be provided", exception.getMessage());
+    }
+
+    @Test
+    void givenRepOrdersNotSuccessfullyUpdated_whenResetRepOrdersSentForBillingIsInvoked_thenReturnsFalse() {
+        UpdateRepOrderBillingRequest request = UpdateRepOrderBillingRequest.builder()
+            .userModified("joe-bloggs")
+            .repOrderIds(List.of(1003456, 1003457))
+            .build();
+
+        when(repOrderRepository.resetBillingFlagForRepOrderIds(request.getUserModified(), request.getRepOrderIds()))
+            .thenReturn(0);
+
+        boolean result = repOrderBillingService.resetRepOrdersSentForBilling(request);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void givenRepOrdersSuccessfullyUpdated_whenResetRepOrdersSentForBillingIsInvoked_thenReturnsTrue() {
+        List<Integer> repOrdersIdsToUpdate = List.of(1003456, 1003457);
+
+        UpdateRepOrderBillingRequest request = UpdateRepOrderBillingRequest.builder()
+            .userModified("joe-bloggs")
+            .repOrderIds(List.of(1003456, 1003457))
+            .build();
+
+        when(repOrderRepository.resetBillingFlagForRepOrderIds(request.getUserModified(), request.getRepOrderIds()))
+            .thenReturn(repOrdersIdsToUpdate.size());
+
+        boolean result = repOrderBillingService.resetRepOrdersSentForBilling(request);
+
+        assertTrue(result);
+    }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/RepOrderBillingServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/RepOrderBillingServiceTest.java
@@ -90,12 +90,14 @@ class RepOrderBillingServiceTest {
             .build();
 
         when(repOrderRepository.resetBillingFlagForRepOrderIds(request.getUserModified(), request.getRepOrderIds()))
-            .thenReturn(0);
+            .thenReturn(1);
 
         MAATCourtDataException exception = assertThrows(MAATCourtDataException.class,
             () -> repOrderBillingService.resetRepOrdersSentForBilling(request));
 
-        assertEquals("Unable to reset rep orders sent for billing", exception.getMessage());
+        assertEquals(
+            "Unable to reset rep orders sent for billing as only 1 rep order(s) could be processed (from a total of 2 rep order(s))"
+            , exception.getMessage());
     }
 
     @Test

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/RepOrderBillingServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/RepOrderBillingServiceTest.java
@@ -1,15 +1,18 @@
 package gov.uk.courtdata.billing.service;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.uk.courtdata.billing.dto.RepOrderBillingDTO;
 import gov.uk.courtdata.billing.mapper.RepOrderBillingMapper;
 import gov.uk.courtdata.billing.request.UpdateRepOrderBillingRequest;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
+import gov.uk.courtdata.exception.MAATCourtDataException;
 import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import java.util.Collections;
@@ -63,9 +66,7 @@ class RepOrderBillingServiceTest {
             .repOrderIds(Collections.emptyList())
             .build();
 
-        boolean result = repOrderBillingService.resetRepOrdersSentForBilling(request);
-
-        assertTrue(result);
+        assertDoesNotThrow(() -> repOrderBillingService.resetRepOrdersSentForBilling(request));
     }
 
     @Test
@@ -91,9 +92,10 @@ class RepOrderBillingServiceTest {
         when(repOrderRepository.resetBillingFlagForRepOrderIds(request.getUserModified(), request.getRepOrderIds()))
             .thenReturn(0);
 
-        boolean result = repOrderBillingService.resetRepOrdersSentForBilling(request);
+        MAATCourtDataException exception = assertThrows(MAATCourtDataException.class,
+            () -> repOrderBillingService.resetRepOrdersSentForBilling(request));
 
-        assertFalse(result);
+        assertEquals("Unable to reset rep orders sent for billing", exception.getMessage());
     }
 
     @Test
@@ -108,8 +110,6 @@ class RepOrderBillingServiceTest {
         when(repOrderRepository.resetBillingFlagForRepOrderIds(request.getUserModified(), request.getRepOrderIds()))
             .thenReturn(repOrdersIdsToUpdate.size());
 
-        boolean result = repOrderBillingService.resetRepOrdersSentForBilling(request);
-
-        assertTrue(result);
+        assertDoesNotThrow(() -> repOrderBillingService.resetRepOrdersSentForBilling(request));
     }
 }


### PR DESCRIPTION
This PR adds a new endpoint to reset rep orders for billing, setting the `SEND_TO_CCLF` flag on relevant rep orders in the database to `null` and updating the date and user modified values alongside.

This behaviour is migrated from the existing `reporder_clear_flag` stored procedure in the MAAT database which was previously called as part of the regular data extraction Hub job.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4228)
