### PR TITLE
[LASB-4229] Add endpoint to delete all entries from maat_refs_to_extract

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +28,16 @@ public class MaatReferenceExtractionController {
         log.info("Populate MAAT references Request received");
         maatReferenceService.populateTable();
         log.info("Populate MAAT references Request completed successfully");
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping(value = "/delete-maat-references")
+    @Operation(description = "Delete MAAT reference records")
+    @StandardApiResponseCodes
+    public ResponseEntity<Object> deleteMaatReferences() {
+        log.info("Delete MAAT references Request received");
+        maatReferenceService.deleteMaatReferences();
+        log.info("Delete MAAT references Request completed successfully");
         return ResponseEntity.ok().build();
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionController.java
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Maat Reference Extraction", description = "Rest API for extracting MAAT references to send to billing teams")
-@RequestMapping("${api-endpoints.billing-domain}")
+@RequestMapping("${api-endpoints.billing-domain}/maat-references")
 public class MaatReferenceExtractionController {
     
     private final MaatReferenceService maatReferenceService;
     
-    @PostMapping(value = "/populate-maat-references")
+    @PostMapping
     @Operation(description = "Create MAAT reference records")
     @StandardApiResponseCodes
     public ResponseEntity<Object> populateMaatReferencesToExtract() {
@@ -31,7 +31,7 @@ public class MaatReferenceExtractionController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping(value = "/delete-maat-references")
+    @DeleteMapping
     @Operation(description = "Delete MAAT reference records")
     @StandardApiResponseCodes
     public ResponseEntity<Object> deleteMaatReferences() {

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/repository/MaatReferenceRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/repository/MaatReferenceRepository.java
@@ -12,4 +12,8 @@ public interface MaatReferenceRepository extends JpaRepository<MaatReferenceEnti
     @Modifying
     @Query(value = "INSERT INTO TOGDATA.maat_refs_to_extract (MAAT_ID, APPL_ID, APHI_ID) SELECT id, appl_id, aphi_id FROM TOGDATA.rep_orders WHERE send_to_cclf = 'Y'", nativeQuery = true)
     void populateMaatReferences();
+    
+    @Modifying
+    @Query(value = "DELETE FROM TOGDATA.maat_refs_to_extract", nativeQuery = true)
+    void deleteMaatReferences();
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/MaatReferenceService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/billing/service/MaatReferenceService.java
@@ -28,4 +28,10 @@ public class MaatReferenceService {
     private boolean isTableEmpty() {
         return maatReferenceRepository.count() == 0;
     }
+
+    @Transactional
+    public ResponseEntity<Void> deleteMaatReferences() {
+        maatReferenceRepository.deleteMaatReferences();
+        return ResponseEntity.ok().build();
+    }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
@@ -19,8 +19,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @AutoConfigureMockMvc(addFilters = false)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MaatReferenceExtractionControllerTest {
-    private static final String POST_ENDPOINT_URL = "/api/internal/v1/billing/populate-maat-references";
-    private static final String DELETE_ENDPOINT_URL = "/api/internal/v1/billing/delete-maat-references";
+    private static final String ENDPOINT_URL = "/api/internal/v1/billing/maat-references";
 
     @Autowired
     private MockMvc mvc;
@@ -30,7 +29,7 @@ class MaatReferenceExtractionControllerTest {
 
     @Test
     void givenNoInput_whenPopulateMaatReferencesToExtract_thenSuccessResponseIsReturned() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.post(POST_ENDPOINT_URL))
+        mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL))
             .andExpect(status().isOk());
         verify(maatReferenceService).populateTable();
     }
@@ -39,14 +38,14 @@ class MaatReferenceExtractionControllerTest {
     void givenRecordsAlreadyExist_whenPopulateMaatReferencesToExtract_thenReturnError() throws Exception {
         when(maatReferenceService.populateTable()).thenThrow(RecordsAlreadyExistException.class);
 
-        mvc.perform(MockMvcRequestBuilders.post(POST_ENDPOINT_URL))
+        mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL))
             .andExpect(status().isInternalServerError());
         verify(maatReferenceService).populateTable();
     }
 
     @Test
     void givenNoInput_whenDeleteMaatReferences_thenSuccessResponseIsReturned() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.delete(DELETE_ENDPOINT_URL))
+        mvc.perform(MockMvcRequestBuilders.delete(ENDPOINT_URL))
             .andExpect(status().isOk());
         verify(maatReferenceService).deleteMaatReferences();
     }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
@@ -19,7 +19,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @AutoConfigureMockMvc(addFilters = false)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MaatReferenceExtractionControllerTest {
-    private static final String ENDPOINT_URL = "/api/internal/v1/billing/populate-maat-references";
+    private static final String POST_ENDPOINT_URL = "/api/internal/v1/billing/populate-maat-references";
+    private static final String DELETE_ENDPOINT_URL = "/api/internal/v1/billing/delete-maat-references";
 
     @Autowired
     private MockMvc mvc;
@@ -29,16 +30,24 @@ class MaatReferenceExtractionControllerTest {
 
     @Test
     void givenNoInput_whenPopulateMaatReferencesToExtract_thenSuccessResponseIsReturned() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL))
+        mvc.perform(MockMvcRequestBuilders.post(POST_ENDPOINT_URL))
             .andExpect(status().isOk());
         verify(maatReferenceService).populateTable();
     }
+    
     @Test
     void givenRecordsAlreadyExist_whenPopulateMaatReferencesToExtract_thenReturnError() throws Exception {
         when(maatReferenceService.populateTable()).thenThrow(RecordsAlreadyExistException.class);
 
-        mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL))
+        mvc.perform(MockMvcRequestBuilders.post(POST_ENDPOINT_URL))
             .andExpect(status().isInternalServerError());
         verify(maatReferenceService).populateTable();
+    }
+
+    @Test
+    void givenNoInput_whenDeleteMaatReferences_thenSuccessResponseIsReturned() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.delete(DELETE_ENDPOINT_URL))
+            .andExpect(status().isOk());
+        verify(maatReferenceService).deleteMaatReferences();
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/controller/MaatReferenceExtractionControllerTest.java
@@ -35,7 +35,7 @@ class MaatReferenceExtractionControllerTest {
     }
     
     @Test
-    void givenRecordsAlreadyExist_whenPopulateMaatReferencesToExtract_thenReturnError() throws Exception {
+    void givenRecordsAlreadyExist_whenPopulateMaatReferencesToExtract_thenErrorResponseIsReturned() throws Exception {
         when(maatReferenceService.populateTable()).thenThrow(RecordsAlreadyExistException.class);
 
         mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL))

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/MaatReferenceServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/MaatReferenceServiceTest.java
@@ -40,4 +40,10 @@ class MaatReferenceServiceTest {
         Assertions.assertThrows(RecordsAlreadyExistException.class,
             () -> maatReferenceService.populateTable());
     }
+    
+    @Test
+    void givenNoInput_whenDeleteMaatReferencesInvoked_thenDeleteIsSuccessful() {
+        maatReferenceService.deleteMaatReferences();
+        verify(maatReferenceRepository, atLeastOnce()).deleteMaatReferences();
+    }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/MaatReferenceServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/billing/service/MaatReferenceServiceTest.java
@@ -1,12 +1,13 @@
 package gov.uk.courtdata.billing.service;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.uk.courtdata.billing.repository.MaatReferenceRepository;
 import gov.uk.courtdata.exception.RecordsAlreadyExistException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,7 +38,7 @@ class MaatReferenceServiceTest {
     void givenEntriesAlreadyExist_whenPopulateTableInvoked_thenThrowAnException() {
         when(maatReferenceRepository.count()).thenReturn(10L);
 
-        Assertions.assertThrows(RecordsAlreadyExistException.class,
+        assertThrows(RecordsAlreadyExistException.class,
             () -> maatReferenceService.populateTable());
     }
     
@@ -45,5 +46,14 @@ class MaatReferenceServiceTest {
     void givenNoInput_whenDeleteMaatReferencesInvoked_thenDeleteIsSuccessful() {
         maatReferenceService.deleteMaatReferences();
         verify(maatReferenceRepository, atLeastOnce()).deleteMaatReferences();
+    }
+
+    @Test
+    void givenARepositoryException_whenDeleteMaatReferencesInvoked_thenThrowAnException() {
+        doThrow(new RuntimeException()).when(maatReferenceRepository).deleteMaatReferences();
+        
+        assertThrows(RuntimeException.class, () -> {
+            maatReferenceService.deleteMaatReferences();
+        });
     }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/billing/MaatReferenceExtractionControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/billing/MaatReferenceExtractionControllerIntegrationTest.java
@@ -16,8 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(classes = {MAATCourtDataApplication.class})
 public class MaatReferenceExtractionControllerIntegrationTest extends MockMvcIntegrationTest {
 
-    private static final String CREATE_ENDPOINT_URL = "/api/internal/v1/billing/populate-maat-references";
-    private static final String DELETE_ENDPOINT_URL = "/api/internal/v1/billing/delete-maat-references";
+    private static final String ENDPOINT_URL = "/api/internal/v1/billing/maat-references";
 
     @Autowired
     private TestEntityDataBuilder testEntityDataBuilder;
@@ -26,7 +25,7 @@ public class MaatReferenceExtractionControllerIntegrationTest extends MockMvcInt
     void givenAValidRepOrder_whenPopulateMaatReferencesToExtract_thenSuccessResponseIsReturned() throws Exception {
         repos.repOrder.saveAndFlush(testEntityDataBuilder.getPopulatedRepOrderToSendToCclf());
         
-        assertThat(runSuccessScenario(post(CREATE_ENDPOINT_URL)).getResponse().getStatus()).isEqualTo(200);
+        assertThat(runSuccessScenario(post(ENDPOINT_URL)).getResponse().getStatus()).isEqualTo(200);
         assertEquals(1, repos.maatReference.count());
     }
     
@@ -36,7 +35,7 @@ public class MaatReferenceExtractionControllerIntegrationTest extends MockMvcInt
         
         assertTrue(
             runServerErrorScenario("The MAAT_REFS_TO_EXTRACT table already has entries",
-                post(CREATE_ENDPOINT_URL)));
+                post(ENDPOINT_URL)));
     }
 
     @Test
@@ -44,7 +43,7 @@ public class MaatReferenceExtractionControllerIntegrationTest extends MockMvcInt
         repos.maatReference.saveAndFlush(testEntityDataBuilder.getMaatReferenceEntity());
 
         assertEquals(1, repos.maatReference.count());
-        assertThat(runSuccessScenario(delete(DELETE_ENDPOINT_URL)).getResponse().getStatus()).isEqualTo(200);
+        assertThat(runSuccessScenario(delete(ENDPOINT_URL)).getResponse().getStatus()).isEqualTo(200);
         assertEquals(0, repos.maatReference.count());
     }
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/billing/MaatReferenceExtractionControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/billing/MaatReferenceExtractionControllerIntegrationTest.java
@@ -30,7 +30,7 @@ public class MaatReferenceExtractionControllerIntegrationTest extends MockMvcInt
     }
     
     @Test
-    void givenRecordsAlreadyExist_whenPopulateMaatReferencesToExtract_thenReturnError() throws Exception {
+    void givenRecordsAlreadyExist_whenPopulateMaatReferencesToExtract_thenErrorResponseIsReturned() throws Exception {
         repos.maatReference.saveAndFlush(testEntityDataBuilder.getMaatReferenceEntity());
         
         assertTrue(


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4229)

Added endpoint to delete all entries from maat_refs_to_extract table. 

Please note, I went with a DELETE sql command rather than TRUNCATE. I did this because it appears that only the table owner can truncate, or a user with the "drop any table" privilege; there is no way to grant a truncate privilege to a specific user like with select, delete etc. It is technically less-efficient to do it this way, but performance-wise it was negligible; I still managed to delete 267k records in half a second, and there shouldn't ever be more than that given this will run weekly.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.