### PR TITLE
Add missing schema reference to rep order query

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
@@ -82,8 +82,8 @@ public interface RepOrderRepository extends JpaRepository<RepOrderEntity, Intege
                               , r.date_modified
                               , r.user_modified
                               , r.caty_case_type
-                        FROM    REP_ORDERS r
-                        JOIN    MAAT_REFS_TO_EXTRACT ex
+                        FROM    TOGDATA.REP_ORDERS r
+                        JOIN    TOGDATA.MAAT_REFS_TO_EXTRACT ex
                         ON      r.ID = ex.MAAT_ID
     """, nativeQuery = true)
     List<RepOrderEntity> getRepOrdersForBilling();


### PR DESCRIPTION
This PR adds missing schema references to a recently added query to extract rep orders to send to CCLF.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4223)
