### PR TITLE
[LASB-4268] Update the setup-gradle version to explicit version 4

### DIFF
--- a/.github/workflows/gradle-build-and-test.yml
+++ b/.github/workflows/gradle-build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
       # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@c9872874b099717fffc25bee4cac9c04ac16c873 # v4.0.0-rc.1
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Check Git Version
         run: git --version


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4268)

There is a bug with the build and test step regarding caching when merging to main. Setting this gradle setup to v4 instead of the SHA commit it had previously to see if this fixes the issue. Regardless, it is better to be explicit about the version we are using, even if it doesn't fix this particular issue. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.