### PR TITLE
Add Prometheus instrumentation

### DIFF
--- a/maat-court-data-api/build.gradle
+++ b/maat-court-data-api/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok-mapstruct-binding:$lombokMapStrutBinding"
 
     implementation "io.micrometer:micrometer-registry-cloudwatch2:$micrometerCloudWatchVersion"
+    implementation "io.micrometer:micrometer-registry-prometheus"
 
     // DB Dependencies
     implementation group: 'com.oracle.database.jdbc', name: 'ojdbc8', version: "$ojdbc8Version"


### PR DESCRIPTION
This PR adds a missing dependency for Prometheus instrumentation, to allow a metrics endpoint to be established for MAAT API and for Prometheus to poll this endpoint periodically for data.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4275)