### PR TITLE
LASB-4373 - fixed and improved performance of Offence native query

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/OffenceRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/OffenceRepository.java
@@ -29,8 +29,8 @@ public interface OffenceRepository extends JpaRepository<OffenceEntity, AsnSeqTx
 
     List<OffenceEntity> findByCaseId(Integer caseId);
 
-    @Query(value = "SELECT * FROM MLA.XXMLA_OFFENCE WHERE CASE_ID = :caseId AND APPLICATION_FLAG = :applicationFlag " +
-                    "AND OFFENCE_ID = :offenceId ORDER BY TX_ID DESC FETCH FIRST 1 ROW ONLY", nativeQuery = true)
+    @Query(value = "SELECT * FROM MLA.XXMLA_OFFENCE WHERE ROWNUM = 1 AND CASE_ID = :caseId AND APPLICATION_FLAG = :applicationFlag " +
+            "AND OFFENCE_ID = :offenceId ORDER BY TX_ID DESC", nativeQuery = true)
     Optional<OffenceEntity> findApplicationByOffenceCode(Integer caseId, String offenceId, Integer applicationFlag);
 
     @Query(value = "SELECT COUNT(*) FROM MLA.XXMLA_OFFENCE WHERE CASE_ID = ?1 AND OFFENCE_ID = ?2 AND CC_NEW_OFFENCE = 'Y' AND APPLICATION_FLAG = 0", nativeQuery = true)

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/OffenceRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/OffenceRepository.java
@@ -30,7 +30,7 @@ public interface OffenceRepository extends JpaRepository<OffenceEntity, AsnSeqTx
     List<OffenceEntity> findByCaseId(Integer caseId);
 
     @Query(value = "SELECT * FROM MLA.XXMLA_OFFENCE WHERE ROWNUM = 1 AND CASE_ID = :caseId AND APPLICATION_FLAG = :applicationFlag " +
-            "AND OFFENCE_ID = :offenceId ORDER BY TX_ID DESC", nativeQuery = true)
+                    "AND OFFENCE_ID = :offenceId ORDER BY TX_ID DESC", nativeQuery = true)
     Optional<OffenceEntity> findApplicationByOffenceCode(Integer caseId, String offenceId, Integer applicationFlag);
 
     @Query(value = "SELECT COUNT(*) FROM MLA.XXMLA_OFFENCE WHERE CASE_ID = ?1 AND OFFENCE_ID = ?2 AND CC_NEW_OFFENCE = 'Y' AND APPLICATION_FLAG = 0", nativeQuery = true)

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/OffenceRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/OffenceRepository.java
@@ -23,14 +23,14 @@ public interface OffenceRepository extends JpaRepository<OffenceEntity, AsnSeqTx
     @Query(value = "SELECT COUNT(*) FROM MLA.XXMLA_OFFENCE WHERE CASE_ID = ?1 AND ASN_SEQ = ?2", nativeQuery = true)
     Integer getOffenceCountForAsnSeq(Integer caseId, String asnSeq);
 
-    @Query(value = "SELECT * FROM MLA.XXMLA_OFFENCE WHERE ROWNUM = 1 AND CASE_ID = :caseId AND ASN_SEQ = :asnSeq " +
-                    "AND OFFENCE_CODE = :offenceCode ORDER BY TX_ID DESC", nativeQuery = true)
+    @Query(value = "SELECT * FROM MLA.XXMLA_OFFENCE WHERE CASE_ID = :caseId AND ASN_SEQ = :asnSeq " +
+                    "AND OFFENCE_CODE = :offenceCode ORDER BY TX_ID DESC FETCH FIRST 1 ROW ONLY", nativeQuery = true)
     Optional<OffenceEntity> findByMaxTxId(Integer caseId, String offenceCode, String asnSeq);
 
     List<OffenceEntity> findByCaseId(Integer caseId);
 
-    @Query(value = "SELECT * FROM MLA.XXMLA_OFFENCE WHERE ROWNUM = 1 AND CASE_ID = :caseId AND APPLICATION_FLAG = :applicationFlag " +
-                    "AND OFFENCE_ID = :offenceId ORDER BY TX_ID DESC", nativeQuery = true)
+    @Query(value = "SELECT * FROM MLA.XXMLA_OFFENCE WHERE CASE_ID = :caseId AND APPLICATION_FLAG = :applicationFlag " +
+                    "AND OFFENCE_ID = :offenceId ORDER BY TX_ID DESC FETCH FIRST 1 ROW ONLY", nativeQuery = true)
     Optional<OffenceEntity> findApplicationByOffenceCode(Integer caseId, String offenceId, Integer applicationFlag);
 
     @Query(value = "SELECT COUNT(*) FROM MLA.XXMLA_OFFENCE WHERE CASE_ID = ?1 AND OFFENCE_ID = ?2 AND CC_NEW_OFFENCE = 'Y' AND APPLICATION_FLAG = 0", nativeQuery = true)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4373)

**Improved Performance of the query**

In Oracle, ROWNUM is applied before ORDER BY. So the queries I've changed originally:

- grabs the first matching row it stumbles upon (no ordering), then
- “orders” that single row (a no-op).

Because the optimizer can’t use the ORDER BY TX_ID DESC to get the latest row efficiently, it may end up scanning a lot of blocks (or even the table) until it finds any match. On a big table that’s exactly the kind of sporadic ~minute latency we're seeing. In SQL Developer I ran a version that orders first and limits after, which is fast - 0.029 seconds.

**Fixed the getting of the first (max) TX_ID:**

WHERE ROWNUM = 1 is applied before ORDER BY, while FETCH FIRST 1 ROW ONLY is applied after the sort. So replacing ROWNUM = 1 with FETCH FIRST 1 ROW ONLY at the end doesn’t just perform better—it also gives the correct “top by TX_ID” row, which ROWNUM does not guarantee.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.