### PR TITLE
LASB-3998 - converted contributions queries to JPA style

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/dces/service/ConcorContributionsService.java
@@ -50,7 +50,8 @@ public class ConcorContributionsService {
     /** Resets a number of concor_contribution rows to status = ACTIVE | REPLACED, contrib_file_id = (null). */
     @Transactional
     public List<Integer> updateConcorContributionStatusAndResetContribFile(UpdateConcorContributionStatusRequest request) {
-        List<Integer> idsToUpdate = concorRepository.findIdsForUpdate(Pageable.ofSize(request.getRecordCount()));
+        List<Integer> idsToUpdate = concorRepository.findByStatusAndFullXmlIsNotNullOrderByIdDesc(SENT, Pageable.ofSize(request.getRecordCount()))
+                .stream().map(ConcorContributionsRepository.IdOnly::getId).toList();
         if (!idsToUpdate.isEmpty()) {
             concorRepository.updateStatusAndResetContribFileForIds(request.getStatus(), USER_AUDIT, idsToUpdate);
         }
@@ -67,7 +68,8 @@ public class ConcorContributionsService {
         }
         log.info("Searching concor contribution file with status {}, startId {} and count {}", status, concorContributionId, noOfRecords);
         Pageable pageable = PageRequest.of(0, noOfRecords, Sort.by("id"));
-        List<Integer> idList = concorRepository.findIdsByStatusAndIdGreaterThan(status, finalConcorContributionId, pageable);
+        List<Integer> idList = concorRepository.findByStatusAndIdGreaterThan(status, finalConcorContributionId, pageable)
+                .stream().map(ConcorContributionsRepository.IdOnly::getId).toList();
         return buildConcorContributionResponseList(() -> concorRepository.findByIdIn(Set.copyOf(idList)));
     }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/ConcorContributionsRepository.java
@@ -14,27 +14,18 @@ import java.util.Set;
 
 @Repository
 public interface ConcorContributionsRepository extends JpaRepository<ConcorContributionsEntity, Integer> {
+
+    interface IdOnly { Integer getId(); }
+
     List<ConcorContributionsEntity> findByStatus(ConcorContributionStatus status);
     List<ConcorContributionsEntity> findByIdIn(Set<Integer> ids);
 
-    @Query("""
-       SELECT cc.id
-       FROM ConcorContributionsEntity cc
-       WHERE cc.status = :status
-       AND cc.id > :startId
-       """)
-    List<Integer> findIdsByStatusAndIdGreaterThan(
-            @Param("status") ConcorContributionStatus status,
-            @Param("startId") Integer startId,
-            Pageable pageable);
+    List<IdOnly> findByStatusAndIdGreaterThan(ConcorContributionStatus status,
+                                              Integer startId,
+                                              Pageable pageable);
 
-    @Query("""
-           SELECT cc.id
-               FROM ConcorContributionsEntity cc
-               WHERE cc.status = 'SENT'
-               AND cc.fullXml IS NOT NULL
-               ORDER BY cc.id DESC""")
-    List<Integer> findIdsForUpdate(Pageable pageable);
+    List<IdOnly> findByStatusAndFullXmlIsNotNullOrderByIdDesc(ConcorContributionStatus status,
+                                                              Pageable pageable);
 
     @Modifying
     @Transactional


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3998)

There are queries that need to be updated to follow the “fetch, update, save” JPA style, instead of the native query method for consistency across the MAAT-CD API.

Repositories:
ConcorContributionsRepository - 2 Find by queries.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.