### PR TITLE
LCAM-1972 Stop Sentry initialisation error

### DIFF
--- a/maat-court-data-api/Dockerfile
+++ b/maat-court-data-api/Dockerfile
@@ -2,6 +2,7 @@ FROM amazoncorretto:21-alpine
 RUN mkdir -p /opt/maat-courtdata-api/
 WORKDIR /opt/maat-courtdata-api/
 COPY ./build/libs/maat-courtdata-api.jar /opt/maat-courtdata-api/app.jar
+COPY ./src/main/resources/sentry.properties /opt/maat-courtdata-api/sentry.properties
 RUN addgroup -S appgroup && adduser -u 1001 -S appuser -G appgroup
 USER 1001
 EXPOSE 8090 8100

--- a/maat-court-data-api/src/main/resources/sentry.properties
+++ b/maat-court-data-api/src/main/resources/sentry.properties
@@ -1,0 +1,8 @@
+# Intentionally empty.
+# All Sentry configuration lives in application.yaml (sentry.* keys) and is
+# injected at runtime via SENTRY_DSN / SENTRY_ENV / SENTRY_SAMPLE_RATE env vars
+# (see helm_deploy/laa-maat-data-api/templates/_environment.tpl).
+# This file exists only to satisfy Sentry SDK 8.x's PropertiesProviderFactory and FilesystemPropertiesLoader,
+# which logs an ERROR when the file path resource is missing.
+# This file will be copied to the working directory of the docker image file system.
+dummy=empty

--- a/maat-court-data-api/start-local.sh
+++ b/maat-court-data-api/start-local.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Specify the vault and the document name in 1Password
-VAULT="LAA Crime Apps - Shared"
+VAULT="LAA Crime Apps"
 DOCUMENT="EnvironmentVariables-MAATCourtDataApi-App"
 APP_ENV_FILE="./app.env"
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1972)

Corrected start-local.sh reference to 1Password
Added SCOPE_MAAT to 1Password, (was missing and required for running locally)

Sentry has 2 checks for config, env & file system, the error is coming from the file system check.
Added dummy sentry.properties.
Modified Dockerfile to copy dummy sentry.properties to container working folder.

Sentry error no longer reported on service startup.