### PR TITLE
Refactor updateRepOrder PATCH endpoint to return RepOrderDTO

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -217,12 +217,12 @@ public class RepOrderController {
   @PatchMapping(value = "/{repId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Partial Update of a Rep record")
     @StandardApiResponseCodes
-  public ResponseEntity<Void> updateRepOrder(@PathVariable int repId,
+  public ResponseEntity<RepOrderDTO> updateRepOrder(@PathVariable int repId,
       @RequestBody Map<String, Object> updatedFields) {
     LoggingData.MAAT_ID.putInMDC(repId);
         log.info("Partial Update of Rep Order Request Received");
-    repOrderService.update(repId, updatedFields);
-        return ResponseEntity.ok().build();
+        RepOrderDTO updatedRepOrderDTO = repOrderService.update(repId, updatedFields);
+        return ResponseEntity.ok(updatedRepOrderDTO);
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, params = {"fdcDelayedPickup=true"})

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/controller/RepOrderController.java
@@ -217,6 +217,9 @@ public class RepOrderController {
   @PatchMapping(value = "/{repId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Partial Update of a Rep record")
     @StandardApiResponseCodes
+    @ApiResponse(responseCode = "200",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+    )
   public ResponseEntity<RepOrderDTO> updateRepOrder(@PathVariable int repId,
       @RequestBody Map<String, Object> updatedFields) {
     LoggingData.MAAT_ID.putInMDC(repId);

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
@@ -88,13 +88,13 @@ public class RepOrderService {
     }
 
     @Transactional
-    public void update(Integer repId, Map<String, Object> repOrder) {
+    public RepOrderDTO update(Integer repId, Map<String, Object> repOrder) {
         log.info("RepOrderService::update - Start");
         RepOrderEntity currentRepOrder = repOrderRepository.findById(repId)
             .orElseThrow(() -> new RequestedObjectNotFoundException(String.format("Rep Order not found for id %d", repId)));
 
         ReflectionHelper.updateEntityFromMap(currentRepOrder, repOrder);
-        repOrderRepository.save(currentRepOrder);
+        return repOrderMapper.repOrderEntityToRepOrderDTO(repOrderRepository.save(currentRepOrder));
     }
 
     @Transactional

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/service/ApplicantServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/applicant/service/ApplicantServiceTest.java
@@ -2,6 +2,7 @@ package gov.uk.courtdata.applicant.service;
 
 import gov.uk.courtdata.applicant.dto.SendToCCLFDTO;
 import gov.uk.courtdata.applicant.repository.ApplicantRepository;
+import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.entity.Applicant;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.reporder.service.RepOrderService;
@@ -76,7 +77,7 @@ public class ApplicantServiceTest {
 
     @Test
     void givenAValidInput_whenUpdateSendToCCLFIsInvoked_thenUpdateIsSuccess() {
-        doNothing().when(repOrderService).update(any(), any());
+        when(repOrderService.update(any(), any())).thenReturn(TestModelDataBuilder.getRepOrderDTO());
         doNothing().when(applicantHistoryService).update(any(), any());
         when(applicantRepository.findById(anyInt())).thenReturn(Optional.of(Applicant.builder().id(ID).build()));
         SendToCCLFDTO sendToCCLFDTO = SendToCCLFDTO.builder().applId(ID).repId(ID).applHistoryId(ID).build();

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +27,6 @@ import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
 import gov.uk.courtdata.exception.ValidationException;
 import gov.uk.courtdata.model.assessment.UpdateAppDateCompleted;
 import gov.uk.courtdata.model.reporder.MaatSearchRequest;
-import gov.uk.courtdata.model.reporder.MaatSearchResponse;
 import gov.uk.courtdata.reporder.service.RepOrderMvoRegService;
 import gov.uk.courtdata.reporder.service.RepOrderMvoService;
 import gov.uk.courtdata.reporder.service.RepOrderService;
@@ -71,7 +69,6 @@ class RepOrderControllerTest {
     private static final String CASE_TYPE_VALUE = "SUMMARY ONLY";
     private static final String IOJ_RESULT_VALUE = "PASS";
     private static final String IOJ_ASSESSOR_FULL_NAME = "Maeve OConnor";
-    private static final String IOJ_ASSESSOR_USERNAME = "ocon-m";
     private static final String DATE_APP_CREATED_VALUE = "2015-01-09";
     private static final String MEANS_INIT_RESULT_VALUE = "PASS";
     private static final String MEANS_INIT_STATUS_VALUE = "COMPLETE";
@@ -348,15 +345,20 @@ class RepOrderControllerTest {
 
     @Test
     void givenValidRequest_whenUpdateRepOrderIsInvoked_thenUpdateIsSuccess() throws Exception {
-        doNothing().when(repOrderService)
-                .update(TestModelDataBuilder.REP_ID, Map.of("iojResult", "PASS"));
-
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.getRepOrderDTO();
+        repOrderDTO.setIojResult(IOJ_RESULT_VALUE);
         String requestJson = "{\"iojResult\":\"PASS\"}";
+
+        when(repOrderService.update(TestModelDataBuilder.REP_ID, Map.of("iojResult", IOJ_RESULT_VALUE)))
+            .thenReturn(repOrderDTO);
+
         mvc.perform(MockMvcRequestBuilders.patch(ENDPOINT_URL + "/" + TestModelDataBuilder.REP_ID)
                         .content(requestJson)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
-        verify(repOrderService).update(TestModelDataBuilder.REP_ID, Map.of("iojResult", "PASS"));
+                .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(TestModelDataBuilder.REP_ID))
+            .andExpect(jsonPath("$.iojResult").value(IOJ_RESULT_VALUE));
+        verify(repOrderService).update(TestModelDataBuilder.REP_ID, Map.of("iojResult", IOJ_RESULT_VALUE));
     }
 
 

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderServiceTest.java
@@ -3,6 +3,7 @@ package gov.uk.courtdata.reporder.service;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.dto.AssessorDetails;
+import gov.uk.courtdata.dto.RepOrderDTO;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
@@ -166,13 +167,17 @@ class RepOrderServiceTest {
     @Test
     void givenAValidInput_whenUpdateIsInvoked_thenUpdateIsSuccess() {
         RepOrderEntity repOrder = TestEntityDataBuilder.getPopulatedRepOrder(TestModelDataBuilder.REP_ID);
-        when(repOrderRepository.findById(anyInt())).thenReturn(Optional.of(repOrder));
         HashMap<String, Object> inputMap = new HashMap<>();
         inputMap.put("iojResult", "PASS");
         inputMap.put("dateModified", LocalDateTime.now().toString());
-        repOrderService.update(TestModelDataBuilder.REP_ID, inputMap);
+        when(repOrderRepository.findById(anyInt())).thenReturn(Optional.of(repOrder));
+        when(repOrderRepository.save(repOrder)).thenReturn(repOrder);
+        RepOrderDTO repOrderDTO = repOrderService.update(TestModelDataBuilder.REP_ID, inputMap);
         verify(repOrderRepository, atLeastOnce()).findById(any());
         verify(repOrderRepository, atLeastOnce()).save(any());
+        assertEquals(TestModelDataBuilder.REP_ID ,repOrderDTO.getId());
+        assertEquals(inputMap.get("iojResult"), repOrderDTO.getIojResult());
+        assertEquals(inputMap.get("dateModified").toString(), repOrderDTO.getDateModified().toString());
     }
 
     @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1806)

Updated the PATCH endpoint on the Rep Order controller to return the updated RepOrderDTO.
Updated the tests to cover this change. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.