### PR TITLE
LASB-4996: Rep Order search enhancements

### DIFF
--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/model/reporder/MaatSearchRequest.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/model/reporder/MaatSearchRequest.java
@@ -19,7 +19,6 @@ public class MaatSearchRequest {
     private String firstName;
     @NotNull
     private String lastName;
-    @NotNull
     private LocalDate dob;
     private String niNumber;
     @NotNull

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/mapper/RepOrderMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/mapper/RepOrderMapper.java
@@ -83,7 +83,7 @@ public interface RepOrderMapper {
                 .build();
     }
 
-    default MaatSearchResponse mapMaatSearchResponse(Integer maatId, List<WqLinkRegisterEntity> wqList) {
+    default MaatSearchResponse mapMaatSearchResponse(Integer maatId, List<WqLinkRegisterEntity> wqList, String caseUrn) {
         if (wqList == null || wqList.isEmpty()) {
             return MaatSearchResponse.builder()
                     .maatId(maatId)
@@ -98,12 +98,19 @@ public interface RepOrderMapper {
                 .isLinked(true)
                 .linkingDetail(LinkingDetail.builder()
                         .libraId(link.getLibraId())
-                        .caseUrn(link.getCaseUrn())
+                        .caseUrn(caseUrn)
                         .cjsAreaCode(link.getCjsAreaCode())
                         .cjsLocation(link.getCjsLocation())
                         .caseId(link.getCaseId())
                         .build())
                 .build();
+    }
+
+    default MaatSearchResponse mapMaatSearchResponse(Integer maatId, List<WqLinkRegisterEntity> wqList) {
+        String caseUrn = (wqList == null || wqList.isEmpty())
+            ? null
+            : wqList.get(0).getCaseUrn();
+        return mapMaatSearchResponse(maatId, wqList, caseUrn);
     }
 }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/mapper/RepOrderMapper.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/mapper/RepOrderMapper.java
@@ -105,12 +105,5 @@ public interface RepOrderMapper {
                         .build())
                 .build();
     }
-
-    default MaatSearchResponse mapMaatSearchResponse(Integer maatId, List<WqLinkRegisterEntity> wqList) {
-        String caseUrn = (wqList == null || wqList.isEmpty())
-            ? null
-            : wqList.get(0).getCaseUrn();
-        return mapMaatSearchResponse(maatId, wqList, caseUrn);
-    }
 }
 

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/reporder/service/RepOrderService.java
@@ -3,6 +3,7 @@ package gov.uk.courtdata.reporder.service;
 import gov.uk.courtdata.dto.AssessorDetails;
 import gov.uk.courtdata.dto.RepOrderStateDTO;
 import gov.uk.courtdata.dto.RepOrderDTO;
+import gov.uk.courtdata.entity.RepOrderCPDataEntity;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
 import gov.uk.courtdata.exception.RequestedObjectNotFoundException;
@@ -14,6 +15,7 @@ import gov.uk.courtdata.model.reporder.MaatSearchRequest;
 import gov.uk.courtdata.model.reporder.MaatSearchResponse;
 import gov.uk.courtdata.reporder.impl.RepOrderImpl;
 import gov.uk.courtdata.reporder.mapper.RepOrderMapper;
+import gov.uk.courtdata.repository.RepOrderCPDataRepository;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import java.time.LocalDate;
 import java.util.List;
@@ -37,6 +39,7 @@ public class RepOrderService {
     private final RepOrderMapper repOrderMapper;
     private final RepOrderRepository repOrderRepository;
     private final WqLinkRegisterRepository linkRegisterRepository;
+    private final RepOrderCPDataRepository repOrderCPDataRepository;
 
     public RepOrderEntity findByRepId(Integer repId) {
         RepOrderEntity repOrder;
@@ -158,8 +161,14 @@ public class RepOrderService {
         return repIdSet.stream()
                 .map(repId -> {
                     List<WqLinkRegisterEntity> linkRegisterList = linkRegisterRepository.findBymaatId(repId);
-                    return repOrderMapper.mapMaatSearchResponse(repId, linkRegisterList);
+                    String caseUrn = getCaseUrn(repId);
+                    return repOrderMapper.mapMaatSearchResponse(repId, linkRegisterList, caseUrn);
                 })
                 .toList();
+    }
+
+    private String getCaseUrn(Integer repId) {
+        Optional<RepOrderCPDataEntity> repOrder = repOrderCPDataRepository.findByrepOrderId(repId);
+        return repOrder.map(RepOrderCPDataEntity::getCaseUrn).orElse(null);
     }
 }

--- a/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
+++ b/maat-court-data-api/src/main/java/gov/uk/courtdata/repository/RepOrderRepository.java
@@ -60,12 +60,12 @@ public interface RepOrderRepository extends JpaRepository<RepOrderEntity, Intege
 
     @Query(value = """
                 SELECT DISTINCT rep.id
-                FROM TOGDATA.REP_ORDERS rep 
+                FROM TOGDATA.REP_ORDERS rep
                 JOIN TOGDATA.APPLICANTS app ON (rep.APPL_ID = app.id)
                 WHERE UPPER(app.FIRST_NAME) = UPPER(:#{#req.firstName})
                 AND UPPER(app.LAST_NAME) = UPPER(:#{#req.lastName})
                 AND rep.ARREST_SUMMONS_NO = :#{#req.asn}
-                AND app.DOB = :#{#req.dob}
+                AND (:#{#req.dob} IS NULL OR app.DOB = :#{#req.dob})
                 AND (:#{#req.niNumber} IS NULL OR app.NI_NUMBER = :#{#req.niNumber})
                 AND (:#{#req.committalDate} IS NULL OR rep.COMMITTAL_DATE = :#{#req.committalDate})
                 AND (:#{#req.caseType} IS NULL OR rep.CATY_CASE_TYPE = :#{#req.caseType})

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestEntityDataBuilder.java
@@ -634,6 +634,21 @@ public class TestEntityDataBuilder {
                 .build();
     }
 
+    public static WqLinkRegisterEntity getWQLinkRegisterEntityWithoutCaseUrn() {
+
+        return WqLinkRegisterEntity.builder()
+            .createdTxId(1234)
+            .caseId(TEST_CASE_ID)
+            .maatId(REP_ID)
+            .cjsAreaCode("16")
+            .cjsLocation("B16BG")
+            .maatCat(253)
+            .createdUserId(TEST_USER)
+            .mlrCat(253)
+            .libraId(LIBRA_ID)
+            .build();
+    }
+
     public static WQOffenceEntity getWQOffenceEntity(Integer offenceTxId) {
 
         return WQOffenceEntity.builder()
@@ -891,9 +906,13 @@ public class TestEntityDataBuilder {
     }
 
     public RepOrderCPDataEntity getRepOrderEntity() {
+        return getRepOrderEntity(REP_ID);
+    }
+    
+    public static RepOrderCPDataEntity getRepOrderEntity(Integer repId) {
         return RepOrderCPDataEntity.builder()
-                .repOrderId(REP_ID)
-                .caseUrn("caseurn1")
+                .repOrderId(repId)
+                .caseUrn(CASE_URN)
                 .dateCreated(LocalDateTime.now())
                 .userCreated("user")
                 .dateModified(LocalDateTime.now())

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/builder/TestModelDataBuilder.java
@@ -1831,6 +1831,20 @@ public class TestModelDataBuilder {
                 """.formatted(firstName, TEST_DATE.toLocalDate(), ASN_NUMBER, TEST_DATE.toLocalDate(), NI_NUMBER, CASE_TYPE_VALUE);
     }
 
+    public static String getMaatSearchRequestJsonWithNullDob() {
+        return """
+                {
+                  "firstName": "firstName",
+                  "lastName": "LastName",
+                  "dob": null,
+                  "asn": "%s",
+                  "committalDate": "%s",
+                  "niNumber": "%s",
+                  "caseType": "%s"
+                }
+                """.formatted(ASN_NUMBER, TEST_DATE.toLocalDate(), NI_NUMBER, CASE_TYPE_VALUE);
+    }
+
     public static MaatSearchRequest getMaatSearchRequest() {
         return MaatSearchRequest.builder()
                 .firstName("FirstName")

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/integration/repOrder/RepOrderControllerIntegrationTest.java
@@ -97,6 +97,8 @@ class RepOrderControllerIntegrationTest extends MockMvcIntegrationTest {
         WqLinkRegisterEntity linkRegisterEntity = TestEntityDataBuilder.getWQLinkRegisterEntity(TestEntityDataBuilder.REP_ID);
         linkRegisterEntity.setMaatId(REP_ORDER_ID_NO_SENTENCE_ORDER_DATE);
         repos.wqLinkRegister.save(linkRegisterEntity);
+
+        repos.repOrderCPData.save(TestEntityDataBuilder.getRepOrderEntity(REP_ORDER_ID_NO_SENTENCE_ORDER_DATE));
     }
 
     private RepOrderDTO getUpdatedRepOrderDTO() {

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/controller/RepOrderControllerTest.java
@@ -654,4 +654,20 @@ class RepOrderControllerTest {
                 .andExpect(jsonPath("$[0].maatId").value(TestModelDataBuilder.REP_ID));
 
     }
+
+    @Test
+    void givenRequestWithoutDateOfBirth_whenSearchApplicationIsInvoked_thenIsValidRequest()
+            throws Exception {
+        when(repOrderService.searchMaatApplication(any(MaatSearchRequest.class)))
+            .thenReturn(List.of(TestModelDataBuilder.getMaatSearchResponse()));
+
+        String maatSearchRequestJson = TestModelDataBuilder.getMaatSearchRequestJsonWithNullDob();
+
+        mvc.perform(MockMvcRequestBuilders.post(SEARCH_MAAT_APPLICATION)
+            .content(maatSearchRequestJson)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$[0].maatId").value(TestModelDataBuilder.REP_ID));
+    }
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/mapper/RepOrderMapperTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/mapper/RepOrderMapperTest.java
@@ -1,7 +1,6 @@
 package gov.uk.courtdata.reporder.mapper;
 
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
-import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.dto.RepOrderStateDTO;
 import gov.uk.courtdata.entity.*;
 import gov.uk.courtdata.model.reporder.MaatSearchResponse;
@@ -332,21 +331,21 @@ class RepOrderMapperTest {
 
     @Test
     void givenAValidRequestAndNullLinking_whenMapMaatSearchResponseIsInvoked_thenCorrectResponseShouldReturn() {
-        MaatSearchResponse response = repOrderMapper.mapMaatSearchResponse(TestEntityDataBuilder.REP_ID, null);
+        MaatSearchResponse response = repOrderMapper.mapMaatSearchResponse(TestEntityDataBuilder.REP_ID, null, null);
         assertEquals(TestEntityDataBuilder.REP_ID, response.getMaatId());
         assertFalse(response.isLinked());
     }
 
     @Test
     void givenAValidRequestAndEmptyLinking_whenMapMaatSearchResponseIsInvoked_thenCorrectResponseShouldReturn() {
-        MaatSearchResponse response = repOrderMapper.mapMaatSearchResponse(TestEntityDataBuilder.REP_ID, Collections.emptyList());
+        MaatSearchResponse response = repOrderMapper.mapMaatSearchResponse(TestEntityDataBuilder.REP_ID, Collections.emptyList(), null);
         assertEquals(TestEntityDataBuilder.REP_ID, response.getMaatId());
         assertFalse(response.isLinked());
     }
     @Test
     void givenAValidRequest_whenMapMaatSearchResponseIsInvoked_thenCorrectResponseShouldReturn() {
         List<WqLinkRegisterEntity> wqLinkRegisterEntities = List.of(TestEntityDataBuilder.getWQLinkRegisterEntity(1235));
-        MaatSearchResponse response = repOrderMapper.mapMaatSearchResponse(TestEntityDataBuilder.REP_ID, wqLinkRegisterEntities);
+        MaatSearchResponse response = repOrderMapper.mapMaatSearchResponse(TestEntityDataBuilder.REP_ID, wqLinkRegisterEntities, TestEntityDataBuilder.CASE_URN);
         assertEquals(TestEntityDataBuilder.REP_ID, response.getMaatId());
         assertTrue(response.isLinked());
         assertEquals(TestEntityDataBuilder.LIBRA_ID, response.getLinkingDetail().getLibraId());

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderServiceTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/reporder/service/RepOrderServiceTest.java
@@ -3,6 +3,7 @@ package gov.uk.courtdata.reporder.service;
 import gov.uk.courtdata.builder.TestEntityDataBuilder;
 import gov.uk.courtdata.builder.TestModelDataBuilder;
 import gov.uk.courtdata.dto.AssessorDetails;
+import gov.uk.courtdata.entity.RepOrderCPDataEntity;
 import gov.uk.courtdata.dto.RepOrderDTO;
 import gov.uk.courtdata.entity.RepOrderEntity;
 import gov.uk.courtdata.entity.WqLinkRegisterEntity;
@@ -12,6 +13,7 @@ import gov.uk.courtdata.model.reporder.MaatSearchRequest;
 import gov.uk.courtdata.model.reporder.MaatSearchResponse;
 import gov.uk.courtdata.reporder.impl.RepOrderImpl;
 import gov.uk.courtdata.reporder.mapper.RepOrderMapper;
+import gov.uk.courtdata.repository.RepOrderCPDataRepository;
 import gov.uk.courtdata.repository.RepOrderRepository;
 import java.time.LocalDateTime;
 
@@ -27,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDate;
 import java.util.*;
 
+import static gov.uk.courtdata.builder.TestEntityDataBuilder.REP_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -52,13 +55,17 @@ class RepOrderServiceTest {
     @Mock
     private WqLinkRegisterRepository wqLinkRegisterRepository;
 
+    @Mock
+    private RepOrderCPDataRepository repOrderCPDataRepository;
+
     @BeforeEach
     public void setup() {
         repOrderMapper = Mappers.getMapper(RepOrderMapper.class);
         repOrderService = new RepOrderService(repOrderImpl,
                 repOrderMapper,
                 repOrderRepository,
-                wqLinkRegisterRepository);
+                wqLinkRegisterRepository,
+                repOrderCPDataRepository);
     }
 
     @Test
@@ -220,6 +227,26 @@ class RepOrderServiceTest {
         verify(repOrderRepository).findRepId(any(MaatSearchRequest.class));
         verify(wqLinkRegisterRepository, times(2)).findBymaatId(anyInt());
         assertEquals(2,maatSearchResponseList.size());
+    }
+
+    @Test
+    void givenAValidRequest_whenMaatIdReturned_thenResponseContainsCaseUrn() {
+        WqLinkRegisterEntity linkWithoutCaseUrn = TestEntityDataBuilder.getWQLinkRegisterEntityWithoutCaseUrn();
+        RepOrderCPDataEntity repOrder = TestEntityDataBuilder.getRepOrderEntity(REP_ID);
+
+        when(repOrderRepository.findRepId(any(MaatSearchRequest.class)))
+            .thenReturn(Set.of(REP_ID));
+        when(wqLinkRegisterRepository.findBymaatId(REP_ID)).thenReturn(
+            List.of(linkWithoutCaseUrn));
+        when(repOrderCPDataRepository.findByrepOrderId(REP_ID)).thenReturn(
+            Optional.of(repOrder));
+
+        List<MaatSearchResponse> maatSearchResponseList = repOrderService.searchMaatApplication(
+            TestModelDataBuilder.getMaatSearchRequest());
+
+        assertEquals(1, maatSearchResponseList.size());
+        MaatSearchResponse response = maatSearchResponseList.get(0);
+        assertEquals(repOrder.getCaseUrn(), response.getLinkingDetail().getCaseUrn());
     }
 
 }

--- a/maat-court-data-api/src/test/java/gov/uk/courtdata/repository/RepOrderRepositoryTest.java
+++ b/maat-court-data-api/src/test/java/gov/uk/courtdata/repository/RepOrderRepositoryTest.java
@@ -1,0 +1,72 @@
+package gov.uk.courtdata.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.uk.courtdata.entity.Applicant;
+import gov.uk.courtdata.entity.RepOrderEntity;
+import gov.uk.courtdata.model.reporder.MaatSearchRequest;
+import java.time.LocalDate;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class RepOrderRepositoryTest {
+
+  @Autowired
+  private RepOrderRepository repository;
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @BeforeEach
+  void setUp() {
+    Applicant applicant = Applicant.builder()
+        .firstName("John")
+        .lastName("Smith")
+        .dob(LocalDate.of(1990, 1, 1))
+        .niNumber("AB123456C")
+        .build();
+    entityManager.persist(applicant);
+
+    RepOrderEntity repOrder = RepOrderEntity.builder()
+        .applicationId(applicant.getId())
+        .arrestSummonsNo("ASN123")
+        .committalDate(LocalDate.of(2024, 1, 1))
+        .catyCaseType("ABC")
+        .build();
+    entityManager.persist(repOrder);
+
+    entityManager.flush();
+  }
+
+  @Test
+  void findRepId_shouldReturnResult_whenDobIsNull() {
+    MaatSearchRequest request = MaatSearchRequest.builder()
+        .firstName("John")
+        .lastName("Smith")
+        .asn("ASN123")
+        .dob(null)
+        .build();
+
+    Set<Integer> result = repository.findRepId(request);
+
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  void findRepId_returnsEmpty_whenDobProvidedButDoesNotMatch() {
+    MaatSearchRequest req = MaatSearchRequest.builder()
+        .firstName("John")
+        .lastName("Smith")
+        .asn("ASN123")
+        .dob(LocalDate.of(2000, 1, 1))
+        .build();
+
+    assertThat(repository.findRepId(req)).isEmpty();
+  }
+
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4996)

This PR contains two improvements to the MAAT rep order search API, at the request of the ACD team.

- Makes date of birth an optional search parameter
   - Updates `dob` field on `MaatSearchRequest` so it can be null.
   - Updates database query to accomodate no DOB being passed.
   - Adds new `@DataJpaTest` for this repository to verify this change.
   - Adds unit tests for this scenario.
- Retrieves case URN from common platform
   - Populates `caseUrn` in `LinkingDetail` response from an additional call to common platform (`RepOrderCPDataRepository`), searching with the MAAT ID. (Rather than the link table).
   - Add unit tests for this scenario.
   - Updates test helper builder methods to facilitate the new tests.
   - Updates `RepOrderControllerIntegrationTest` to reflect the new flow.

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.